### PR TITLE
VORTEX-5442 : Prevent network drive Windows install

### DIFF
--- a/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
+++ b/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
@@ -101,6 +101,7 @@ public class OpenSphereTargetPanel extends TargetPanel
         layout.setConstraints(myPathPreview, c);
         myBottomInfoArea.add(myPathPreview);
 
+        // Path Preview listener
         pathSelectionPanel.getPathInputField().getDocument().addDocumentListener(new DocumentListener()
         {
             @Override
@@ -113,7 +114,6 @@ public class OpenSphereTargetPanel extends TargetPanel
             public void insertUpdate(DocumentEvent e)
             {
                 updatePreview();
-                warnDirectory();
             }
 
             @Override
@@ -134,19 +134,37 @@ public class OpenSphereTargetPanel extends TargetPanel
                 path += installData.getVariable("InstallVersion");
                 myPathPreview.setText(path);
             }
-
-            private void warnDirectory()
-            {
-                String path = pathSelectionPanel.getPathInputField().getText();
-                if (StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE"))
-                        && installData.getPlatform().getName() == Name.WINDOWS && path.length() > 2)
-                {
-                    OpenSphereTargetPanel.this.emitWarning("Directory Warning", "The selected install directory may be invalid."
-                            + "Attempting to install to a non-letter drive (such as OneDrive or another network folder) may"
-                            + "cause the install to fail.");
-                }
-            }
         });
+
+        // Directory Warning listener
+        if (installData.getPlatform().getName() == Name.WINDOWS)
+        {
+            pathSelectionPanel.getPathInputField().getDocument().addDocumentListener(new DocumentListener()
+            {
+                @Override
+                public void removeUpdate(DocumentEvent e)
+                {
+                }
+
+                @Override
+                public void insertUpdate(DocumentEvent e)
+                {
+                    String path = pathSelectionPanel.getPathInputField().getText();
+                    if (StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE"))
+                            && installData.getPlatform().getName() == Name.WINDOWS && path.length() > 2)
+                    {
+                        OpenSphereTargetPanel.this.emitWarning("Directory Warning",
+                                "The selected install directory may be invalid. Attempting to install to a non-letter drive"
+                                        + "(such as OneDrive or another network folder) may cause the install to fail.");
+                    }
+                }
+
+                @Override
+                public void changedUpdate(DocumentEvent e)
+                {
+                }
+            });
+        }
 
         add(new JScrollPane(myBottomInfoArea), NEXT_LINE);
     }

--- a/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
+++ b/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
@@ -113,25 +113,19 @@ public class OpenSphereTargetPanel extends TargetPanel
             public void insertUpdate(DocumentEvent e)
             {
                 updatePreview();
+                warnDirectory();
             }
 
             @Override
             public void changedUpdate(DocumentEvent e)
             {
+                // this probably won't be fired according to documentation
                 updatePreview();
             }
 
             private void updatePreview()
             {
                 String path = pathSelectionPanel.getPathInputField().getText();
-                if (StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE"))
-                        && installData.getPlatform().getName() == Name.WINDOWS)
-                {
-                    OpenSphereTargetPanel.this.emitWarning("Directory Warning", "The selected install directory may be invalid."
-                            + "Attempting to install to a non-letter drive (such as OneDrive or another network folder) may"
-                            + "cause the install to fail.");
-                }
-
                 if (!path.endsWith(File.separator))
                 {
                     path += File.separator;
@@ -141,6 +135,17 @@ public class OpenSphereTargetPanel extends TargetPanel
                 myPathPreview.setText(path);
             }
 
+            private void warnDirectory()
+            {
+                String path = pathSelectionPanel.getPathInputField().getText();
+                if (StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE"))
+                        && installData.getPlatform().getName() == Name.WINDOWS && path.length() > 2)
+                {
+                    OpenSphereTargetPanel.this.emitWarning("Directory Warning", "The selected install directory may be invalid."
+                            + "Attempting to install to a non-letter drive (such as OneDrive or another network folder) may"
+                            + "cause the install to fail.");
+                }
+            }
         });
 
         add(new JScrollPane(myBottomInfoArea), NEXT_LINE);

--- a/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
+++ b/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
@@ -150,8 +150,7 @@ public class OpenSphereTargetPanel extends TargetPanel
                 public void insertUpdate(DocumentEvent e)
                 {
                     String path = pathSelectionPanel.getPathInputField().getText();
-                    if (StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE"))
-                            && installData.getPlatform().getName() == Name.WINDOWS && path.length() > 2)
+                    if (path.length() > 2 && StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE")))
                     {
                         OpenSphereTargetPanel.this.emitWarning("Directory Warning",
                                 "The selected install directory may be invalid. Attempting to install to a non-letter drive"

--- a/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
+++ b/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
@@ -132,15 +132,16 @@ public class OpenSphereTargetPanel extends TargetPanel
                 }
                 preview += installData.getVariable("InstallVersion");
 
-                if (installData.getPlatform().getName() == Name.WINDOWS && preview.length() > 2)
+                if (installData.getPlatform().getName() == Name.WINDOWS
+                        && StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE")))
+                {
+                    parent.getNavigator().setNextEnabled(false);
+                    preview = "Warning: The application may only be installed to a letter drive. Installing to a network or "
+                            + "OneDrive location is not possible.";
+                }
+                else
                 {
                     parent.getNavigator().setNextEnabled(true);
-                    if (StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE")))
-                    {
-                        parent.getNavigator().setNextEnabled(false);
-                        preview = "Warning: The application may only be installed to a letter drive. Installing to a network or "
-                                + "OneDrive location is not possible.";
-                    }
                 }
 
                 myPathPreview.setText(preview);

--- a/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
+++ b/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
@@ -13,12 +13,15 @@ import javax.swing.UIManager;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.izforge.izpack.api.data.Panel;
 import com.izforge.izpack.api.resource.Resources;
 import com.izforge.izpack.gui.log.Log;
 import com.izforge.izpack.installer.data.GUIInstallData;
 import com.izforge.izpack.installer.gui.InstallerFrame;
 import com.izforge.izpack.panels.target.TargetPanel;
+import com.izforge.izpack.util.Platform.Name;
 
 /**
  * An extension to the target panel on which additional information is
@@ -121,10 +124,19 @@ public class OpenSphereTargetPanel extends TargetPanel
             private void updatePreview()
             {
                 String path = pathSelectionPanel.getPathInputField().getText();
+                if (StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE"))
+                        && installData.getPlatform().getName() == Name.WINDOWS)
+                {
+                    OpenSphereTargetPanel.this.emitWarning("Directory Warning", "The selected install directory may be invalid."
+                            + "Attempting to install to a non-letter drive (such as OneDrive or another network folder) may"
+                            + "cause the install to fail.");
+                }
+
                 if (!path.endsWith(File.separator))
                 {
                     path += File.separator;
                 }
+
                 path += installData.getVariable("InstallVersion");
                 myPathPreview.setText(path);
             }

--- a/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
+++ b/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/OpenSphereTargetPanel.java
@@ -125,45 +125,27 @@ public class OpenSphereTargetPanel extends TargetPanel
 
             private void updatePreview()
             {
-                String path = pathSelectionPanel.getPathInputField().getText();
-                if (!path.endsWith(File.separator))
+                String preview = pathSelectionPanel.getPathInputField().getText();
+                if (!preview.endsWith(File.separator))
                 {
-                    path += File.separator;
+                    preview += File.separator;
                 }
+                preview += installData.getVariable("InstallVersion");
 
-                path += installData.getVariable("InstallVersion");
-                myPathPreview.setText(path);
-            }
-        });
-
-        // Directory Warning listener
-        if (installData.getPlatform().getName() == Name.WINDOWS)
-        {
-            pathSelectionPanel.getPathInputField().getDocument().addDocumentListener(new DocumentListener()
-            {
-                @Override
-                public void removeUpdate(DocumentEvent e)
+                if (installData.getPlatform().getName() == Name.WINDOWS && preview.length() > 2)
                 {
-                }
-
-                @Override
-                public void insertUpdate(DocumentEvent e)
-                {
-                    String path = pathSelectionPanel.getPathInputField().getText();
-                    if (path.length() > 2 && StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE")))
+                    parent.getNavigator().setNextEnabled(true);
+                    if (StringUtils.isBlank(installData.getVariable("INSTALL_DRIVE")))
                     {
-                        OpenSphereTargetPanel.this.emitWarning("Directory Warning",
-                                "The selected install directory may be invalid. Attempting to install to a non-letter drive"
-                                        + "(such as OneDrive or another network folder) may cause the install to fail.");
+                        parent.getNavigator().setNextEnabled(false);
+                        preview = "Warning: The application may only be installed to a letter drive. Installing to a network or "
+                                + "OneDrive location is not possible.";
                     }
                 }
 
-                @Override
-                public void changedUpdate(DocumentEvent e)
-                {
-                }
-            });
-        }
+                myPathPreview.setText(preview);
+            }
+        });
 
         add(new JScrollPane(myBottomInfoArea), NEXT_LINE);
     }


### PR DESCRIPTION
## Proposed Changes
If a user selects a non-letter drive, disable the Next button and display a warning.