### PR TITLE
VORTEX-5655: Buffering spatial filter areas to resolve complex polygons.

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/datafilter/impl/DataFilterRegistryImpl.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/datafilter/impl/DataFilterRegistryImpl.java
@@ -105,10 +105,12 @@ public class DataFilterRegistryImpl implements DataFilterRegistry
     }
 
     @Override
-    public long addSpatialLoadFilter(final String typeKey, final Geometry filter)
+    public long addSpatialLoadFilter(final String typeKey, final Geometry geometry)
     {
-        myTypeKeyToSpatialFilterMap.put(typeKey, filter);
-        notifyListeners(l -> l.spatialFilterAdded(typeKey, filter));
+        Geometry bufferedGeometry = geometry.buffer(0);
+
+        myTypeKeyToSpatialFilterMap.put(typeKey, bufferedGeometry);
+        notifyListeners(l -> l.spatialFilterAdded(typeKey, bufferedGeometry));
         return 0;
     }
 

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/terrain/ImmutableTriangleGlobeModel.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/terrain/ImmutableTriangleGlobeModel.java
@@ -223,7 +223,7 @@ public class ImmutableTriangleGlobeModel extends TriangleGlobeModel
         catch (TopologyException e)
         {
             // This is likely caused by the polygon overlapping itself.
-            LOGGER.error("JTS polygon intersection failed." + e);
+            LOGGER.error("JTS polygon intersection failed.", e);
             return null;
         }
     }


### PR DESCRIPTION
Fixes #5655: Buffering polygons for spatial filters to resolve complex polygons. 

## Proposed Changes
  - Buffer all spatial filters with a distance of zero, which draws an outline around complex polygons, resolving overlap issues. 
  - Update catch log message to actually grab the stack trace. 
  -
