### PR TITLE
Fix Heading Rotation Processing

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/geometry/PointSpriteGeometry.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/geometry/PointSpriteGeometry.java
@@ -185,7 +185,8 @@ public class PointSpriteGeometry extends PointGeometry implements ImageProviding
         /**
          * Sets whether the geometry is sensitive to projection changes.
          *
-         * @param isProjectionSensitive whether the geometry is sensitive to projection changes
+         * @param isProjectionSensitive whether the geometry is sensitive to
+         *            projection changes
          */
         public void setProjectionSensitive(boolean isProjectionSensitive)
         {

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/PointSpriteProcessor.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/PointSpriteProcessor.java
@@ -353,7 +353,10 @@ public class PointSpriteProcessor extends TextureProcessor<PointSpriteGeometry>
                     List<PointSpriteGeometry> projectionSensitiveGeoms = getGeometries().parallelStream()
                             .filter(g -> g.isProjectionSensitive()).collect(Collectors.toCollection(New::list));
 
-                    projectionSensitiveGeoms.forEach(geom -> getImageManagersToGeoms().remove(geom.getImageManager()));
+                    projectionSensitiveGeoms.parallelStream().map(geom -> geom.getImageManager())
+                            .collect(Collectors.toCollection(New::set))
+                            .forEach(manager -> getImageManagersToGeoms().remove(manager));
+
                     resetDueToImageUpdate(projectionSensitiveGeoms, State.UNPROCESSED);
                 }
             }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/PointSpriteProcessor.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/PointSpriteProcessor.java
@@ -353,9 +353,8 @@ public class PointSpriteProcessor extends TextureProcessor<PointSpriteGeometry>
                     List<PointSpriteGeometry> projectionSensitiveGeoms = getGeometries().parallelStream()
                             .filter(g -> g.isProjectionSensitive()).collect(Collectors.toCollection(New::list));
 
-                    projectionSensitiveGeoms.parallelStream().map(geom -> geom.getImageManager())
-                            .collect(Collectors.toCollection(New::set))
-                            .forEach(manager -> getImageManagersToGeoms().remove(manager));
+                    projectionSensitiveGeoms.parallelStream()
+                            .forEach(geom -> getImageManagersToGeoms().remove(geom.getImageManager()));
 
                     resetDueToImageUpdate(projectionSensitiveGeoms, State.UNPROCESSED);
                 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/PointSpriteProcessor.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/PointSpriteProcessor.java
@@ -346,8 +346,9 @@ public class PointSpriteProcessor extends TextureProcessor<PointSpriteGeometry>
             {
                 myLastHandledHeading = heading;
 
-                Collection<PointSpriteGeometry> processorGeometries = getGeometrySet();
-                synchronized (processorGeometries)
+                // When re-processing rotated images, we want to ensure they
+                // aren't otherwise modified.
+                synchronized (getGeometrySet())
                 {
                     List<PointSpriteGeometry> projectionSensitiveGeoms = getGeometries().parallelStream()
                             .filter(g -> g.isProjectionSensitive()).collect(Collectors.toCollection(New::list));

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/TextureProcessor.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/TextureProcessor.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -12,7 +13,6 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.media.opengl.GL;
@@ -1287,10 +1287,19 @@ public abstract class TextureProcessor<E extends ImageProvidingGeometry<E>> exte
         Collection<E> processorGeometries = getGeometrySet();
         synchronized (processorGeometries)
         {
-            resets = resets.stream().filter(geom -> hasGeometry(geom)).collect(Collectors.toCollection(New::list));
-            Collection<ImageManager> imageManagers = resets.parallelStream().map(geom -> geom.getImageManager())
-                    .collect(Collectors.toCollection(New::collection));
-
+            Collection<ImageManager> imageManagers = New.collection(resets.size());
+            for (Iterator<? extends E> iter = resets.iterator(); iter.hasNext();)
+            {
+                E geom = iter.next();
+                if (!hasGeometry(geom))
+                {
+                    iter.remove();
+                }
+                else
+                {
+                    imageManagers.add(geom.getImageManager());
+                }
+            }
             if (!resets.isEmpty())
             {
                 // Clear the cache to force a reload.

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/IconFeatureVisualizationStyle.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/IconFeatureVisualizationStyle.java
@@ -156,8 +156,8 @@ public class IconFeatureVisualizationStyle extends AbstractLocationFeatureVisual
 
     /** The default heading column parameter. */
     public static final VisualizationStyleParameter ourDefaultHeadingColumnParameter = new VisualizationStyleParameter(
-            ourHeadingColumnPropertyKey, "Heading Column", null, String.class,
-            new VisualizationStyleParameterFlags(true, true), ParameterHint.hint(false, true));
+            ourHeadingColumnPropertyKey, "Heading Column", null, String.class, new VisualizationStyleParameterFlags(true, true),
+            ParameterHint.hint(false, true));
 
     /** The Temp icon record. */
     private transient IconRecord myTempIconRecord;
@@ -194,14 +194,16 @@ public class IconFeatureVisualizationStyle extends AbstractLocationFeatureVisual
 
     @Override
     public void createCombinedGeometry(Set<Geometry> setToAddTo, FeatureCombinedGeometryBuilderData builderData,
-            RenderPropertyPool renderPropertyPool) throws IllegalArgumentException
+            RenderPropertyPool renderPropertyPool)
+        throws IllegalArgumentException
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void createIndividualGeometry(Set<Geometry> setToAddTo, FeatureIndividualGeometryBuilderData bd,
-            RenderPropertyPool renderPropertyPool) throws IllegalArgumentException
+            RenderPropertyPool renderPropertyPool)
+        throws IllegalArgumentException
     {
         if (bd.getMGS() instanceof MapLocationGeometrySupport)
         {
@@ -425,8 +427,8 @@ public class IconFeatureVisualizationStyle extends AbstractLocationFeatureVisual
 
         param = style.getStyleParameter(ourDefaultPointSizePropertyKey);
         FloatSliderStyleParameterEditorPanel pointSizePanel = new FloatSliderStyleParameterEditorPanel(
-                StyleUtils.createSliderMiniPanelBuilder(param.getName()), style, ourDefaultPointSizePropertyKey, true, false, 1.0f,
-                MAX_POINT_SIZE, new FloatSliderStyleParameterEditorPanel.BasicIntFloatConvertor(0, null));
+                StyleUtils.createSliderMiniPanelBuilder(param.getName()), style, ourDefaultPointSizePropertyKey, true, false,
+                1.0f, MAX_POINT_SIZE, new FloatSliderStyleParameterEditorPanel.BasicIntFloatConvertor(0, null));
         paramList.add(pointSizePanel);
 
         EditorPanelVisibilityDependency vd = new EditorPanelVisibilityDependency(panel, pointSizePanel);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/IconImageProvider.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/IconImageProvider.java
@@ -54,8 +54,8 @@ public class IconImageProvider implements ImmediateImageProvider<Void>
     private volatile Image myContent;
 
     /**
-     * The unprocessed image if there is an image processor. This is to avoid having to reload the image when we just want to
-     * re-process it.
+     * The unprocessed image if there is an image processor. This is to avoid
+     * having to reload the image when we just want to re-process it.
      */
     private Image myUnprocessedContent;
 
@@ -280,7 +280,6 @@ public class IconImageProvider implements ImmediateImageProvider<Void>
                 }
 
                 bufferedImage = myImageProcessor.process(bufferedImage);
-
                 content = new ImageIOImage(bufferedImage);
             }
             else


### PR DESCRIPTION
VORTEX-5573 / VORTEX-5574
- Fix: Disconnection between point sprite geometries & other geometries that depend on positioning data would occur when interacting with rotation-enabled sprites.
- Fix: Selection would not occur properly when interacting with rotation-enabled sprites, and will occasionally freeze until another processing refresh occurs.
- Fix: Formatting.
- Fix: Some operations that utilized the geometry list, copy or actual, were not synchronized even though they probably should have been.
- Update: Some loops can be operated in parallel for better performance. Some parallel operations will be forced-sequential regardless.