### PR TITLE
Feature arcgis subpaths

### DIFF
--- a/eclipse/open-sphere-dictionary.txt
+++ b/eclipse/open-sphere-dictionary.txt
@@ -65,3 +65,5 @@ datatypes
 proxy
 orchestrate
 proxies
+unmarshalled
+subpath

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/net/UrlUtilities.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/net/UrlUtilities.java
@@ -132,7 +132,7 @@ public final class UrlUtilities
             }
             catch (MalformedURLException e)
             {
-                LOGGER.error(e.toString());
+                LOGGER.error(e.toString(), e);
             }
         }
         return url;

--- a/open-sphere-plugins/arcgis/src/main/java/io/opensphere/arcgis2/envoy/ArcGISLayerListEnvoy.java
+++ b/open-sphere-plugins/arcgis/src/main/java/io/opensphere/arcgis2/envoy/ArcGISLayerListEnvoy.java
@@ -360,6 +360,7 @@ public class ArcGISLayerListEnvoy extends AbstractEnvoy implements DataRegistryD
                 {
                     builder.setPath(split.subList(servicesIndex + 1, serverIndex));
                 }
+                break;
             }
         }
         builder.setURL(url);

--- a/open-sphere-plugins/arcgis/src/main/java/io/opensphere/arcgis2/envoy/ArcGISLayerListEnvoy.java
+++ b/open-sphere-plugins/arcgis/src/main/java/io/opensphere/arcgis2/envoy/ArcGISLayerListEnvoy.java
@@ -359,8 +359,8 @@ public class ArcGISLayerListEnvoy extends AbstractEnvoy implements DataRegistryD
                 if ((serverIndex = split.indexOf(serverType)) >= 0)
                 {
                     builder.setPath(split.subList(servicesIndex + 1, serverIndex));
+                    break;
                 }
-                break;
             }
         }
         builder.setURL(url);

--- a/open-sphere-plugins/arcgis/src/main/java/io/opensphere/arcgis2/mantle/ArcGISLayerProvider.java
+++ b/open-sphere-plugins/arcgis/src/main/java/io/opensphere/arcgis2/mantle/ArcGISLayerProvider.java
@@ -121,10 +121,13 @@ public class ArcGISLayerProvider
                     .partition(layersAndParents, v -> getService(v.getFirstObject().getURL()));
             List<Pair<ArcGISLayer, DataGroupInfo>> mapLayers = serviceToLayerMap.getOrDefault("MapServer",
                     Collections.emptyList());
+            List<Pair<ArcGISLayer, DataGroupInfo>> featureLayers = serviceToLayerMap.getOrDefault("FeatureServer",
+                    Collections.emptyList());
 
             // Feature data types must be created before adding the data groups
             // to the controller.
             createFeatureTypes(mapLayers);
+            createFeatureTypes(featureLayers);
 
             mantleController.addServerGroup(serverName, sourceURL, serverGroup);
 
@@ -138,7 +141,7 @@ public class ArcGISLayerProvider
         }
         else if (tracker.getQueryStatus() == QueryTracker.QueryStatus.CANCELLED)
         {
-            LOGGER.info("The query for " + serverName +  " was canceled");
+            LOGGER.info("The query for " + serverName + " was canceled");
         }
         else
         {

--- a/open-sphere-plugins/arcgis/src/test/java/io/opensphere/arcgis2/envoy/ArcGISLayerListEnvoyTest.java
+++ b/open-sphere-plugins/arcgis/src/test/java/io/opensphere/arcgis2/envoy/ArcGISLayerListEnvoyTest.java
@@ -39,6 +39,26 @@ public class ArcGISLayerListEnvoyTest
     private static final String ourTestUrl = "http://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer";
 
     /**
+     * Tests the {@link ArcGISLayerListEnvoy#removeServerComponent(String)}
+     * method.
+     *
+     * @throws IOException Bad IO.
+     * @throws URISyntaxException bad URL.
+     */
+    @Test
+    public void removeServerComponent() throws IOException, URISyntaxException
+    {
+        EasyMockSupport support = new EasyMockSupport();
+        Toolbox toolbox = createToolbox(support, "/testLayers.json");
+        support.replayAll();
+
+        ArcGISLayerListEnvoy envoy = new ArcGISLayerListEnvoy(toolbox);
+
+        String result = envoy.removeServerComponent("foo/bar/FeatureServer");
+        assertEquals("foo/bar", result);
+    }
+
+    /**
      * Tests getting Arc layers.
      *
      * @throws URISyntaxException Bad URI.


### PR DESCRIPTION
Fixes VORTEX-5682: ArcGIS URLs that include a layer don't show up in Add Data

## Proposed Changes
  - Updated handling of ArcGIS servers to introspect the URL, and treat anything beyond "rest/services" as a subpath
  - Subpaths are used to restrict the set of recursive HTTP calls to the Arc server so that only required items are requested. 
