### PR TITLE
Fix SSL context load.

### DIFF
--- a/open-sphere-base/core/src/main/resources/system.properties
+++ b/open-sphere-base/core/src/main/resources/system.properties
@@ -4,8 +4,8 @@ sun.awt.noerasebackground=true
 sun.net.http.allowRestrictedHeaders=true
 jogl.glu.nojava
 #jogamp.gluegen.UseTempJarCache=false
-javax.net.ssl.trustStore=truststore.jks
-javax.net.ssl.trustStorePassword=password
+#javax.net.ssl.trustStore=truststore.jks
+#javax.net.ssl.trustStorePassword=password
 user.timezone=GMT
 java.util.logging.config.class=io.opensphere.core.appl.JavaLoggingInit
 java.net.useSystemProxies=true


### PR DESCRIPTION
After failing to load a default SSL context due to (x) issue, attempt to correct the resource load. Otherwise, fail instead of generating a context without a trust store.