### PR TITLE
Fix Joins - Cache Exception

### DIFF
--- a/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/algorithm/JoinData.java
+++ b/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/algorithm/JoinData.java
@@ -2,6 +2,7 @@ package io.opensphere.merge.algorithm;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -95,7 +96,7 @@ public class JoinData extends DatasetOperation
         JoinInfo primary = src.get(0);
         for (DataElement elt : getSupp().getRecords(primary.getType()))
         {
-            Map<String, Serializable> valMap = new TreeMap<>();
+            Map<String, Serializable> valMap = new LinkedHashMap<>();
             primary.mergeRecordWithValueMap(valMap, elt);
             Object val = elt.getMetaData().getValue(primary.getJoinKey());
             if (val == null)

--- a/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/ui/JoinGui.java
+++ b/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/ui/JoinGui.java
@@ -2,7 +2,6 @@ package io.opensphere.merge.ui;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.TreeSet;
 
 import io.opensphere.core.Toolbox;
 import io.opensphere.core.util.ValidationStatus;

--- a/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/ui/JoinGui.java
+++ b/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/ui/JoinGui.java
@@ -217,7 +217,7 @@ public class JoinGui
         MetaDataInfo meta = row.layer.getMetaDataInfo();
         if (meta != null)
         {
-            row.colCombo.getItems().addAll(new TreeSet<>(meta.getKeyNames()));
+            row.colCombo.getItems().addAll(meta.getKeyNames());
         }
         selectFirst(row.colCombo);
         // set a tooltip for the ComboBox


### PR DESCRIPTION
- Do not use TreeMap and TreeSet if a specific order matters
- Related: VORTEX-5695