### PR TITLE
VORTEX-5659: Proxy configuration migrator

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/net/NetworkConfigurationOptionsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/net/NetworkConfigurationOptionsProvider.java
@@ -96,6 +96,7 @@ public class NetworkConfigurationOptionsProvider extends AbstractPreferencesOpti
         }
 
         SystemProxyConfiguration systemConfiguration = myNetworkConfigurationManager.getSystemConfiguration();
+        systemConfiguration.getExclusionPatterns().clear();
         systemConfiguration.getExclusionPatterns().addAll(Arrays.asList(mySystemProxyExclusionsField.getText().split(",\\s*|\\s+")));
 
         UrlProxyConfiguration urlConfiguration = myNetworkConfigurationManager.getUrlConfiguration();
@@ -110,6 +111,7 @@ public class NetworkConfigurationOptionsProvider extends AbstractPreferencesOpti
             configuration.setHost(myManualProxyHostField.getText());
             configuration.setPort(port);
 
+            configuration.getExclusionPatterns().clear();
             configuration.getExclusionPatterns().addAll(Arrays.asList(myManualProxyExclusionsField.getText().split(",\\s*|\\s+")));
         }
         catch (@SuppressWarnings("unused") NumberFormatException e)

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/ManualProxyConfiguration.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/ManualProxyConfiguration.java
@@ -8,6 +8,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.opensphere.core.util.lang.ToStringHelper;
+
 /** Configuration class for Manual proxies with exclusion lists. */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -78,5 +80,17 @@ public class ManualProxyConfiguration extends ProxyConfiguration
     public void setPort(int port)
     {
         myPort = port;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        return new ToStringHelper(this).add("Host", myHost).add("Port", myPort).addIfNotNull("Exclusions", myExclusionPatterns)
+                .toString();
     }
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/ProxyConfigurationMigrator.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/ProxyConfigurationMigrator.java
@@ -3,7 +3,6 @@ package io.opensphere.core.net.config;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -13,6 +12,7 @@ import org.apache.log4j.Logger;
 import io.opensphere.core.appl.PreConfigurationUpdateModule;
 import io.opensphere.core.preferences.Preferences;
 import io.opensphere.core.preferences.PreferencesRegistry;
+import io.opensphere.core.util.collections.New;
 
 /** Migrates the old proxy configs to the new format. */
 public class ProxyConfigurationMigrator implements PreConfigurationUpdateModule
@@ -24,23 +24,21 @@ public class ProxyConfigurationMigrator implements PreConfigurationUpdateModule
     public void updateConfigs(PreferencesRegistry prefsRegistry)
     {
         Preferences proxyPreferences = prefsRegistry.getPreferences("io.opensphere.core.net.NetworkConfigurationManagerImpl");
-        Set<String> preferenceKeys = new HashSet<String>(
-                Arrays.asList("ProxyConfigUrl", "ProxyExclusionPatterns", "ProxyHost", "ProxyPort", "SystemProxiesEnabled"));
+        Set<String> preferenceKeys = New.set("ProxyConfigUrl", "ProxyExclusionPatterns", "ProxyHost", "ProxyPort",
+                "SystemProxiesEnabled");
         Map<String, String> preferenceValues = new HashMap<String, String>();
-        boolean isChanged = false;
 
         for (String key : preferenceKeys)
         {
             String preferenceValue = proxyPreferences.getString(key, "");
             if (!preferenceValue.isEmpty())
             {
-                isChanged = true;
                 preferenceValues.put(key, preferenceValue);
             }
             proxyPreferences.remove(key, this);
         }
 
-        if (isChanged)
+        if (!preferenceValues.isEmpty())
         {
             LOGGER.info("Migrating old proxy configurations");
             ProxyConfigurations proxyConfigs = convertPreferences(preferenceValues);

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/ProxyConfigurationMigrator.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/ProxyConfigurationMigrator.java
@@ -1,0 +1,101 @@
+package io.opensphere.core.net.config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.log4j.Logger;
+
+import io.opensphere.core.appl.PreConfigurationUpdateModule;
+import io.opensphere.core.preferences.Preferences;
+import io.opensphere.core.preferences.PreferencesRegistry;
+
+/** Migrates the old proxy configs to the new format. */
+public class ProxyConfigurationMigrator implements PreConfigurationUpdateModule
+{
+    /** Logger reference. */
+    private static final Logger LOGGER = Logger.getLogger(ProxyConfigurationMigrator.class);
+
+    /** The proxy preference keys. */
+    private static final Set<String> PREFERENCE_KEYS = new HashSet<String>(
+            Arrays.asList("ProxyConfigUrl", "ProxyExclusionPatterns", "ProxyHost", "ProxyPort", "SystemProxiesEnabled"));
+
+    @Override
+    public void updateConfigs(PreferencesRegistry prefsRegistry)
+    {
+        Preferences proxyPreferences = prefsRegistry.getPreferences("io.opensphere.core.net.NetworkConfigurationManagerImpl");
+        Map<String, String> preferenceValues = new HashMap<String, String>();
+        boolean isChanged = false;
+        for (String key : PREFERENCE_KEYS)
+        {
+            String preferenceValue = proxyPreferences.getString(key, "");
+            if (!preferenceValue.isEmpty())
+            {
+                System.out.println("NON EMPTY STRING: " + preferenceValue);
+                isChanged = true;
+                preferenceValues.put(key, preferenceValue);
+            }
+            proxyPreferences.remove(key, this);
+        }
+
+        if (isChanged)
+        {
+            LOGGER.info("Migrating old proxy configurations");
+            ProxyConfigurations proxyConfigs = convertPreferences(preferenceValues);
+            proxyPreferences.putJAXBObject("configurations", proxyConfigs, false, this);
+            proxyPreferences.printPrefs();
+            LOGGER.info("Finished migrating to new proxy configurations");
+        }
+    }
+
+    /**
+     * Converts the old preferences to the new proxy configurations.
+     *
+     * @param preferences the map of old preferences
+     * @return the new proxy configurations
+     */
+    private ProxyConfigurations convertPreferences(Map<String, String> preferences)
+    {
+        ProxyConfigurations proxyConfigs = new ProxyConfigurations();
+
+        List<String> exclusions = new ArrayList<String>();
+        if (preferences.get("ProxyExclusionPatterns") != null)
+        {
+            // split exclusions on one or more spaces, comma and one or more spaces, or comma
+            exclusions = Arrays.asList(preferences.get("ProxyExclusionPatterns").trim().split(" +|, +|,"));
+        }
+
+        if (Boolean.parseBoolean(preferences.get("SystemProxiesEnabled")))
+        {
+            // System proxy & exclusions
+            proxyConfigs.setSelectedConfigurationType(ConfigurationType.SYSTEM);
+            proxyConfigs.getSystemProxyConfiguration().getExclusionPatterns().addAll(exclusions);
+        }
+        else if (preferences.get("ProxyConfigUrl") != null)
+        {
+            // Url proxy and url
+            proxyConfigs.setSelectedConfigurationType(ConfigurationType.URL);
+            proxyConfigs.getUrlProxyConfiguration().setProxyUrl(preferences.get("ProxyConfigUrl"));
+        }
+        else if (preferences.get("ProxyPort") != null)
+        {
+            // Manual proxy, host, port, and exclusions
+            proxyConfigs.setSelectedConfigurationType(ConfigurationType.MANUAL);
+            // Must be set to empty host if the field was blank, not null
+            proxyConfigs.getManualProxyConfiguration()
+                    .setHost(preferences.get("ProxyHost") != null ? preferences.get("ProxyHost") : "");
+            proxyConfigs.getManualProxyConfiguration().setPort(Integer.parseInt(preferences.get("ProxyPort")));
+            proxyConfigs.getManualProxyConfiguration().getExclusionPatterns().addAll(exclusions);
+        }
+        else
+        {
+            // No proxy
+            proxyConfigs.setSelectedConfigurationType(ConfigurationType.NONE);
+        }
+        return proxyConfigs;
+    }
+}

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/ProxyConfigurations.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/ProxyConfigurations.java
@@ -6,6 +6,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
+import io.opensphere.core.util.lang.ToStringHelper;
+
 /** A collection of the set of possible proxy configurations. */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -141,5 +143,18 @@ public class ProxyConfigurations
             myManualProxyConfiguration = new ManualProxyConfiguration();
         }
         return myManualProxyConfiguration;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        return new ToStringHelper(this).add("SelectedProxy", mySelectedConfigurationType)
+                .add(mySystemProxyConfiguration.toString()).add(myUrlProxyConfiguration.toString())
+                .add(myManualProxyConfiguration.toString()).toStringPreferenceDump();
     }
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/SystemProxyConfiguration.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/SystemProxyConfiguration.java
@@ -8,6 +8,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.opensphere.core.util.lang.ToStringHelper;
+
 /**
  * Configuration class for system proxy configurations, with exclusion patterns.
  */
@@ -32,5 +34,16 @@ public class SystemProxyConfiguration extends ProxyConfiguration
             myExclusionPatterns = new HashSet<>();
         }
         return myExclusionPatterns;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        return new ToStringHelper(this).addIfNotNull("Exclusions", myExclusionPatterns).toString();
     }
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/UrlProxyConfiguration.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/net/config/UrlProxyConfiguration.java
@@ -5,6 +5,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.opensphere.core.util.lang.ToStringHelper;
+
 /** Configuration class for URL-based proxies. */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -32,5 +34,16 @@ public class UrlProxyConfiguration extends ProxyConfiguration
     public void setProxyUrl(String proxyUrl)
     {
         myProxyUrl = proxyUrl;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        return new ToStringHelper(this).addIfNotNull("Url", myProxyUrl).toString();
     }
 }

--- a/open-sphere-base/core/src/main/resources/META-INF/services/io.opensphere.core.appl.PreConfigurationUpdateModule
+++ b/open-sphere-base/core/src/main/resources/META-INF/services/io.opensphere.core.appl.PreConfigurationUpdateModule
@@ -1,0 +1,1 @@
+io.opensphere.core.net.config.ProxyConfigurationMigrator

--- a/open-sphere-base/core/src/main/resources/prefs/io.opensphere.core.net.NetworkConfigurationManagerImpl.xml
+++ b/open-sphere-base/core/src/main/resources/prefs/io.opensphere.core.net.NetworkConfigurationManagerImpl.xml
@@ -1,6 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<preferences topic="io.opensphere.core.net.NetworkConfigurationManagerImpl">
-   <preference key="SystemProxiesEnabled" class="java.lang.Boolean">
-      <value>true</value>
+<?xml version="1.0" encoding="UTF-8"?><preferences topic="io.opensphere.core.net.NetworkConfigurationManagerImpl">
+   <preference class="io.opensphere.core.net.config.ProxyConfigurations" key="configurations">
+      <proxyConfigurations>
+         <selected>system</selected>
+         <no-proxy/>
+         <system-proxy/>
+         <url-proxy/>
+         <manual-proxy>
+            <port>0</port>
+         </manual-proxy>
+      </proxyConfigurations>
    </preference>
 </preferences>

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/net/config/ProxyConfigurationMigratorTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/net/config/ProxyConfigurationMigratorTest.java
@@ -1,0 +1,173 @@
+package io.opensphere.core.net.config;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.junit.Test;
+
+/** Test {@link ProxyConfigurationMigrator}. */
+public class ProxyConfigurationMigratorTest
+{
+    /** Test {@link ProxyConfigurationMigrator#convertPreferences(Map)} for the no proxy case. */
+    @Test
+    public void testConvertPreferencesNoProxy()
+    {
+        ProxyConfigurations expectedConfigs = new ProxyConfigurations();
+        expectedConfigs.setSelectedConfigurationType(ConfigurationType.NONE);
+
+        Map<String, String> preferenceValues = new HashMap<String, String>();
+        preferenceValues.put("SystemProxiesEnabled", "false");
+        ProxyConfigurations actualConfigs = new ProxyConfigurationMigrator().convertPreferences(preferenceValues);
+
+        assertTrue(configsMatch(expectedConfigs, actualConfigs));
+    }
+
+    /** Test {@link ProxyConfigurationMigrator#convertPreferences(Map)} for the system proxy case. */
+    @Test
+    public void testConvertPreferencesSystemProxy()
+    {
+        ProxyConfigurations expectedConfigs = new ProxyConfigurations();
+        expectedConfigs.setSelectedConfigurationType(ConfigurationType.SYSTEM);
+        expectedConfigs.getSystemProxyConfiguration().getExclusionPatterns()
+                .addAll(new HashSet<String>(Arrays.asList("example1", "example2", "example3", "example4")));
+
+        Map<String, String> preferenceValues = new HashMap<String, String>();
+        preferenceValues.put("SystemProxiesEnabled", "true");
+        preferenceValues.put("ProxyExclusionPatterns", " example1, example2,example3   example4 ");
+        ProxyConfigurations actualConfigs = new ProxyConfigurationMigrator().convertPreferences(preferenceValues);
+
+        assertTrue(configsMatch(expectedConfigs, actualConfigs));
+    }
+
+    /** Test {@link ProxyConfigurationMigrator#convertPreferences(Map)} for the url proxy case. */
+    @Test
+    public void testConvertPreferencesUrlProxy()
+    {
+        ProxyConfigurations expectedConfigs = new ProxyConfigurations();
+        expectedConfigs.setSelectedConfigurationType(ConfigurationType.URL);
+        expectedConfigs.getUrlProxyConfiguration().setProxyUrl("example-url");
+
+        Map<String, String> preferenceValues = new HashMap<String, String>();
+        preferenceValues.put("SystemProxiesEnabled", "false");
+        preferenceValues.put("ProxyConfigUrl", "example-url");
+        ProxyConfigurations actualConfigs = new ProxyConfigurationMigrator().convertPreferences(preferenceValues);
+
+        assertTrue(configsMatch(expectedConfigs, actualConfigs));
+    }
+
+    /** Test {@link ProxyConfigurationMigrator#convertPreferences(Map)} for the manual proxy case. */
+    @Test
+    public void testConvertPreferencesManualProxy()
+    {
+        ProxyConfigurations expectedConfigs = new ProxyConfigurations();
+        expectedConfigs.setSelectedConfigurationType(ConfigurationType.MANUAL);
+        expectedConfigs.getManualProxyConfiguration().setHost("example-host");
+        expectedConfigs.getManualProxyConfiguration().setPort(80);
+        expectedConfigs.getManualProxyConfiguration().getExclusionPatterns()
+                .addAll(new HashSet<String>(Arrays.asList("example1", "example2", "example3")));
+
+        Map<String, String> preferenceValues = new HashMap<String, String>();
+        preferenceValues.put("SystemProxiesEnabled", "false");
+        preferenceValues.put("ProxyHost", "example-host");
+        preferenceValues.put("ProxyPort", "80");
+        preferenceValues.put("ProxyExclusionPatterns", "example1 example2 example3");
+        ProxyConfigurations actualConfigs = new ProxyConfigurationMigrator().convertPreferences(preferenceValues);
+
+        assertTrue(configsMatch(expectedConfigs, actualConfigs));
+    }
+
+    /**
+     * Test if the actual converted proxy configurations match the expected proxy configurations.
+     *
+     * @param expected the expected proxy configurations
+     * @param actual the actual proxy configurations
+     * @return if the expected and new configurations match
+     */
+    private boolean configsMatch(ProxyConfigurations expected, ProxyConfigurations actual)
+    {
+        return expected.getSelectedConfigurationType() == actual.getSelectedConfigurationType()
+                && systemProxiesMatch(expected.getSystemProxyConfiguration(), actual.getSystemProxyConfiguration())
+                && urlProxiesMatch(expected.getUrlProxyConfiguration(), actual.getUrlProxyConfiguration())
+                && manualProxiesMatch(expected.getManualProxyConfiguration(), actual.getManualProxyConfiguration());
+    }
+
+    /**
+     * Test if the system proxy configurations match.
+     *
+     * @param expected the expected system proxy configuration
+     * @param actual the actual system proxy configuration
+     * @return if the system proxies match
+     */
+    private boolean systemProxiesMatch(SystemProxyConfiguration expected, SystemProxyConfiguration actual)
+    {
+        if (null == expected.getExclusionPatterns())
+        {
+            return null == actual.getExclusionPatterns();
+        }
+        else
+        {
+            return expected.getExclusionPatterns().equals(actual.getExclusionPatterns());
+        }
+    }
+
+    /**
+     * Test if the url proxy configurations match.
+     *
+     * @param expected the expected url proxy configuration
+     * @param actual the actual url proxy configuration
+     * @return if the url proxies match
+     */
+    private boolean urlProxiesMatch(UrlProxyConfiguration expected, UrlProxyConfiguration actual)
+    {
+        if (null == expected.getProxyUrl())
+        {
+            return null == actual.getProxyUrl();
+        }
+        else
+        {
+            return expected.getProxyUrl().equals(actual.getProxyUrl());
+        }
+    }
+
+    /**
+     * Test if the system proxy configurations match.
+     *
+     * @param expected the expected system proxy configuration
+     * @param actual the actual system proxy configuration
+     * @return if the system proxies match
+     */
+    private boolean manualProxiesMatch(ManualProxyConfiguration expected, ManualProxyConfiguration actual)
+    {
+        if (null == expected.getHost())
+        {
+            // null host and null exclusion patterns
+            if (null == expected.getExclusionPatterns())
+            {
+                return null == actual.getHost() && null == actual.getExclusionPatterns()
+                        && expected.getPort() == actual.getPort();
+            }
+            // null host only
+            else
+            {
+                return null == actual.getHost() && expected.getExclusionPatterns().equals(actual.getExclusionPatterns())
+                        && expected.getPort() == actual.getPort();
+            }
+        }
+        // null exclusion patterns only
+        else if (null == expected.getExclusionPatterns())
+        {
+            return null == actual.getExclusionPatterns() && expected.getHost().equals(actual.getHost())
+                    && expected.getPort() == actual.getPort();
+        }
+        // no null values
+        else
+        {
+            return expected.getHost().equals(actual.getHost()) && expected.getPort() == actual.getPort()
+                    && expected.getExclusionPatterns().equals(actual.getExclusionPatterns());
+        }
+    }
+}

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/net/config/ProxyConfigurationMigratorTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/net/config/ProxyConfigurationMigratorTest.java
@@ -104,14 +104,7 @@ public class ProxyConfigurationMigratorTest
      */
     private boolean systemProxiesMatch(SystemProxyConfiguration expected, SystemProxyConfiguration actual)
     {
-        if (null == expected.getExclusionPatterns())
-        {
-            return null == actual.getExclusionPatterns();
-        }
-        else
-        {
-            return expected.getExclusionPatterns().equals(actual.getExclusionPatterns());
-        }
+        return expected.getExclusionPatterns().equals(actual.getExclusionPatterns());
     }
 
     /**
@@ -144,26 +137,9 @@ public class ProxyConfigurationMigratorTest
     {
         if (null == expected.getHost())
         {
-            // null host and null exclusion patterns
-            if (null == expected.getExclusionPatterns())
-            {
-                return null == actual.getHost() && null == actual.getExclusionPatterns()
-                        && expected.getPort() == actual.getPort();
-            }
-            // null host only
-            else
-            {
-                return null == actual.getHost() && expected.getExclusionPatterns().equals(actual.getExclusionPatterns())
-                        && expected.getPort() == actual.getPort();
-            }
-        }
-        // null exclusion patterns only
-        else if (null == expected.getExclusionPatterns())
-        {
-            return null == actual.getExclusionPatterns() && expected.getHost().equals(actual.getHost())
+            return null == actual.getHost() && expected.getExclusionPatterns().equals(actual.getExclusionPatterns())
                     && expected.getPort() == actual.getPort();
         }
-        // no null values
         else
         {
             return expected.getHost().equals(actual.getHost()) && expected.getPort() == actual.getPort()


### PR DESCRIPTION
Added migrator for old proxy configuration format to new proxy configurations format.
Fixed bug where exclusions for system/manual proxy were not being cleared.
Made proxy configurations readable for preference printing purposes.
Added tests for logic to convert the old preferences to new.