### PR TITLE
LOB style loading

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/LengthSliderStyleParameterEditorPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/LengthSliderStyleParameterEditorPanel.java
@@ -86,8 +86,16 @@ public class LengthSliderStyleParameterEditorPanel extends AbstractStyleParamete
         myDisplayUnits = displayUnits;
         myParamUnits = paramUnits;
 
-        int iMax = (int)Math.floor(Length.create(displayUnits, maxLength).getMagnitude());
-        int iMin = (int)Math.ceil(Length.create(displayUnits, minLength).getMagnitude());
+        int iMax = Math.abs((int)Math.floor(Length.create(displayUnits, maxLength).getMagnitude()));
+        int iMin = Math.abs((int)Math.ceil(Length.create(displayUnits, minLength).getMagnitude()));
+
+        // Getting some cool exceptions here but not being told what they are
+        int realMax = Math.max(iMax, iMin);
+        int realMin = Math.min(iMax, iMin);
+
+        iMax = realMax;
+        iMin = realMin;
+
         int initialVal = MathUtil.clamp((int)Math.round(getParameterValue().getMagnitude()), iMin, iMax);
 
         myLengthSlider = new JSlider(iMin, iMax, initialVal);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/LengthSliderStyleParameterEditorPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/LengthSliderStyleParameterEditorPanel.java
@@ -89,7 +89,7 @@ public class LengthSliderStyleParameterEditorPanel extends AbstractStyleParamete
         int iMax = Math.abs((int)Math.floor(Length.create(displayUnits, maxLength).getMagnitude()));
         int iMin = Math.abs((int)Math.ceil(Length.create(displayUnits, minLength).getMagnitude()));
 
-        // Getting some cool exceptions here but not being told what they are
+        // Slider range exception means that these might be backwards.
         int realMax = Math.max(iMax, iMin);
         int realMin = Math.min(iMax, iMin);
 


### PR DESCRIPTION
- Fix: It's possible for the line length slider range to be backwards, which throws an exception and requires deleting the feature layer and pulling it back in.