### PR TITLE
VORTEX-5655: Buffering polygons used for spatial filters.

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/datafilter/impl/DataFilterRegistryImpl.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/datafilter/impl/DataFilterRegistryImpl.java
@@ -107,8 +107,10 @@ public class DataFilterRegistryImpl implements DataFilterRegistry
     @Override
     public long addSpatialLoadFilter(final String typeKey, final Geometry filter)
     {
-        myTypeKeyToSpatialFilterMap.put(typeKey, filter);
-        notifyListeners(l -> l.spatialFilterAdded(typeKey, filter));
+        Geometry bufferedFilter = filter.buffer(0);
+
+        myTypeKeyToSpatialFilterMap.put(typeKey, bufferedFilter);
+        notifyListeners(l -> l.spatialFilterAdded(typeKey, bufferedFilter));
         return 0;
     }
 

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/terrain/ImmutableTriangleGlobeModel.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/terrain/ImmutableTriangleGlobeModel.java
@@ -169,14 +169,15 @@ public class ImmutableTriangleGlobeModel extends TriangleGlobeModel
 
         try
         {
-            SimpleTesseraBlockBuilder<GeographicTesseraVertex> triBuilder = new SimpleTesseraBlockBuilder<GeographicTesseraVertex>(
-                    3, modelCenter);
+            Geometry bufferedPolygon = polygon.buffer(0);
+
+            SimpleTesseraBlockBuilder<GeographicTesseraVertex> triBuilder = new SimpleTesseraBlockBuilder<>(3, modelCenter);
 
             Collection<TerrainTriangle> fullyContained = New.collection();
             Collection<TerrainTriangle> partiallyContained = New.collection();
 
-            getNorthBottom().getOverlappingTriangles(polygon, fullyContained, partiallyContained);
-            getSouthBottom().getOverlappingTriangles(polygon, fullyContained, partiallyContained);
+            getNorthBottom().getOverlappingTriangles(bufferedPolygon, fullyContained, partiallyContained);
+            getSouthBottom().getOverlappingTriangles(bufferedPolygon, fullyContained, partiallyContained);
 
             for (TerrainTriangle tri : fullyContained)
             {
@@ -194,7 +195,7 @@ public class ImmutableTriangleGlobeModel extends TriangleGlobeModel
 
             for (TerrainTriangle partial : partiallyContained)
             {
-                Geometry geom = polygon.intersection(partial.getJTSPolygon());
+                Geometry geom = bufferedPolygon.intersection(partial.getJTSPolygon());
                 VertexGenerator<GeographicTesseraVertex> vertexGenerator = new SimpleVertexGenerator(terrainVertices, partial);
                 for (int i = 0; i < geom.getNumGeometries(); ++i)
                 {

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/terrain/NorthTerrainTriangle.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/terrain/NorthTerrainTriangle.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.geom.Geometry;
 
 import io.opensphere.core.model.GeographicBoundingBox;
 import io.opensphere.core.model.GeographicConvexPolygon;
@@ -72,7 +72,7 @@ public class NorthTerrainTriangle extends TerrainTriangle
     }
 
     @Override
-    public void getOverlappingTriangles(Polygon polygon, Collection<TerrainTriangle> fullyContained,
+    public void getOverlappingTriangles(Geometry polygon, Collection<TerrainTriangle> fullyContained,
             Collection<TerrainTriangle> partiallyContained)
     {
         getLeftChild().getOverlappingTriangles(polygon, fullyContained, partiallyContained);

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/terrain/TerrainTriangle.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/terrain/TerrainTriangle.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 
+import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Polygon;
 
 import io.opensphere.core.math.DefaultSphere;
@@ -839,7 +840,7 @@ public class TerrainTriangle implements Cloneable, Tessera<GeographicPosition>
      * @param partiallyContained Triangles which overlap but are not fully
      *            contained within the polygon.
      */
-    public void getOverlappingTriangles(Polygon polygon, Collection<TerrainTriangle> fullyContained,
+    public void getOverlappingTriangles(Geometry polygon, Collection<TerrainTriangle> fullyContained,
             Collection<TerrainTriangle> partiallyContained)
     {
         if (getJTSPolygon().intersects(polygon))


### PR DESCRIPTION
Fixes #5655

## Proposed Changes

  - Updated triangle globe model to use generic Geometry instead of Polygon
  - Updated uses of Geometry to use buffered geometries of size zero to protect against overlapping polygons
  -
