### PR TITLE
VORTEX-5719 : Streaming & Additional Functions for Custom Column

### DIFF
--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Average.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Average.java
@@ -1,0 +1,24 @@
+package io.opensphere.analysis.table.functions;
+
+/** Average of values. */
+public class Average extends ColumnFunction
+{
+    /** Constructs a Average function. */
+    public Average()
+    {
+        super("Average", 0, Average::performAverage);
+    }
+
+    /**
+     * Maps all objects to Double, then returns their average.
+     * <p>
+     * Non-parseable objects are mapped to the (additive) identity value
+     *
+     * @param objects the objects to operate on
+     * @return the average
+     */
+    static Double performAverage(Object... objects)
+    {
+        return Double.valueOf(Sum.performSum(objects).doubleValue() / objects.length);
+    }
+}

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/ColumnFunction.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/ColumnFunction.java
@@ -18,6 +18,7 @@ public class ColumnFunction
     /** The function to apply. */
     private final Function<Object[], Object> myFunction;
 
+    /** String representation of {@link #getValue(Object...)}. */
     private String myValueAsString;
 
     /**

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/ColumnFunction.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/ColumnFunction.java
@@ -18,6 +18,8 @@ public class ColumnFunction
     /** The function to apply. */
     private final Function<Object[], Object> myFunction;
 
+    private String myValueAsString;
+
     /**
      * Constructs a ColumnFunction against any number of columns
      *
@@ -61,13 +63,20 @@ public class ColumnFunction
      */
     public String getValue(Object... values)
     {
-        return Objects.toString(myFunction.apply(values));
+        myValueAsString = Objects.toString(myFunction.apply(values));
+        return myValueAsString;
     }
 
     @Override
     public String toString()
     {
-        return myName;
+        String returnVal = myName;
+        if (myValueAsString != null)
+        {
+            returnVal = myValueAsString;
+        }
+
+        return returnVal;
     }
 
     /**

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/ColumnFunction.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/ColumnFunction.java
@@ -1,55 +1,67 @@
 package io.opensphere.analysis.table.functions;
 
-import java.util.function.BiFunction;
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
- * Representation of a multi-column function.
+ * Representation of a multi-column function. Constructors are used to generate
+ * templates, which are then instantiated for use via {@link #build(int...)}.
  */
 public class ColumnFunction
 {
-    /** Array of column values. */
-    private final Object[] myValues = new Object[2];
+    /** Array of column indices. Operations are executed in order. */
+    private final int[] myColumns;
 
     /** The function name. */
     private final String myName;
 
     /** The function to apply. */
-    private final BiFunction<Object, Object, Object> myFunction;
+    private final Function<Object[], Object> myFunction;
 
     /**
-     * Constructs a ColumnFunction.
+     * Constructs a ColumnFunction against any number of columns
      *
      * @param name the name of the function
-     * @param function the function to apply each value to
+     * @param columnCount the number of columns
+     * @param function the function to use
      */
-    public ColumnFunction(String name, BiFunction<Object, Object, Object> function)
+    protected ColumnFunction(String name, int columnCount, Function<Object[], Object> function)
     {
         myName = name;
+        myColumns = new int[columnCount];
         myFunction = function;
     }
 
     /**
      * Sets the values that the function will utilize.
      *
-     * @param value the value to set
-     * @param index the index to set
+     * @param index the index of the array
+     * @param column the index of the column
      */
-    public void setValue(Object value, int index)
+    public void setColumn(int index, int column)
     {
-        if (index >= 0 && index < myValues.length)
-        {
-            myValues[index] = value;
-        }
+        myColumns[index] = column;
+    }
+
+    /**
+     * Retrieves the value of {@link #myColumns}.
+     *
+     * @return the array of column indices
+     */
+    public int[] getColumns()
+    {
+        return myColumns;
     }
 
     /**
      * Returns the result of the function.
      *
+     * @param values the values to calculate against
      * @return the function result after applying to each value
      */
-    public Object getValue()
+    public String getValue(Object... values)
     {
-        return myFunction.apply(myValues[0], myValues[1]);
+        return Objects.toString(myFunction.apply(values));
     }
 
     @Override
@@ -61,15 +73,16 @@ public class ColumnFunction
     /**
      * Builds and applies the function with whatever values it requires.
      *
-     * @param left the left (initial) value
-     * @param right the right (applied) value
+     * @param columns the columns this function applies to
      * @return a readable ColumnFunction
      */
-    public ColumnFunction build(Object left, Object right)
+    public ColumnFunction build(int... columns)
     {
-        ColumnFunction result = new ColumnFunction(myName, myFunction);
-        result.setValue(left, 0);
-        result.setValue(right, 1);
+        ColumnFunction result = new ColumnFunction(myName, columns.length, myFunction);
+        for (int i = 0; i < columns.length; i++)
+        {
+            result.setColumn(i, columns[i]);
+        }
 
         return result;
     }

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/ColumnFunctionRegistry.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/ColumnFunctionRegistry.java
@@ -21,6 +21,10 @@ public class ColumnFunctionRegistry
     public ColumnFunctionRegistry(Toolbox toolbox)
     {
         myFunctionValues = New.list();
+
+        myFunctionValues.add(new StringJoin());
+        myFunctionValues.add(new Sum());
+        myFunctionValues.add(new Difference());
     }
 
     /**

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/ColumnFunctionRegistry.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/ColumnFunctionRegistry.java
@@ -25,6 +25,9 @@ public class ColumnFunctionRegistry
         myFunctionValues.add(new StringJoin());
         myFunctionValues.add(new Sum());
         myFunctionValues.add(new Difference());
+        myFunctionValues.add(new Product());
+        myFunctionValues.add(new Quotient());
+        myFunctionValues.add(new Average());
     }
 
     /**

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Difference.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Difference.java
@@ -1,0 +1,36 @@
+package io.opensphere.analysis.table.functions;
+
+import io.opensphere.core.util.lang.NumberUtilities;
+
+/** Difference between values in order of appearance. */
+public class Difference extends ColumnFunction
+{
+    /** Constructs a Difference function. */
+    public Difference()
+    {
+        super("Difference", 0, Difference::performDiff);
+    }
+
+    /**
+     * Maps all objects to Double, then returns their difference.
+     *
+     * @param objects the objects to operate on
+     * @return the sum
+     */
+    static Object performDiff(Object... objects)
+    {
+        double[] diffArr = new double[objects.length];
+        for (int i = 0; i < objects.length; i++)
+        {
+            diffArr[i] = NumberUtilities.parseDouble(objects[i], 0.);
+        }
+
+        double diff = diffArr[0];
+        for (int i = 1; i < diffArr.length; i++)
+        {
+            diff -= diffArr[i];
+        }
+
+        return Double.valueOf(diff);
+    }
+}

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Difference.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Difference.java
@@ -13,11 +13,13 @@ public class Difference extends ColumnFunction
 
     /**
      * Maps all objects to Double, then returns their difference.
+     * <p>
+     * Non-parseable objects are mapped to the (additive) identity value
      *
      * @param objects the objects to operate on
-     * @return the sum
+     * @return the difference
      */
-    static Object performDiff(Object... objects)
+    static Double performDiff(Object... objects)
     {
         double[] diffArr = new double[objects.length];
         for (int i = 0; i < objects.length; i++)
@@ -25,6 +27,7 @@ public class Difference extends ColumnFunction
             diffArr[i] = NumberUtilities.parseDouble(objects[i], 0.);
         }
 
+        // this is gonna throw if we don't have any objects but whatever
         double diff = diffArr[0];
         for (int i = 1; i < diffArr.length; i++)
         {

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Product.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Product.java
@@ -1,0 +1,32 @@
+package io.opensphere.analysis.table.functions;
+
+import io.opensphere.core.util.lang.NumberUtilities;
+
+/** Product of values. */
+public class Product extends ColumnFunction
+{
+    /** Constructs a Product function. */
+    public Product()
+    {
+        super("Product", 0, Product::performProd);
+    }
+
+    /**
+     * Maps all objects to Double, then returns their product.
+     * <p>
+     * Non-parseable objects are mapped to the (multiplicative) identity value.
+     *
+     * @param objects the objects to operate on
+     * @return the product
+     */
+    static Double performProd(Object... objects)
+    {
+        double product = 1.;
+        for (Object o : objects)
+        {
+            product *= NumberUtilities.parseDouble(o, 1.);
+        }
+
+        return Double.valueOf(product);
+    }
+}

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Quotient.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Quotient.java
@@ -1,0 +1,39 @@
+package io.opensphere.analysis.table.functions;
+
+import io.opensphere.core.util.lang.NumberUtilities;
+
+/** Quotient of values in order of appearance. */
+public class Quotient extends ColumnFunction
+{
+    /** Constructs a Difference function. */
+    public Quotient()
+    {
+        super("Quotient", 0, Quotient::performDiv);
+    }
+
+    /**
+     * Maps all objects to Double, then returns their quotient.
+     * <p>
+     * Non-parseable objects are mapped to the (multiplicative) identity value
+     *
+     * @param objects the objects to operate on
+     * @return the quotient
+     */
+    static Double performDiv(Object... objects)
+    {
+        double[] divArr = new double[objects.length];
+        for (int i = 0; i < objects.length; i++)
+        {
+            divArr[i] = NumberUtilities.parseDouble(objects[i], 1.);
+        }
+
+        // this is gonna throw if we don't have any objects but whatever
+        double div = divArr[0];
+        for (int i = 1; i < divArr.length; i++)
+        {
+            div /= divArr[i];
+        }
+
+        return Double.valueOf(div);
+    }
+}

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/StringJoin.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/StringJoin.java
@@ -1,6 +1,7 @@
 package io.opensphere.analysis.table.functions;
 
-import org.apache.commons.lang.StringUtils;
+import java.util.Objects;
+import java.util.StringJoiner;
 
 /** Joins all values in an array as a single String. */
 public class StringJoin extends ColumnFunction
@@ -8,7 +9,25 @@ public class StringJoin extends ColumnFunction
     /** Constructs a StringJoin function. */
     protected StringJoin()
     {
-        super("String Join", 0, StringUtils::join);
+        super("String Join", 0, StringJoin::performJoin);
     }
 
+    /**
+     * Joins array of Objects to a single String, utilizing
+     * {@link Objects#toString(Object)} as the String parser.
+     * <p>
+     * Resulting Strings will be in the format "0,1,...".
+     *
+     * @param objects the objects to operate on
+     * @return the string
+     */
+    static String performJoin(Object... objects)
+    {
+        StringJoiner sj = new StringJoiner(",", "", "");
+        for (Object o : objects)
+        {
+            sj.add(Objects.toString(o));
+        }
+        return sj.toString();
+    }
 }

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/StringJoin.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/StringJoin.java
@@ -1,0 +1,14 @@
+package io.opensphere.analysis.table.functions;
+
+import org.apache.commons.lang.StringUtils;
+
+/** Joins all values in an array as a single String. */
+public class StringJoin extends ColumnFunction
+{
+    /** Constructs a StringJoin function. */
+    protected StringJoin()
+    {
+        super("String Join", 0, StringUtils::join);
+    }
+
+}

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Sum.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Sum.java
@@ -1,0 +1,30 @@
+package io.opensphere.analysis.table.functions;
+
+import io.opensphere.core.util.lang.NumberUtilities;
+
+/** Sum of values. */
+public class Sum extends ColumnFunction
+{
+    /** Constructs a Sum function. */
+    public Sum()
+    {
+        super("Sum", 0, Sum::performSum);
+    }
+
+    /**
+     * Maps all objects to Double, then returns their sum.
+     *
+     * @param objects the objects to operate on
+     * @return the sum
+     */
+    static Object performSum(Object... objects)
+    {
+        double sum = 0.;
+        for (Object o : objects)
+        {
+            sum += NumberUtilities.parseDouble(o, 0.);
+        }
+
+        return Double.valueOf(sum);
+    }
+}

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Sum.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/functions/Sum.java
@@ -13,11 +13,13 @@ public class Sum extends ColumnFunction
 
     /**
      * Maps all objects to Double, then returns their sum.
+     * <p>
+     * Non-parseable objects are mapped to the (additive) identity value
      *
      * @param objects the objects to operate on
      * @return the sum
      */
-    static Object performSum(Object... objects)
+    static Double performSum(Object... objects)
     {
         double sum = 0.;
         for (Object o : objects)

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/renderers/ColumnFunctionTableCellRenderer.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/table/renderers/ColumnFunctionTableCellRenderer.java
@@ -46,7 +46,17 @@ public class ColumnFunctionTableCellRenderer extends NumberTableCellRenderer
     {
         if (value instanceof ColumnFunction)
         {
-            value = ((ColumnFunction)value).getValue();
+            ColumnFunction colFunc = (ColumnFunction)value;
+            int[] cols = colFunc.getColumns();
+            Object[] vals = new Object[cols.length];
+
+            for (int i = 0; i < cols.length; i++)
+            {
+                vals[i] = table.getModel().getValueAt(row, cols[i]);
+            }
+
+            // Format as Label
+            value = colFunc.getValue(vals);
         }
 
         return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/dynmeta/impl/DynamicMetadataDataTypeControllerImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/dynmeta/impl/DynamicMetadataDataTypeControllerImpl.java
@@ -138,15 +138,17 @@ public class DynamicMetadataDataTypeControllerImpl implements DynamicMetadataDat
     @Override
     public boolean addDynamicColumn(String columnName, Class<?> columnClass, Object source)
     {
+        boolean added = false;
+
         if (!myDTI.getMetaDataInfo().hasKey(columnName))
         {
-            boolean added = myDTI.getMetaDataInfo().addKey(columnName, columnClass, source);
+            added = myDTI.getMetaDataInfo().addKey(columnName, columnClass, source);
             int columnIndex = myDTI.getMetaDataInfo().getKeyNames().indexOf(columnName);
             DynamicMetadataController<?> controller = createController(myToolbox, columnIndex, myDTI);
             myDynColumnNameToValueMap.put(columnIndex, controller);
-            return added;
         }
-        return false;
+
+        return added;
     }
 
     @Override


### PR DESCRIPTION
- **Fix**: Inability to modify custom columns via double-click (or single-click checkbox, if boolean)
  - API update caused wrong MetadataDataTypeController access
- **Fix**: Calculated columns do not allow dynamic updates as data changes
  - Now a function of column indices rather than values
- **Add**: The following column functions have been added
  - _Sum_ - Computes the sum of two columns, using non-numeric columns as 0.0
  - _Difference_ - Computes the difference between two columns, using the first column selected as the initial value and non-numeric columns as 0.0
  - _Product_ - Computes the product of two columns, using non-numeric columns as 1.0
  - _Quotient_ - Computes the quotient of two columns, using the first column selected as the dividend and non-numeric columns as 1.0
  - _Average_ - Computes the average of two columns, using non-numeric columns as 0.0
  - _String Join_ - Joins two columns as a String
- **Add**: Column functions can support more than two columns in a table