### PR TITLE
VORTEX-5612 : Adding custom columns to Merge feature layers kills the metadata

### DIFF
--- a/open-sphere-plugins/merge/.classpath
+++ b/open-sphere-plugins/merge/.classpath
@@ -25,12 +25,8 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-9">
 		<attributes>
-			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
-		<accessrules>
-			<accessrule kind="accessible" pattern="javafx/**"/>
-		</accessrules>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>

--- a/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/MergePlugin.java
+++ b/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/MergePlugin.java
@@ -49,7 +49,6 @@ public class MergePlugin extends PluginAdapter
         if (mySystemPreferences != null)
         {
             myMergePreferences = mySystemPreferences.getJAXBObject(MergePrefs.class, PREFS_KEY, null);
-            myMergePreferences.prepareForRead();
         }
 
         // Jam in an empty MergePrefs in case a real one was not found
@@ -57,6 +56,7 @@ public class MergePlugin extends PluginAdapter
         {
             myMergePreferences = new MergePrefs();
         }
+        myMergePreferences.prepareForRead();
 
         Runnable saveCallback = this::writePrefs;
 
@@ -80,7 +80,7 @@ public class MergePlugin extends PluginAdapter
         EventQueue.invokeLater(() ->
         {
             GuiUtil.addMenuItem(GuiUtil.getMainMenu(toolbox, MenuBarRegistry.EDIT_MENU), "Joins/Merges",
-                () -> myConfigGui.show());
+                    () -> myConfigGui.show());
 
             myConfigGui = new ConfigGui(toolbox, joinManager, mergeController, saveCallback);
             myConfigGui.setData(myMergePreferences);

--- a/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/controller/MetaDataInfoProvider.java
+++ b/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/controller/MetaDataInfoProvider.java
@@ -73,6 +73,7 @@ public class MetaDataInfoProvider
         }
 
         addSpecialKeys(metadataInfo, mergedLayers);
+        metadataInfo.copyKeysToOriginalKeys();
 
         return metadataInfo;
     }


### PR DESCRIPTION
Fixes that by making sure the constructed MetaDataInfo actually has "original keys".