### PR TITLE
VORTEX-5756 Fix labels not showing on hover

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
@@ -18,7 +18,6 @@ import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.time.TimeSpan;
 import io.opensphere.mantle.MantleToolbox;
 import io.opensphere.mantle.data.DataGroupInfo;
-import io.opensphere.mantle.data.DataTypeInfo;
 import io.opensphere.mantle.data.VisualizationSupport;
 import io.opensphere.mantle.data.element.DataElement;
 import io.opensphere.mantle.data.element.MapDataElement;
@@ -118,8 +117,8 @@ public class LabelHoverController implements EventListener<DataElementHighlightC
         {
             // We're dealing with server data which won't have a single group
             // and will be harder to check
-            DataTypeInfo dataInfo = toolbox.getDataTypeInfoFromKey(dtiKey);
-            List<? extends DataGroupInfo> dataGroupList = toolbox.getDataGroupController().getDataGroupInfosWithDti(dataInfo);
+            List<? extends DataGroupInfo> dataGroupList = toolbox.getDataGroupController()
+                    .getDataGroupInfosWithDti(toolbox.getDataTypeInfoFromKey(dtiKey));
 
             return dataGroupList.stream().anyMatch(dg -> dg.activationProperty().isActive());
         }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
@@ -18,6 +18,7 @@ import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.time.TimeSpan;
 import io.opensphere.mantle.MantleToolbox;
 import io.opensphere.mantle.data.DataGroupInfo;
+import io.opensphere.mantle.data.DataTypeInfo;
 import io.opensphere.mantle.data.VisualizationSupport;
 import io.opensphere.mantle.data.element.DataElement;
 import io.opensphere.mantle.data.element.MapDataElement;
@@ -115,12 +116,8 @@ public class LabelHoverController implements EventListener<DataElementHighlightC
 
         if (dataGroup == null)
         {
-            // We're dealing with server data which won't have a single group
-            // and will be harder to check
-            List<? extends DataGroupInfo> dataGroupList = toolbox.getDataGroupController()
-                    .getDataGroupInfosWithDti(toolbox.getDataTypeInfoFromKey(dtiKey));
-
-            return dataGroupList.stream().anyMatch(dg -> dg.activationProperty().isActive());
+            DataTypeInfo dataInfo = toolbox.getDataTypeInfoFromKey(dtiKey);
+            return dataInfo != null && dataInfo.isVisible();
         }
 
         return dataGroup.activationProperty().isActive();

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
@@ -94,7 +94,6 @@ public class LabelHoverController implements EventListener<DataElementHighlightC
     {
         if (isEventElementActive(event.getDataTypeKey()) && event.isHighlighted())
         {
-            System.out.println("drawLabel");
             drawLabel(event);
         }
         else

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/labelcontroller/LabelHoverController.java
@@ -18,6 +18,7 @@ import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.time.TimeSpan;
 import io.opensphere.mantle.MantleToolbox;
 import io.opensphere.mantle.data.DataGroupInfo;
+import io.opensphere.mantle.data.DataTypeInfo;
 import io.opensphere.mantle.data.VisualizationSupport;
 import io.opensphere.mantle.data.element.DataElement;
 import io.opensphere.mantle.data.element.MapDataElement;
@@ -93,6 +94,7 @@ public class LabelHoverController implements EventListener<DataElementHighlightC
     {
         if (isEventElementActive(event.getDataTypeKey()) && event.isHighlighted())
         {
+            System.out.println("drawLabel");
             drawLabel(event);
         }
         else
@@ -113,7 +115,17 @@ public class LabelHoverController implements EventListener<DataElementHighlightC
         MantleToolbox toolbox = MantleToolboxUtils.getMantleToolbox(getToolbox());
         DataGroupInfo dataGroup = toolbox.getDataGroupController().getDataGroupInfo(dtiKey);
 
-        return dataGroup != null && dataGroup.activationProperty().isActive();
+        if (dataGroup == null)
+        {
+            // We're dealing with server data which won't have a single group
+            // and will be harder to check
+            DataTypeInfo dataInfo = toolbox.getDataTypeInfoFromKey(dtiKey);
+            List<? extends DataGroupInfo> dataGroupList = toolbox.getDataGroupController().getDataGroupInfosWithDti(dataInfo);
+
+            return dataGroupList.stream().anyMatch(dg -> dg.activationProperty().isActive());
+        }
+
+        return dataGroup.activationProperty().isActive();
     }
 
     /**


### PR DESCRIPTION
- **Fix**: Labels would not show on hover for certain feature sets.
  - Server features, where the server had multiple data groups, would return null for `getDataGroupInfo`
  - Adds a check to see if a DataTypeInfo exists & is visible to the user