### PR TITLE
Performance improvement for icon rotation on view change

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/PointSpriteProcessor.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/PointSpriteProcessor.java
@@ -48,6 +48,7 @@ import io.opensphere.core.util.concurrent.CommonTimer;
 import io.opensphere.core.util.concurrent.ThreadedStateMachine.StateController;
 import io.opensphere.core.viewer.ViewChangeSupport;
 import io.opensphere.core.viewer.Viewer;
+import io.opensphere.core.viewer.impl.DynamicViewer;
 
 /**
  * Processor for {@link PointSpriteGeometry}s. This class determines the model
@@ -56,6 +57,9 @@ import io.opensphere.core.viewer.Viewer;
  */
 public class PointSpriteProcessor extends TextureProcessor<PointSpriteGeometry>
 {
+    /** Sensitivity of heading rotation for triggering point sprite rotation. */
+    private static final double HEADING_SENSITIVITY = Math.toRadians(1);
+
     /** Comparator that determines geometry processing priority. */
     private final Comparator<? super PointSpriteGeometry> myPriorityComparator;
 
@@ -64,6 +68,9 @@ public class PointSpriteProcessor extends TextureProcessor<PointSpriteGeometry>
 
     /** An executor that procrastinates before running tasks. */
     private final Executor myViewChangeExecutor = CommonTimer.createProcrastinatingExecutor(100);
+
+    /** The last heading value for which rotation was handled. */
+    private double myLastHandledHeading = Double.MAX_VALUE;
 
     /**
      * Construct a point processor.
@@ -309,25 +316,37 @@ public class PointSpriteProcessor extends TextureProcessor<PointSpriteGeometry>
         }
 
         // Reset projection-sensitive geometries so they get re-processed
-        myViewChangeExecutor.execute(this::resetProjectionSensitiveGeometries);
+        myViewChangeExecutor.execute(() -> resetProjectionSensitiveGeometries(view));
 
         super.handleViewChanged(view, type);
     }
 
     /**
      * Resets projection-sensitive geometries so they get re-processed.
+     *
+     * @param view the viewer
      */
-    private void resetProjectionSensitiveGeometries()
+    private void resetProjectionSensitiveGeometries(Viewer view)
     {
-        List<PointSpriteGeometry> projectionSensitiveGeoms = getGeometries().stream().filter(g -> g.isProjectionSensitive())
-                .collect(Collectors.toList());
-        if (CollectionUtilities.hasContent(projectionSensitiveGeoms))
+        if (view instanceof DynamicViewer)
         {
-            for (PointSpriteGeometry geom : projectionSensitiveGeoms)
+            double heading = ((DynamicViewer)view).getHeading();
+            double delta = Math.abs(heading - myLastHandledHeading);
+            if (delta >= HEADING_SENSITIVITY || myLastHandledHeading == Double.MAX_VALUE)
             {
-                getImageManagersToGeoms().remove(geom.getImageManager());
+                myLastHandledHeading = heading;
+
+                List<PointSpriteGeometry> projectionSensitiveGeoms = getGeometries().stream()
+                        .filter(g -> g.isProjectionSensitive()).collect(Collectors.toList());
+                if (CollectionUtilities.hasContent(projectionSensitiveGeoms))
+                {
+                    for (PointSpriteGeometry geom : projectionSensitiveGeoms)
+                    {
+                        getImageManagersToGeoms().remove(geom.getImageManager());
+                    }
+                    resetDueToImageUpdate(New.linkedList(projectionSensitiveGeoms), State.UNPROCESSED);
+                }
             }
-            resetDueToImageUpdate(New.linkedList(projectionSensitiveGeoms), State.UNPROCESSED);
         }
     }
 

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/PointSpriteProcessor.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/PointSpriteProcessor.java
@@ -316,8 +316,6 @@ public class PointSpriteProcessor extends TextureProcessor<PointSpriteGeometry>
             resetState(scalableGeoms, State.UNPROCESSED);
         }
 
-        System.out.println(type);
-
         // Reset projection-sensitive geometries so they get re-processed
         if (type == ViewChangeSupport.ViewChangeType.NEW_VIEWER)
         {


### PR DESCRIPTION
There's no ticket for this.  Further testing made it clear we need to ignore view changes that don't significantly change the heading as it pertains to icon rotation.  That's what this fix does.