### PR TITLE
VORTEX-5679 add clear button to search results dialog

### DIFF
--- a/open-sphere-plugins/search/src/main/java/io/opensphere/search/SearchResultHudDialog.java
+++ b/open-sphere-plugins/search/src/main/java/io/opensphere/search/SearchResultHudDialog.java
@@ -55,7 +55,7 @@ public class SearchResultHudDialog extends AbstractInternalFrame
 
         myResultPanel = new SearchDialogPanel(toolbox, searchModel);
         myResultPanelContainer = new JFXPanel();
-        Scene scene = new Scene(myResultPanel, 500, 800);
+        Scene scene = new Scene(myResultPanel, 600, 800);
         myResultPanelContainer.setScene(FXUtilities.addDesktopStyle(scene));
         setDefaultCloseOperation(HIDE_ON_CLOSE);
 
@@ -70,7 +70,8 @@ public class SearchResultHudDialog extends AbstractInternalFrame
             @Override
             public void internalFrameActivated(InternalFrameEvent e)
             {
-                // VORTEX-5538 Temporarily disable search notification dialog until recommended layers is added back
+                // VORTEX-5538 Temporarily disable search notification dialog
+                // until recommended layers is added back
 //                myResultPanel.setDialogVisible(true);
             }
 

--- a/open-sphere-plugins/search/src/main/java/io/opensphere/search/view/MetadataPane.java
+++ b/open-sphere-plugins/search/src/main/java/io/opensphere/search/view/MetadataPane.java
@@ -1,12 +1,12 @@
 package io.opensphere.search.view;
 
+import io.opensphere.search.model.SearchModel;
+import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
-
-import io.opensphere.search.model.SearchModel;
 
 /**
  * A pane in which the result count, search terms, and sort configuration are
@@ -19,6 +19,9 @@ public class MetadataPane extends AbstractSearchPane
 
     /** The combo-box in which the sort operation is configured. */
     private final ComboBox<String> mySortDropdown;
+
+    /** The button to clear search results without affecting the search box. */
+    private final Button myClearButton;
 
     /**
      * Creates a new metadata pane bound to the supplied model.
@@ -48,6 +51,9 @@ public class MetadataPane extends AbstractSearchPane
         mySortDropdown = new ComboBox<>(getModel().getSortTypes());
         mySortDropdown.valueProperty().bindBidirectional(getModel().getSortType());
 
+        myClearButton = new Button("Clear");
+        myClearButton.setOnAction((evt) -> getModel().getKeyword().setValue(null));
+
         Label resultsFor = new Label("Showing Results for : ");
         Label sortLabel = new Label("Sort By:");
         Region spacer = new Region();
@@ -57,5 +63,6 @@ public class MetadataPane extends AbstractSearchPane
         add(spacer, 2, 0);
         add(sortLabel, 3, 0);
         add(mySortDropdown, 4, 0);
+        add(myClearButton, 5, 0);
     }
 }


### PR DESCRIPTION
## Fixes
- Various formatting updates.

## Proposed Changes
- Add a button to the search result dialog that clears the search.
  - Does not clear the search text, so retrying the search is easy.
  - Search window size expanded so that text fits without truncating.
