### PR TITLE
Fix Label NullPointerException

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
@@ -122,18 +122,21 @@ public class LabelHoverController implements EventListener<DataElementHighlightC
         DataElement element = MantleToolboxUtils.getDataElementLookupUtils(getToolbox()).getDataElement(pEvent.getRegistryId(),
                 null, null);
 
-        List<Class<? extends VisualizationSupport>> featureClasses = StyleManagerUtils
-                .getDefaultFeatureClassesForType(element.getDataTypeInfo());
-        VisualizationStyleController vsc = MantleToolboxUtils.getMantleToolbox(myToolbox).getVisualizationStyleController();
-        for (Class<? extends VisualizationSupport> featureClass : featureClasses)
+        if (element != null)
         {
-            Class<? extends VisualizationStyle> selectedStyleClass = vsc.getSelectedVisualizationStyleClass(featureClass,
-                    element.getDataTypeInfo().getParent(), element.getDataTypeInfo());
-
-            if (selectedStyleClass != null && ClassUtils.isAssignable(selectedStyleClass, AbstractLocationFeatureVisualizationStyle.class))
+            List<Class<? extends VisualizationSupport>> featureClasses = StyleManagerUtils
+                    .getDefaultFeatureClassesForType(element.getDataTypeInfo());
+            VisualizationStyleController vsc = MantleToolboxUtils.getMantleToolbox(myToolbox).getVisualizationStyleController();
+            for (Class<? extends VisualizationSupport> featureClass : featureClasses)
             {
-                drawLabel(pEvent, element, vsc, featureClass,
-                        selectedStyleClass.asSubclass(AbstractLocationFeatureVisualizationStyle.class));
+                Class<? extends VisualizationStyle> selectedStyleClass = vsc.getSelectedVisualizationStyleClass(featureClass,
+                        element.getDataTypeInfo().getParent(), element.getDataTypeInfo());
+
+                if (selectedStyleClass != null && ClassUtils.isAssignable(selectedStyleClass, AbstractLocationFeatureVisualizationStyle.class))
+                {
+                    drawLabel(pEvent, element, vsc, featureClass,
+                            selectedStyleClass.asSubclass(AbstractLocationFeatureVisualizationStyle.class));
+                }
             }
         }
     }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
@@ -130,7 +130,7 @@ public class LabelHoverController implements EventListener<DataElementHighlightC
             Class<? extends VisualizationStyle> selectedStyleClass = vsc.getSelectedVisualizationStyleClass(featureClass,
                     element.getDataTypeInfo().getParent(), element.getDataTypeInfo());
 
-            if (ClassUtils.isAssignable(selectedStyleClass, AbstractLocationFeatureVisualizationStyle.class))
+            if (selectedStyleClass != null && ClassUtils.isAssignable(selectedStyleClass, AbstractLocationFeatureVisualizationStyle.class))
             {
                 drawLabel(pEvent, element, vsc, featureClass,
                         selectedStyleClass.asSubclass(AbstractLocationFeatureVisualizationStyle.class));


### PR DESCRIPTION
Fix NullPointerException when attempting to draw labels for features that do not yet have a style class. Don't attempt to draw labels if the style class is null.