### PR TITLE
VORTEX-5526: Cancel server loading (Mapbox support)

### DIFF
--- a/open-sphere-plugins/mapbox/src/main/java/io/opensphere/mapbox/server/MapboxServerSourceController.java
+++ b/open-sphere-plugins/mapbox/src/main/java/io/opensphere/mapbox/server/MapboxServerSourceController.java
@@ -71,6 +71,10 @@ public class MapboxServerSourceController extends UrlServerSourceController
         {
             success = true;
         }
+        else if (tracker.getQueryStatus() == QueryTracker.QueryStatus.CANCELLED)
+        {
+            LOGGER.info("The query for " + source.getName() + " was canceled");
+        }
         else
         {
             Throwable e = tracker.getException();


### PR DESCRIPTION
Adding support for Mapbox servers to the server cancel load button. 
The button is now functional for ArcGIS and Mapbox servers.