### PR TITLE
Group By Z-Order My-Places Flattend Tree

### DIFF
--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesDataGroupController.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesDataGroupController.java
@@ -121,7 +121,7 @@ public class MyPlacesDataGroupController implements EventListener<DataTypeVisibi
                 folder.setVisibility(Boolean.TRUE);
 
                 dataGroup = new MyPlacesDataGroupInfo(true, myToolbox, folder);
-                dataGroup.setIsFlattenable(false);
+                dataGroup.setIsFlattenable(true);
             }
 
             DataGroupController controller = MantleToolboxUtils.getMantleToolbox(myToolbox).getDataGroupController();

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/models/MyPlacesDataGroupInfo.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/models/MyPlacesDataGroupInfo.java
@@ -25,7 +25,7 @@ public class MyPlacesDataGroupInfo extends DefaultDataGroupInfo
     public MyPlacesDataGroupInfo(boolean rootNode, Toolbox aToolbox, Folder kmlFolder)
     {
         super(rootNode, aToolbox, "My Places", kmlFolder.getId(), kmlFolder.getName());
-        setIsFlattenable(false);
+        setIsFlattenable(true);
 
         myKmlFolder = kmlFolder;
     }


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - My-Places Tree is flattened when Group-By Z-Order. This retains the elements in the folder, but removes the sub folders when grouped this way. 
  -
  -
