### PR TITLE
 Spatial query using a single area (ROI) from layer manager

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
@@ -850,7 +850,7 @@ public class SelectionHandler
      * Gets menu items for geometry.
      * 
      * @param menuItems the menu items
-     * @param geom the geometry.
+     * @param geom the geometry
      * @return menu items
      */
     public List<JMenuItem> getGeomtryMenuItems(List<JMenuItem> menuItems, Geometry geom)

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
@@ -128,7 +128,7 @@ public class SelectionHandler
             if (contextId.equals(ContextIdentifiers.GEOMETRY_SELECTION_CONTEXT))
             {
                 Geometry geom = key.getGeometry();
-                menuItems = getGeomtryMenuItems(menuItems, geom);
+                menuItems = getGeometryMenuItems(geom);
             }
             else if (contextId.equals(ContextIdentifiers.GEOMETRY_COMPLETED_CONTEXT)
                     && key.getGeometry() instanceof PolygonGeometry)
@@ -849,13 +849,12 @@ public class SelectionHandler
     /**
      * Gets menu items for geometry.
      * 
-     * @param menuItems the menu items
      * @param geom the geometry
      * @return menu items
      */
-    public List<JMenuItem> getGeomtryMenuItems(List<JMenuItem> menuItems, Geometry geom)
+    public List<JMenuItem> getGeometryMenuItems(Geometry geom)
     {
-
+        List<JMenuItem> menuItems = null;
         if (myQueryRegionManager.getQueryRegion(geom) != null)
         {
             myLastGeometry = geom;

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
@@ -128,31 +128,7 @@ public class SelectionHandler
             if (contextId.equals(ContextIdentifiers.GEOMETRY_SELECTION_CONTEXT))
             {
                 Geometry geom = key.getGeometry();
-                if (myQueryRegionManager.getQueryRegion(geom) != null)
-                {
-                    myLastGeometry = geom;
-                    menuItems = SelectionCommand.getQueryRegionMenuItems(myMenuActionListener, hasLoadFilters());
-                }
-                else if (geom instanceof PolygonGeometry)
-                {
-                    myLastGeometry = geom;
-                    menuItems = SelectionCommand.getPolygonMenuItems(myMenuActionListener, hasLoadFilters(), false);
-                }
-                else if (geom instanceof PolylineGeometry)
-                {
-                    myLastGeometry = geom;
-                    menuItems = SelectionCommand.getPolylineMenuItems(myMenuActionListener, hasLoadFilters());
-                }
-                else if (geom instanceof PointGeometry)
-                {
-                    myLastGeometry = geom;
-                    menuItems = SelectionCommand.getPointMenuItems(myMenuActionListener, hasLoadFilters());
-                }
-                else
-                {
-                    LOGGER.warn(
-                            "Unrecognized geometry type: '" + geom.getClass().getName() + "' cannot be used to create a buffer.");
-                }
+                menuItems = getRegionMenuItems(menuItems, geom);
             }
             else if (contextId.equals(ContextIdentifiers.GEOMETRY_COMPLETED_CONTEXT)
                     && key.getGeometry() instanceof PolygonGeometry)
@@ -289,6 +265,11 @@ public class SelectionHandler
                 myGeometryContextMenuProvider);
         actionManager.registerContextMenuItemProvider(ContextIdentifiers.ROI_CONTEXT, MultiGeometryContextKey.class,
                 myMultiGeometryContextMenuProvider);
+        /* actionManager.registerContextMenuItemProvider(DataGroupInfo.
+         * ACTIVE_DATA_CONTEXT, DataGroupInfo.DataGroupContextKey.class,
+         * myGeometryContextMenuProvider);
+         * MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().
+         * myGeometryContextMenuProvider; */
     }
 
     /**
@@ -868,6 +849,42 @@ public class SelectionHandler
             return "Distance may be positive or negative, but not zero";
         }
         return "Distance must be greater than zero";
+    }
+
+    /**
+     * Gets menu items for geometry.
+     * @param menuItems the menu items
+     * @param geom the geometry.
+     * @return menu items
+     */
+    public List<JMenuItem> getRegionMenuItems(List<JMenuItem> menuItems, Geometry geom)
+    {
+
+        if (myQueryRegionManager.getQueryRegion(geom) != null)
+        {
+            myLastGeometry = geom;
+            menuItems = SelectionCommand.getQueryRegionMenuItems(myMenuActionListener, hasLoadFilters());
+        }
+        else if (geom instanceof PolygonGeometry)
+        {
+            myLastGeometry = geom;
+            menuItems = SelectionCommand.getPolygonMenuItems(myMenuActionListener, hasLoadFilters(), false);
+        }
+        else if (geom instanceof PolylineGeometry)
+        {
+            myLastGeometry = geom;
+            menuItems = SelectionCommand.getPolylineMenuItems(myMenuActionListener, hasLoadFilters());
+        }
+        else if (geom instanceof PointGeometry)
+        {
+            myLastGeometry = geom;
+            menuItems = SelectionCommand.getPointMenuItems(myMenuActionListener, hasLoadFilters());
+        }
+        else
+        {
+            LOGGER.warn("Unrecognized geometry type: '" + geom.getClass().getName() + "' cannot be used to create a buffer.");
+        }
+        return menuItems;
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
@@ -128,7 +128,7 @@ public class SelectionHandler
             if (contextId.equals(ContextIdentifiers.GEOMETRY_SELECTION_CONTEXT))
             {
                 Geometry geom = key.getGeometry();
-                menuItems = getRegionMenuItems(menuItems, geom);
+                menuItems = getGeomtryMenuItems(menuItems, geom);
             }
             else if (contextId.equals(ContextIdentifiers.GEOMETRY_COMPLETED_CONTEXT)
                     && key.getGeometry() instanceof PolygonGeometry)
@@ -853,11 +853,12 @@ public class SelectionHandler
 
     /**
      * Gets menu items for geometry.
+     * 
      * @param menuItems the menu items
      * @param geom the geometry.
      * @return menu items
      */
-    public List<JMenuItem> getRegionMenuItems(List<JMenuItem> menuItems, Geometry geom)
+    public List<JMenuItem> getGeomtryMenuItems(List<JMenuItem> menuItems, Geometry geom)
     {
 
         if (myQueryRegionManager.getQueryRegion(geom) != null)

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
@@ -265,11 +265,6 @@ public class SelectionHandler
                 myGeometryContextMenuProvider);
         actionManager.registerContextMenuItemProvider(ContextIdentifiers.ROI_CONTEXT, MultiGeometryContextKey.class,
                 myMultiGeometryContextMenuProvider);
-        /* actionManager.registerContextMenuItemProvider(DataGroupInfo.
-         * ACTIVE_DATA_CONTEXT, DataGroupInfo.DataGroupContextKey.class,
-         * myGeometryContextMenuProvider);
-         * MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().
-         * myGeometryContextMenuProvider; */
     }
 
     /**

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesController.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesController.java
@@ -23,7 +23,6 @@ import io.opensphere.mantle.data.DataTypeInfo;
 import io.opensphere.mantle.data.MapVisualizationInfo;
 import io.opensphere.mantle.data.MapVisualizationType;
 import io.opensphere.mantle.data.util.impl.DataTypeActionUtils;
-import io.opensphere.mantle.plugin.selection.SelectionHandler;
 import io.opensphere.myplaces.constants.Constants;
 import io.opensphere.myplaces.dataaccess.MyPlacesDataAccessor;
 import io.opensphere.myplaces.importer.MyPlacesMasterImporter;

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesController.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesController.java
@@ -23,6 +23,7 @@ import io.opensphere.mantle.data.DataTypeInfo;
 import io.opensphere.mantle.data.MapVisualizationInfo;
 import io.opensphere.mantle.data.MapVisualizationType;
 import io.opensphere.mantle.data.util.impl.DataTypeActionUtils;
+import io.opensphere.mantle.plugin.selection.SelectionHandler;
 import io.opensphere.myplaces.constants.Constants;
 import io.opensphere.myplaces.dataaccess.MyPlacesDataAccessor;
 import io.opensphere.myplaces.importer.MyPlacesMasterImporter;
@@ -45,6 +46,7 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
      */
     private static final int WAIT_TIME = 1000;
 
+    private final RoiContextMenuProvider myRoiMenuProvider;
     /**
      * The context menu provider for categories.
      */
@@ -110,6 +112,7 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
         myDataGroupController = new MyPlacesDataGroupController(myToolbox, myModel);
         mySingleGroupMenuProvider = new SingleGroupContextMenuProvider(myToolbox, myModel, this);
         myCategoryMenuProvider = new CategoryContextMenuProvider(myToolbox, myModel);
+        myRoiMenuProvider = new RoiContextMenuProvider(myToolbox,myModel);
         myToolbox.getImporterRegistry().addImporter(new MyPlacesMasterImporter(myToolbox, myModel));
     }
 
@@ -132,6 +135,8 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
         ContextActionManager contextActionManager = myToolbox.getUIRegistry().getContextActionManager();
         contextActionManager.deregisterContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT,
                 DataGroupInfo.DataGroupContextKey.class, mySingleGroupMenuProvider);
+        contextActionManager.deregisterContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT, CategoryContextKey.class,
+                myCategoryMenuProvider);
         contextActionManager.deregisterContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT, CategoryContextKey.class,
                 myCategoryMenuProvider);
     }
@@ -202,6 +207,11 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
                 DataGroupInfo.DataGroupContextKey.class, mySingleGroupMenuProvider);
         contextActionManager.registerContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT, CategoryContextKey.class,
                 myCategoryMenuProvider);
+        // REGISTER A NEW CONTEXT PROVIDER HERE
+        //contextActionManager.registerContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT,
+          //      DataGroupInfo.DataGroupContextKey.class, myRoiMenuProvider);
+        //contextActionManager.registerContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT,
+          //      DataGroupInfo.DataGroupContextKey.class, provider);
     }
 
     @Override

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesController.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesController.java
@@ -46,6 +46,9 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
      */
     private static final int WAIT_TIME = 1000;
 
+    /**
+     * The context menu provider for ROI.
+     */
     private final RoiContextMenuProvider myRoiMenuProvider;
     /**
      * The context menu provider for categories.
@@ -137,8 +140,6 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
                 DataGroupInfo.DataGroupContextKey.class, mySingleGroupMenuProvider);
         contextActionManager.deregisterContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT, CategoryContextKey.class,
                 myCategoryMenuProvider);
-        contextActionManager.deregisterContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT, CategoryContextKey.class,
-                myCategoryMenuProvider);
     }
 
     /**
@@ -208,10 +209,8 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
         contextActionManager.registerContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT, CategoryContextKey.class,
                 myCategoryMenuProvider);
         // REGISTER A NEW CONTEXT PROVIDER HERE
-        //contextActionManager.registerContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT,
-          //      DataGroupInfo.DataGroupContextKey.class, myRoiMenuProvider);
-        //contextActionManager.registerContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT,
-          //      DataGroupInfo.DataGroupContextKey.class, provider);
+        contextActionManager.registerContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT,
+               DataGroupInfo.DataGroupContextKey.class, myRoiMenuProvider);
     }
 
     @Override

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesController.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesController.java
@@ -50,6 +50,7 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
      * The context menu provider for ROI.
      */
     private final RoiContextMenuProvider myRoiMenuProvider;
+
     /**
      * The context menu provider for categories.
      */
@@ -115,8 +116,9 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
         myDataGroupController = new MyPlacesDataGroupController(myToolbox, myModel);
         mySingleGroupMenuProvider = new SingleGroupContextMenuProvider(myToolbox, myModel, this);
         myCategoryMenuProvider = new CategoryContextMenuProvider(myToolbox, myModel);
-        myRoiMenuProvider = new RoiContextMenuProvider(myToolbox,myModel);
+        myRoiMenuProvider = new RoiContextMenuProvider(myToolbox);
         myToolbox.getImporterRegistry().addImporter(new MyPlacesMasterImporter(myToolbox, myModel));
+
     }
 
     /**
@@ -140,6 +142,8 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
                 DataGroupInfo.DataGroupContextKey.class, mySingleGroupMenuProvider);
         contextActionManager.deregisterContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT, CategoryContextKey.class,
                 myCategoryMenuProvider);
+        contextActionManager.deregisterContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT,
+                DataGroupInfo.DataGroupContextKey.class, myRoiMenuProvider);
     }
 
     /**
@@ -208,9 +212,8 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
                 DataGroupInfo.DataGroupContextKey.class, mySingleGroupMenuProvider);
         contextActionManager.registerContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT, CategoryContextKey.class,
                 myCategoryMenuProvider);
-        // REGISTER A NEW CONTEXT PROVIDER HERE
         contextActionManager.registerContextMenuItemProvider(DataGroupInfo.ACTIVE_DATA_CONTEXT,
-               DataGroupInfo.DataGroupContextKey.class, myRoiMenuProvider);
+                DataGroupInfo.DataGroupContextKey.class, myRoiMenuProvider);
     }
 
     @Override

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -10,7 +10,6 @@ import io.opensphere.core.control.action.ContextMenuProvider;
 import io.opensphere.core.geometry.PolygonGeometry;
 import io.opensphere.mantle.data.DataGroupInfo.DataGroupContextKey;
 import io.opensphere.mantle.util.MantleToolboxUtils;
-import io.opensphere.myplaces.models.MyPlacesDataGroupInfo;
 import io.opensphere.myplaces.models.MyPlacesDataTypeInfo;
 import io.opensphere.myplaces.specific.regions.utils.RegionUtils;
 

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -36,7 +36,7 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupCont
     public List<JMenuItem> getMenuItems(String contextId, DataGroupContextKey key)
     {
         List<JMenuItem> menuItems = Collections.emptyList();
-        if (key.getDataGroup() instanceof MyPlacesDataTypeInfo)
+        if (key.getDataType() instanceof MyPlacesDataTypeInfo)
         {
             MyPlacesDataTypeInfo type = (MyPlacesDataTypeInfo)key.getDataType();
             PolygonGeometry geom = RegionUtils.createGeometry(type.getKmlPlacemark());

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -22,12 +22,6 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupCont
     /** The toolbox. */
     private final Toolbox myToolbox;
 
-    /** The Current placemark. */
-    private Placemark myPlacemark;
-
-    /** The Type. */
-    private MyPlacesDataTypeInfo myType;
-
     /**
      * Constructs region of interest context menu provider.
      *
@@ -42,17 +36,16 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupCont
     @Override
     public List<JMenuItem> getMenuItems(String contextId, DataGroupContextKey key)
     {
-        List<JMenuItem> menuItems = null;
         PolygonGeometry geom = null;
-        myType = (MyPlacesDataTypeInfo)key.getDataType();
+        MyPlacesDataTypeInfo type = (MyPlacesDataTypeInfo)key.getDataType();
 
-        if (myType != null)
+        if (type != null)
         {
-            myPlacemark = myType.getKmlPlacemark();
-            geom = RegionUtils.createGeometry(myPlacemark);
+            Placemark placemark = type.getKmlPlacemark();
+            geom = RegionUtils.createGeometry(placemark);
         }
 
-        return MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().getGeomtryMenuItems(menuItems, geom);
+        return MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().getGeometryMenuItems(geom);
     }
 
     @Override

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -37,7 +37,7 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupCont
     public List<JMenuItem> getMenuItems(String contextId, DataGroupContextKey key)
     {
         List<JMenuItem> menuItems = Collections.emptyList();
-        if (key.getDataGroup() instanceof MyPlacesDataGroupInfo)
+        if (key.getDataGroup() instanceof MyPlacesDataTypeInfo)
         {
             MyPlacesDataTypeInfo type = (MyPlacesDataTypeInfo)key.getDataType();
             PolygonGeometry geom = RegionUtils.createGeometry(type.getKmlPlacemark());

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -1,5 +1,6 @@
 package io.opensphere.myplaces.controllers;
 
+import java.util.LinkedList;
 import java.util.List;
 
 import javax.swing.JMenuItem;
@@ -10,6 +11,7 @@ import io.opensphere.core.control.action.ContextMenuProvider;
 import io.opensphere.core.geometry.PolygonGeometry;
 import io.opensphere.mantle.data.DataGroupInfo.DataGroupContextKey;
 import io.opensphere.mantle.util.MantleToolboxUtils;
+import io.opensphere.myplaces.models.MyPlacesDataGroupInfo;
 import io.opensphere.myplaces.models.MyPlacesDataTypeInfo;
 import io.opensphere.myplaces.specific.regions.utils.RegionUtils;
 
@@ -36,6 +38,11 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupCont
     @Override
     public List<JMenuItem> getMenuItems(String contextId, DataGroupContextKey key)
     {
+        if (!(key.getDataGroup() instanceof MyPlacesDataGroupInfo))
+        {
+            return new LinkedList<>();
+        }
+
         PolygonGeometry geom = null;
         MyPlacesDataTypeInfo type = (MyPlacesDataTypeInfo)key.getDataType();
 

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -1,14 +1,23 @@
 package io.opensphere.myplaces.controllers;
 
-import java.awt.Component;
-import java.util.Collection;
 import java.util.List;
 
+import javax.swing.JMenuItem;
+
+import de.micromata.opengis.kml.v_2_2_0.Placemark;
 import io.opensphere.core.Toolbox;
 import io.opensphere.core.control.action.ContextMenuProvider;
+import io.opensphere.core.geometry.Geometry;
+import io.opensphere.core.geometry.PolygonGeometry;
+import io.opensphere.core.util.collections.New;
+import io.opensphere.mantle.MantleToolbox;
 import io.opensphere.mantle.data.DataGroupInfo;
 import io.opensphere.mantle.data.DataGroupInfo.DataGroupContextKey;
+import io.opensphere.mantle.util.MantleToolboxUtils;
+import io.opensphere.myplaces.models.MyPlacesDataGroupInfo;
+import io.opensphere.myplaces.models.MyPlacesDataTypeInfo;
 import io.opensphere.myplaces.models.MyPlacesModel;
+import io.opensphere.myplaces.specific.regions.utils.RegionUtils;
 
 public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo.DataGroupContextKey>
 {
@@ -27,6 +36,15 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo
      */
     private final MyPlacesModel myModel;
 
+    /** The Current placemark. */
+    private Placemark myPlacemark;
+
+    /** The Group. */
+    private MyPlacesDataGroupInfo myGroup;
+
+    /** The Type. */
+    private MyPlacesDataTypeInfo myType;
+
     /**
      * Constructs a new points context menu provider.
      *
@@ -37,14 +55,27 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo
     {
         myToolbox = toolbox;
         myModel = model;
+
     }
 
     @Override
-    public Collection<? extends Component> getMenuItems(String contextId, DataGroupContextKey key)
+    public List<JMenuItem> getMenuItems(String contextId, DataGroupContextKey key)
     {
-        List<Component> menuItems;
 
-        return menuItems;
+        myGroup = (MyPlacesDataGroupInfo)key.getDataGroup();
+        myType = (MyPlacesDataTypeInfo)key.getDataType();
+
+        System.out.println("My GROUP : " + myGroup.toString());
+        System.out.println("My Type : " + myType.toString());
+
+        if (myType != null)
+        {
+            myPlacemark = myType.getKmlPlacemark();
+        }
+        PolygonGeometry geom = RegionUtils.createGeometry(myPlacemark);
+        List<JMenuItem> menuItems = null;
+
+        return MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().blah(menuItems, geom);
     }
 
     @Override

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -1,0 +1,60 @@
+package io.opensphere.myplaces.controllers;
+
+import java.awt.Component;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import io.opensphere.core.Toolbox;
+import io.opensphere.core.control.action.ContextMenuProvider;
+import io.opensphere.core.util.collections.New;
+import io.opensphere.mantle.data.CategoryContextKey;
+import io.opensphere.mantle.data.DataGroupInfo;
+import io.opensphere.mantle.data.DataGroupInfo.DataGroupContextKey;
+import io.opensphere.mantle.data.DataTypeInfo;
+import io.opensphere.myplaces.constants.Constants;
+import io.opensphere.myplaces.models.MyPlacesModel;
+
+public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo.DataGroupContextKey>
+{
+
+    /**
+     * Provides the context menu for group modifications.
+     *
+     */
+    /**
+     * The toolbox.
+     */
+    private final Toolbox myToolbox;
+
+    /**
+     * The places model.
+     */
+    private final MyPlacesModel myModel;
+
+    /**
+     * Constructs a new points context menu provider.
+     *
+     * @param toolbox The toolbox.
+     * @param model The my places model.
+     */
+    public RoiContextMenuProvider(Toolbox toolbox, MyPlacesModel model)
+    {
+        myToolbox = toolbox;
+        myModel = model;
+    }
+
+    @Override
+    public Collection<? extends Component> getMenuItems(String contextId, DataGroupContextKey key)
+    {
+        List<Component> menuItems;
+
+        return menuItems;
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 6;
+    }
+}

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -2,17 +2,12 @@ package io.opensphere.myplaces.controllers;
 
 import java.awt.Component;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import io.opensphere.core.Toolbox;
 import io.opensphere.core.control.action.ContextMenuProvider;
-import io.opensphere.core.util.collections.New;
-import io.opensphere.mantle.data.CategoryContextKey;
 import io.opensphere.mantle.data.DataGroupInfo;
 import io.opensphere.mantle.data.DataGroupInfo.DataGroupContextKey;
-import io.opensphere.mantle.data.DataTypeInfo;
-import io.opensphere.myplaces.constants.Constants;
 import io.opensphere.myplaces.models.MyPlacesModel;
 
 public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo.DataGroupContextKey>

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -1,11 +1,10 @@
 package io.opensphere.myplaces.controllers;
 
-import java.util.LinkedList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.swing.JMenuItem;
 
-import de.micromata.opengis.kml.v_2_2_0.Placemark;
 import io.opensphere.core.Toolbox;
 import io.opensphere.core.control.action.ContextMenuProvider;
 import io.opensphere.core.geometry.PolygonGeometry;
@@ -35,24 +34,16 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupCont
         myToolbox = toolbox;
     }
 
-    @Override
     public List<JMenuItem> getMenuItems(String contextId, DataGroupContextKey key)
     {
-        if (!(key.getDataGroup() instanceof MyPlacesDataGroupInfo))
+        List<JMenuItem> menuItems = Collections.emptyList();
+        if (key.getDataGroup() instanceof MyPlacesDataGroupInfo)
         {
-            return new LinkedList<>();
+            MyPlacesDataTypeInfo type = (MyPlacesDataTypeInfo)key.getDataType();
+            PolygonGeometry geom = RegionUtils.createGeometry(type.getKmlPlacemark());
+            menuItems = MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().getGeometryMenuItems(geom);
         }
-
-        PolygonGeometry geom = null;
-        MyPlacesDataTypeInfo type = (MyPlacesDataTypeInfo)key.getDataType();
-
-        if (type != null)
-        {
-            Placemark placemark = type.getKmlPlacemark();
-            geom = RegionUtils.createGeometry(placemark);
-        }
-
-        return MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().getGeometryMenuItems(geom);
+        return menuItems;
     }
 
     @Override

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -7,10 +7,7 @@ import javax.swing.JMenuItem;
 import de.micromata.opengis.kml.v_2_2_0.Placemark;
 import io.opensphere.core.Toolbox;
 import io.opensphere.core.control.action.ContextMenuProvider;
-import io.opensphere.core.geometry.Geometry;
 import io.opensphere.core.geometry.PolygonGeometry;
-import io.opensphere.core.util.collections.New;
-import io.opensphere.mantle.MantleToolbox;
 import io.opensphere.mantle.data.DataGroupInfo;
 import io.opensphere.mantle.data.DataGroupInfo.DataGroupContextKey;
 import io.opensphere.mantle.util.MantleToolboxUtils;
@@ -22,10 +19,6 @@ import io.opensphere.myplaces.specific.regions.utils.RegionUtils;
 public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo.DataGroupContextKey>
 {
 
-    /**
-     * Provides the context menu for group modifications.
-     *
-     */
     /**
      * The toolbox.
      */
@@ -46,7 +39,7 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo
     private MyPlacesDataTypeInfo myType;
 
     /**
-     * Constructs a new points context menu provider.
+     * Constructs region of interest context menu provider.
      *
      * @param toolbox The toolbox.
      * @param model The my places model.
@@ -58,15 +51,16 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo
 
     }
 
+    /**
+     * The menu provider for events related to single ROI geometry selection.
+     * 
+     */
     @Override
     public List<JMenuItem> getMenuItems(String contextId, DataGroupContextKey key)
     {
 
         myGroup = (MyPlacesDataGroupInfo)key.getDataGroup();
         myType = (MyPlacesDataTypeInfo)key.getDataType();
-
-        System.out.println("My GROUP : " + myGroup.toString());
-        System.out.println("My Type : " + myType.toString());
 
         if (myType != null)
         {
@@ -75,7 +69,7 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo
         PolygonGeometry geom = RegionUtils.createGeometry(myPlacemark);
         List<JMenuItem> menuItems = null;
 
-        return MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().blah(menuItems, geom);
+        return MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().getGeomtryMenuItems(menuItems, geom);
     }
 
     @Override

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -19,7 +19,7 @@ import io.opensphere.myplaces.specific.regions.utils.RegionUtils;
  */
 public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo.DataGroupContextKey>
 {
-    
+
     /** The toolbox. */
     private final Toolbox myToolbox;
 
@@ -44,15 +44,15 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo
     public List<JMenuItem> getMenuItems(String contextId, DataGroupContextKey key)
     {
         List<JMenuItem> menuItems = null;
+        PolygonGeometry geom = null;
         myType = (MyPlacesDataTypeInfo)key.getDataType();
-         
+
         if (myType != null)
         {
             myPlacemark = myType.getKmlPlacemark();
-            
+            geom = RegionUtils.createGeometry(myPlacemark);
         }
-        PolygonGeometry geom = RegionUtils.createGeometry(myPlacemark);
-        
+
         return MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().getGeomtryMenuItems(menuItems, geom);
     }
 

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -11,29 +11,20 @@ import io.opensphere.core.geometry.PolygonGeometry;
 import io.opensphere.mantle.data.DataGroupInfo;
 import io.opensphere.mantle.data.DataGroupInfo.DataGroupContextKey;
 import io.opensphere.mantle.util.MantleToolboxUtils;
-import io.opensphere.myplaces.models.MyPlacesDataGroupInfo;
 import io.opensphere.myplaces.models.MyPlacesDataTypeInfo;
-import io.opensphere.myplaces.models.MyPlacesModel;
 import io.opensphere.myplaces.specific.regions.utils.RegionUtils;
 
+/**
+ * Provides the context menu for ROI selections.
+ */
 public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo.DataGroupContextKey>
 {
-
-    /**
-     * The toolbox.
-     */
+    
+    /** The toolbox. */
     private final Toolbox myToolbox;
-
-    /**
-     * The places model.
-     */
-    private final MyPlacesModel myModel;
 
     /** The Current placemark. */
     private Placemark myPlacemark;
-
-    /** The Group. */
-    private MyPlacesDataGroupInfo myGroup;
 
     /** The Type. */
     private MyPlacesDataTypeInfo myType;
@@ -44,31 +35,24 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo
      * @param toolbox The toolbox.
      * @param model The my places model.
      */
-    public RoiContextMenuProvider(Toolbox toolbox, MyPlacesModel model)
+    public RoiContextMenuProvider(Toolbox toolbox)
     {
         myToolbox = toolbox;
-        myModel = model;
-
     }
 
-    /**
-     * The menu provider for events related to single ROI geometry selection.
-     * 
-     */
     @Override
     public List<JMenuItem> getMenuItems(String contextId, DataGroupContextKey key)
     {
-
-        myGroup = (MyPlacesDataGroupInfo)key.getDataGroup();
+        List<JMenuItem> menuItems = null;
         myType = (MyPlacesDataTypeInfo)key.getDataType();
-
+         
         if (myType != null)
         {
             myPlacemark = myType.getKmlPlacemark();
+            
         }
         PolygonGeometry geom = RegionUtils.createGeometry(myPlacemark);
-        List<JMenuItem> menuItems = null;
-
+        
         return MantleToolboxUtils.getMantleToolbox(myToolbox).getSelectionHandler().getGeomtryMenuItems(menuItems, geom);
     }
 

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/RoiContextMenuProvider.java
@@ -8,7 +8,6 @@ import de.micromata.opengis.kml.v_2_2_0.Placemark;
 import io.opensphere.core.Toolbox;
 import io.opensphere.core.control.action.ContextMenuProvider;
 import io.opensphere.core.geometry.PolygonGeometry;
-import io.opensphere.mantle.data.DataGroupInfo;
 import io.opensphere.mantle.data.DataGroupInfo.DataGroupContextKey;
 import io.opensphere.mantle.util.MantleToolboxUtils;
 import io.opensphere.myplaces.models.MyPlacesDataTypeInfo;
@@ -17,7 +16,7 @@ import io.opensphere.myplaces.specific.regions.utils.RegionUtils;
 /**
  * Provides the context menu for ROI selections.
  */
-public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo.DataGroupContextKey>
+public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupContextKey>
 {
 
     /** The toolbox. */
@@ -61,4 +60,5 @@ public class RoiContextMenuProvider implements ContextMenuProvider<DataGroupInfo
     {
         return 6;
     }
+
 }

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/specific/MyPointsMenuItemProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/specific/MyPointsMenuItemProvider.java
@@ -14,6 +14,7 @@ import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.swing.EventQueueUtilities;
 import io.opensphere.kml.gx.Track;
 import io.opensphere.mantle.data.DataTypeInfo;
+import io.opensphere.mantle.plugin.selection.SelectionCommand;
 import io.opensphere.myplaces.constants.Constants;
 import io.opensphere.myplaces.models.DataTypeInfoMyPlaceChangedEvent;
 
@@ -39,6 +40,7 @@ public abstract class MyPointsMenuItemProvider implements ActionListener
                 item.addActionListener(e -> actionPerformed(e));
                 menuItems.put(type, item);
             }
+
         });
     }
 
@@ -109,8 +111,8 @@ public abstract class MyPointsMenuItemProvider implements ActionListener
             return;
         }
         // find the "Data" called dataParam and set its boolean value
-        mark.getExtendedData().getData().stream().filter(d -> d.getName().equals(dataParam))
-                .findFirst().ifPresent(d -> d.setValue(String.valueOf(value)));
+        mark.getExtendedData().getData().stream().filter(d -> d.getName().equals(dataParam)).findFirst()
+                .ifPresent(d -> d.setValue(String.valueOf(value)));
         dataType.fireChangeEvent(new DataTypeInfoMyPlaceChangedEvent(dataType, this));
     }
 

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/specific/MyPointsMenuItemProvider.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/specific/MyPointsMenuItemProvider.java
@@ -14,7 +14,6 @@ import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.swing.EventQueueUtilities;
 import io.opensphere.kml.gx.Track;
 import io.opensphere.mantle.data.DataTypeInfo;
-import io.opensphere.mantle.plugin.selection.SelectionCommand;
 import io.opensphere.myplaces.constants.Constants;
 import io.opensphere.myplaces.models.DataTypeInfoMyPlaceChangedEvent;
 


### PR DESCRIPTION
Load / add from a single polygon in the layer manager. Purge from a single polygon in the layer manager (would remove all query results that exist within the bounds of the polygon)