### PR TITLE
VORTEX-5703 / Max lob arrow size

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/AbstractLOBFeatureVisualizationStyle.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/AbstractLOBFeatureVisualizationStyle.java
@@ -610,10 +610,13 @@ public abstract class AbstractLOBFeatureVisualizationStyle extends AbstractLocat
                 builderBuilder.apply(vsp.getName()), style, ourShowArrowPropertyKey, true);
         paramList.add(showArrowPanel);
 
+        // Max size shouldn't be 500k meters, it should be the actual max size.
+        Length maxArrowLength = manualLengthPanel.getLengthBinding().get().multiplyBy(0.5);
+
         vsp = style.getStyleParameter(ourArrowLengthPropertyKey);
         arrowBuilder = arrowBuilder == null ? builderBuilder.apply(vsp.getName()) : arrowBuilder;
         LengthSliderStyleParameterEditorPanel arrowLenPanel = new LengthSliderStyleParameterEditorPanel(arrowBuilder, style,
-                ourArrowLengthPropertyKey, false, true, MIN_ARROW_LENGTH, MAX_ARROW_LENGTH, myLengthUnits, Kilometers.class);
+                ourArrowLengthPropertyKey, false, true, MIN_ARROW_LENGTH, maxArrowLength, myLengthUnits, Kilometers.class);
         AbstractStyleParameterEditorPanel filler = new BlankPanel();
         showArrowPanel.getSiblingComponents().add(arrowLenPanel);
         showArrowPanel.getSiblingComponents().add(filler);


### PR DESCRIPTION
  - Fix: max arrow size correctly initialized to half the length, as opposed to 500k meters