### PR TITLE
Warning / Error Cleanup

### DIFF
--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/binning/editor/view/CriterionCell.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/binning/editor/view/CriterionCell.java
@@ -78,7 +78,7 @@ public class CriterionCell extends ListCell<BinCriteriaElement> implements Crite
 
         myBox.setAlignment(Pos.CENTER_LEFT);
         myBox.getChildren().addAll(myField, myBinType, myPlusMinus, myTolerance, FXUtilities.newHSpacer(), myRemoveButton);
-//        myAutoComplete = new AutoCompleteComboBoxListener<>(myField);
+
         NewAutoCompleteComboBoxListener listener = new NewAutoCompleteComboBoxListener();
         listener.setupComboBox(myField);
     }

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/binning/editor/view/CriterionCell.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/binning/editor/view/CriterionCell.java
@@ -3,6 +3,13 @@ package io.opensphere.analysis.binning.editor.view;
 import java.text.DecimalFormat;
 import java.text.ParsePosition;
 
+import io.opensphere.analysis.binning.criteria.BinCriteriaElement;
+import io.opensphere.analysis.binning.editor.controller.CriterionController;
+import io.opensphere.analysis.binning.editor.model.BinCriteriaModel;
+import io.opensphere.analysis.binning.editor.model.CriterionModel;
+import io.opensphere.core.util.fx.FXUtilities;
+import io.opensphere.core.util.fx.NewAutoCompleteComboBoxListener;
+import io.opensphere.core.util.image.IconUtil.IconType;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
@@ -13,14 +20,6 @@ import javafx.scene.control.TextFormatter;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
-
-import io.opensphere.analysis.binning.criteria.BinCriteriaElement;
-import io.opensphere.analysis.binning.editor.controller.CriterionController;
-import io.opensphere.analysis.binning.editor.model.BinCriteriaModel;
-import io.opensphere.analysis.binning.editor.model.CriterionModel;
-import io.opensphere.core.util.fx.AutoCompleteComboBoxListener;
-import io.opensphere.core.util.fx.FXUtilities;
-import io.opensphere.core.util.image.IconUtil.IconType;
 
 /**
  * Represents one row in the criteria editor panel, showing the values for a
@@ -64,12 +63,6 @@ public class CriterionCell extends ListCell<BinCriteriaElement> implements Crite
     private final TextField myTolerance = new TextField();
 
     /**
-     * Enables the combo box to be auto completed.
-     */
-    @SuppressWarnings("unused")
-    private final AutoCompleteComboBoxListener<String> myAutoComplete;
-
-    /**
      * Constructs a new criterion cell UI.
      *
      * @param model The overall criteria model.
@@ -85,7 +78,9 @@ public class CriterionCell extends ListCell<BinCriteriaElement> implements Crite
 
         myBox.setAlignment(Pos.CENTER_LEFT);
         myBox.getChildren().addAll(myField, myBinType, myPlusMinus, myTolerance, FXUtilities.newHSpacer(), myRemoveButton);
-        myAutoComplete = new AutoCompleteComboBoxListener<>(myField);
+//        myAutoComplete = new AutoCompleteComboBoxListener<>(myField);
+        NewAutoCompleteComboBoxListener listener = new NewAutoCompleteComboBoxListener();
+        listener.setupComboBox(myField);
     }
 
     @Override

--- a/open-sphere-base/analysis/src/test/java/io/opensphere/analysis/export/controller/ExportExecutorTest.java
+++ b/open-sphere-base/analysis/src/test/java/io/opensphere/analysis/export/controller/ExportExecutorTest.java
@@ -80,7 +80,7 @@ public class ExportExecutorTest
 
         CountDownLatch latch = new CountDownLatch(1);
         Exporter exporter = createExporter(support, dataElements, testFile, latch, null);
-        EasyMock.expect(exporter.preExport()).andReturn(Boolean.TRUE);
+        EasyMock.expect(Boolean.valueOf(exporter.preExport())).andReturn(Boolean.TRUE);
         MetaColumnsTableModel elements = createTableModel(support, dataElements);
 
         ExportOptionsModel optionsModel = new ExportOptionsModel();
@@ -132,12 +132,13 @@ public class ExportExecutorTest
 
         Exporter exporter = support.createMock(Exporter.class);
         EasyMock.expect(exporter.setObjects(EasyMock.anyObject())).andReturn(null);
-        EasyMock.expect(exporter.preExport()).andReturn(Boolean.TRUE);
+        EasyMock.expect(Boolean.valueOf(exporter.preExport())).andReturn(Boolean.TRUE);
         MetaColumnsTableModel elements = createTableModel(support, dataElements);
 
         PreferencesRegistry prefsRegistry = support.createMock(PreferencesRegistry.class);
         Preferences prefs = support.createMock(Preferences.class);
-        EasyMock.expect(prefs.getInt(ListToolPreferences.LIST_TOOL_TIME_PRECISION_DIGITS, 0)).andReturn(0);
+        EasyMock.expect(Integer.valueOf(prefs.getInt(ListToolPreferences.LIST_TOOL_TIME_PRECISION_DIGITS, 0)))
+                .andReturn(Integer.valueOf(0));
         EasyMock.expect(prefsRegistry.getPreferences(ListToolPreferences.class)).andReturn(prefs);
 
         ExportOptionsModel optionsModel = new ExportOptionsModel();
@@ -181,7 +182,7 @@ public class ExportExecutorTest
         CountDownLatch latch = new CountDownLatch(1);
         ExportException testException = new ExportException("Test exception");
         Exporter exporter = createExporter(support, dataElements, testFile, latch, testException);
-        EasyMock.expect(exporter.preExport()).andReturn(Boolean.TRUE);
+        EasyMock.expect(Boolean.valueOf(exporter.preExport())).andReturn(Boolean.TRUE);
 
         EventManager eventManager = createEventManager(support, testException, testFile, latch);
         MetaColumnsTableModel elements = createTableModel(support, dataElements);
@@ -235,7 +236,7 @@ public class ExportExecutorTest
 
         CountDownLatch latch = new CountDownLatch(1);
         Exporter exporter = createExporter(support, dataElements, testFile, latch, null);
-        EasyMock.expect(exporter.preExport()).andReturn(Boolean.TRUE);
+        EasyMock.expect(Boolean.valueOf(exporter.preExport())).andReturn(Boolean.TRUE);
 
         MetaColumnsTableModel elements = createTableModel(support, dataElements);
 
@@ -244,7 +245,7 @@ public class ExportExecutorTest
         PreferencesRegistry prefsRegistry = createPrefsRegistry(support);
 
         ExportCompleteListener listener = createListener(support, parent, testFile, dataElements.size());
-        listener = createUserAskListener(listener, parent, testFile, true);
+        listener = createUserAskListener(listener, parent, testFile, Boolean.TRUE);
 
         support.replayAll();
 
@@ -290,19 +291,20 @@ public class ExportExecutorTest
         Exporter exporter = support.createMock(Exporter.class);
         EasyMock.expect(exporter.getMimeType()).andReturn(MimeType.KML).atLeastOnce();
         EasyMock.expect(exporter.setObjects(EasyMock.anyObject())).andReturn(null).times(2);
-        EasyMock.expect(exporter.preExport()).andReturn(Boolean.TRUE);
+        EasyMock.expect(Boolean.valueOf(exporter.preExport())).andReturn(Boolean.TRUE);
 
         MetaColumnsTableModel elements = createTableModel(support, dataElements);
 
         PreferencesRegistry prefsRegistry = support.createMock(PreferencesRegistry.class);
         Preferences prefs = support.createMock(Preferences.class);
-        EasyMock.expect(prefs.getInt(ListToolPreferences.LIST_TOOL_TIME_PRECISION_DIGITS, 0)).andReturn(0);
+        EasyMock.expect(Integer.valueOf(prefs.getInt(ListToolPreferences.LIST_TOOL_TIME_PRECISION_DIGITS, 0)))
+                .andReturn(Integer.valueOf(0));
         EasyMock.expect(prefsRegistry.getPreferences(ListToolPreferences.class)).andReturn(prefs);
 
         ExportOptionsModel optionsModel = new ExportOptionsModel();
 
         ExportCompleteListener listener = support.createMock(ExportCompleteListener.class);
-        listener = createUserAskListener(listener, parent, testFile, false);
+        listener = createUserAskListener(listener, parent, testFile, Boolean.FALSE);
 
         support.replayAll();
 
@@ -381,7 +383,8 @@ public class ExportExecutorTest
      * @throws ExportException Bad export.
      */
     private Exporter createExporter(EasyMockSupport support, List<DataElement> elements, File expectedFile, CountDownLatch latch,
-            ExportException expectedException) throws IOException, ExportException
+            ExportException expectedException)
+        throws IOException, ExportException
     {
         Exporter exporter = support.createMock(Exporter.class);
         EasyMock.expect(exporter.getMimeType()).andReturn(MimeType.KML).atLeastOnce();
@@ -432,8 +435,9 @@ public class ExportExecutorTest
     private PreferencesRegistry createPrefsRegistry(EasyMockSupport support)
     {
         Preferences prefs = support.createMock(Preferences.class);
-        EasyMock.expect(prefs.getInt(EasyMock.cmpEq(ListToolPreferences.LIST_TOOL_TIME_PRECISION_DIGITS), EasyMock.eq(0)))
-                .andReturn(2);
+        EasyMock.expect(Integer
+                .valueOf(prefs.getInt(EasyMock.cmpEq(ListToolPreferences.LIST_TOOL_TIME_PRECISION_DIGITS), EasyMock.eq(0))))
+                .andReturn(Integer.valueOf(2));
 
         PreferencesRegistry registry = support.createMock(PreferencesRegistry.class);
         EasyMock.expect(registry.getPreferences(EasyMock.eq(ListToolPreferences.class))).andReturn(prefs);
@@ -452,7 +456,7 @@ public class ExportExecutorTest
     {
         MetaColumnsTableModel model = support.createMock(MetaColumnsTableModel.class);
 
-        EasyMock.expect(model.getRowCount()).andReturn(data.size()).anyTimes();
+        EasyMock.expect(Integer.valueOf(model.getRowCount())).andReturn(Integer.valueOf(data.size())).anyTimes();
         EasyMock.expect(model.getDataAt(EasyMock.anyInt())).andAnswer(() -> getDataAtAnswer(data)).anyTimes();
 
         return model;
@@ -484,8 +488,8 @@ public class ExportExecutorTest
             row.put("DATE_TIME", timeSpan);
             row.put("ROOM", "room" + i);
             row.put("MESSAGE", "message" + i);
-            row.put("LAT", 10.1 * i);
-            row.put("LON", 11.1 * i);
+            row.put("LAT", Double.valueOf(10.1 * i));
+            row.put("LON", Double.valueOf(11.1 * i));
 
             SimpleMetaDataProvider provider = new SimpleMetaDataProvider(row);
             DataElement element = new DefaultDataElement(i, timeSpan, dataType, provider);
@@ -528,9 +532,9 @@ public class ExportExecutorTest
      * @return The mocked {@link ExportCompleteListener}.
      */
     private ExportCompleteListener createUserAskListener(ExportCompleteListener listener, Component expectedParent,
-            File expectedFile, boolean canOverwrite)
+            File expectedFile, Boolean canOverwrite)
     {
-        EasyMock.expect(listener.askUserForOverwrite(EasyMock.eq(expectedParent), EasyMock.eq(expectedFile)))
+        EasyMock.expect(Boolean.valueOf(listener.askUserForOverwrite(EasyMock.eq(expectedParent), EasyMock.eq(expectedFile))))
                 .andReturn(canOverwrite);
 
         return listener;

--- a/open-sphere-base/core/.classpath
+++ b/open-sphere-base/core/.classpath
@@ -24,9 +24,8 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-9">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-9">
 		<attributes>
-			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/open-sphere-base/core/.classpath
+++ b/open-sphere-base/core/.classpath
@@ -24,8 +24,9 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-9">
+	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-9">
 		<attributes>
+			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/open-sphere-base/core/src/main/java/com/bitsys/common/http/auth/AuthenticationScope.java
+++ b/open-sphere-base/core/src/main/java/com/bitsys/common/http/auth/AuthenticationScope.java
@@ -9,224 +9,213 @@ import org.apache.http.auth.AuthScope;
  */
 public class AuthenticationScope
 {
-   /** The host pattern that matches any host. */
-   public static final String ANY_HOST = AuthScope.ANY_HOST;
+    /** The host pattern that matches any host. */
+    public static final String ANY_HOST = AuthScope.ANY_HOST;
 
-   /** The port pattern that matches any port. */
-   public static final int ANY_PORT = AuthScope.ANY_PORT;
+    /** The port pattern that matches any port. */
+    public static final int ANY_PORT = AuthScope.ANY_PORT;
 
-   /** The realm pattern that matches any realm. */
-   public static final String ANY_REALM = AuthScope.ANY_REALM;
+    /** The realm pattern that matches any realm. */
+    public static final String ANY_REALM = AuthScope.ANY_REALM;
 
-   /** The scheme pattern that matches any scheme. */
-   public static final String ANY_SCHEME = AuthScope.ANY_SCHEME;
+    /** The scheme pattern that matches any scheme. */
+    public static final String ANY_SCHEME = AuthScope.ANY_SCHEME;
 
-   /** The delegated instance. */
-   private final AuthScope authScope;
+    /** The delegated instance. */
+    private final AuthScope authScope;
 
-   /**
-    * Constructs a {@linkplain AuthenticationScope} from the given host name and
-    * port. The scope will apply to any realm and scheme.
-    *
-    * @param host
-    *           the host name or {@link #ANY_HOST}.
-    * @param port
-    *           the port or {@link #ANY_PORT}.
-    */
-   public AuthenticationScope(final String host, final int port)
-   {
-      this(host, port, ANY_REALM);
-   }
+    /**
+     * Constructs a {@linkplain AuthenticationScope} from the given host name
+     * and port. The scope will apply to any realm and scheme.
+     *
+     * @param host the host name or {@link #ANY_HOST}.
+     * @param port the port or {@link #ANY_PORT}.
+     */
+    public AuthenticationScope(final String host, final int port)
+    {
+        this(host, port, ANY_REALM);
+    }
 
-   /**
-    * Constructs a {@linkplain AuthenticationScope} from the given host name,
-    * port and realm. The scope will apply to any scheme.
-    *
-    * @param host
-    *           the host name or {@link #ANY_HOST}.
-    * @param port
-    *           the port or {@link #ANY_PORT}.
-    * @param realm
-    *           the realm or {@link #ANY_REALM}.
-    */
-   public AuthenticationScope(final String host, final int port, final String realm)
-   {
-      this(host, port, realm, ANY_SCHEME);
-   }
+    /**
+     * Constructs a {@linkplain AuthenticationScope} from the given host name,
+     * port and realm. The scope will apply to any scheme.
+     *
+     * @param host the host name or {@link #ANY_HOST}.
+     * @param port the port or {@link #ANY_PORT}.
+     * @param realm the realm or {@link #ANY_REALM}.
+     */
+    public AuthenticationScope(final String host, final int port, final String realm)
+    {
+        this(host, port, realm, ANY_SCHEME);
+    }
 
-   /**
-    * Constructs a {@linkplain AuthenticationScope} from the given host name,
-    * port, realm and scheme.
-    *
-    * @param host
-    *           the host name or {@link #ANY_HOST}.
-    * @param port
-    *           the port or {@link #ANY_PORT}.
-    * @param realm
-    *           the realm or {@link #ANY_REALM}.
-    * @param scheme
-    *           the scheme (e.g. http) or {@link #ANY_SCHEME}.
-    */
-   public AuthenticationScope(final String host, final int port, final String realm, final String scheme)
-   {
-      this(new AuthScope(host, port, realm, scheme));
-   }
+    /**
+     * Constructs a {@linkplain AuthenticationScope} from the given host name,
+     * port, realm and scheme.
+     *
+     * @param host the host name or {@link #ANY_HOST}.
+     * @param port the port or {@link #ANY_PORT}.
+     * @param realm the realm or {@link #ANY_REALM}.
+     * @param scheme the scheme (e.g. http) or {@link #ANY_SCHEME}.
+     */
+    public AuthenticationScope(final String host, final int port, final String realm, final String scheme)
+    {
+        this(new AuthScope(host, port, realm, scheme));
+    }
 
-   /**
-    * Constructs a {@linkplain AuthenticationScope} from an Apache
-    * {@link AuthScope}.
-    *
-    * @param authScope
-    *           the delegated instance.
-    */
-   AuthenticationScope(final AuthScope authScope)
-   {
-      if (authScope == null)
-      {
-         throw new IllegalArgumentException("The delegated instance cannot be null");
-      }
-      this.authScope = authScope;
-   }
+    /**
+     * Constructs a {@linkplain AuthenticationScope} from an Apache
+     * {@link AuthScope}.
+     *
+     * @param authScope the delegated instance.
+     */
+    AuthenticationScope(final AuthScope authScope)
+    {
+        if (authScope == null)
+        {
+            throw new IllegalArgumentException("The delegated instance cannot be null");
+        }
+        this.authScope = authScope;
+    }
 
-   /**
-    * Returns the delegated Apache {@link AuthScope}.
-    *
-    * @return the Apache authentication scope.
-    */
-   AuthScope getAuthScope()
-   {
-      return authScope;
-   }
+    /**
+     * Returns the delegated Apache {@link AuthScope}.
+     *
+     * @return the Apache authentication scope.
+     */
+    AuthScope getAuthScope()
+    {
+        return authScope;
+    }
 
-   /**
-    * Returns the host name.
-    *
-    * @return the host name.
-    */
-   public String getHost()
-   {
-      return authScope.getHost();
-   }
+    /**
+     * Returns the host name.
+     *
+     * @return the host name.
+     */
+    public String getHost()
+    {
+        return authScope.getHost();
+    }
 
-   /**
-    * Returns the port.
-    *
-    * @return the port.
-    */
-   public int getPort()
-   {
-      return authScope.getPort();
-   }
+    /**
+     * Returns the port.
+     *
+     * @return the port.
+     */
+    public int getPort()
+    {
+        return authScope.getPort();
+    }
 
-   /**
-    * Returns the realm.
-    *
-    * @return the realm.
-    */
-   public String getRealm()
-   {
-      return authScope.getRealm();
-   }
+    /**
+     * Returns the realm.
+     *
+     * @return the realm.
+     */
+    public String getRealm()
+    {
+        return authScope.getRealm();
+    }
 
-   /**
-    * Returns the scheme.
-    *
-    * @return the scheme.
-    */
-   public String getScheme()
-   {
-      return authScope.getScheme();
-   }
+    /**
+     * Returns the scheme.
+     *
+     * @return the scheme.
+     */
+    public String getScheme()
+    {
+        return authScope.getScheme();
+    }
 
-   /**
-    * Tests the other scope with the current one and determines how closely the
-    * two match. A negative return value indicates that the two do not match at
-    * all. The higher the number, the closer the match.
-    *
-    * @param other
-    *           the other scope with which to test.
-    * @return the degree of match. A negative number indicates no match. Higher
-    *         numbers indicate a closer match.
-    */
-   public int match(final AuthenticationScope other)
-   {
-      return authScope.match(other.getAuthScope());
-   }
+    /**
+     * Tests the other scope with the current one and determines how closely the
+     * two match. A negative return value indicates that the two do not match at
+     * all. The higher the number, the closer the match.
+     *
+     * @param other the other scope with which to test.
+     * @return the degree of match. A negative number indicates no match. Higher
+     *         numbers indicate a closer match.
+     */
+    public int match(final AuthenticationScope other)
+    {
+        return authScope.match(other.getAuthScope());
+    }
 
-   /**
-    * @see java.lang.Object#hashCode()
-    */
-   @Override
-   public int hashCode()
-   {
-      return Objects.hash(getHost(), getPort(), getRealm(), getScheme());
-   }
+    /**
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getHost(), Integer.valueOf(getPort()), getRealm(), getScheme());
+    }
 
-   /**
-    * @see java.lang.Object#equals(java.lang.Object)
-    */
-   @Override
-   public boolean equals(final Object obj)
-   {
-      if (this == obj)
-      {
-         return true;
-      }
-      if (obj == null)
-      {
-         return false;
-      }
-      if (getClass() != obj.getClass())
-      {
-         return false;
-      }
-      final AuthenticationScope other = (AuthenticationScope)obj;
-      if (getHost() == null)
-      {
-         if (other.getHost() != null)
-         {
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(final Object obj)
+    {
+        if (this == obj)
+        {
+            return true;
+        }
+        if (obj == null)
+        {
             return false;
-         }
-      }
-      else if (!getHost().equals(other.getHost()))
-      {
-         return false;
-      }
-      if (getPort() != other.getPort())
-      {
-         return false;
-      }
-      if (getRealm() == null)
-      {
-         if (other.getRealm() != null)
-         {
+        }
+        if (getClass() != obj.getClass())
+        {
             return false;
-         }
-      }
-      else if (!getRealm().equals(other.getRealm()))
-      {
-         return false;
-      }
-      if (getScheme() == null)
-      {
-         if (other.getScheme() != null)
-         {
+        }
+        final AuthenticationScope other = (AuthenticationScope)obj;
+        if (getHost() == null)
+        {
+            if (other.getHost() != null)
+            {
+                return false;
+            }
+        }
+        else if (!getHost().equals(other.getHost()))
+        {
             return false;
-         }
-      }
-      else if (!getScheme().equals(other.getScheme()))
-      {
-         return false;
-      }
-      return true;
-   }
+        }
+        if (getPort() != other.getPort())
+        {
+            return false;
+        }
+        if (getRealm() == null)
+        {
+            if (other.getRealm() != null)
+            {
+                return false;
+            }
+        }
+        else if (!getRealm().equals(other.getRealm()))
+        {
+            return false;
+        }
+        if (getScheme() == null)
+        {
+            if (other.getScheme() != null)
+            {
+                return false;
+            }
+        }
+        else if (!getScheme().equals(other.getScheme()))
+        {
+            return false;
+        }
+        return true;
+    }
 
-   /**
-    * @see java.lang.Object#toString()
-    */
-   @Override
-   public String toString()
-   {
-      return authScope.toString();
-   }
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        return authScope.toString();
+    }
 }

--- a/open-sphere-base/core/src/main/java/com/bitsys/common/http/auth/CachingCredentialsProvider.java
+++ b/open-sphere-base/core/src/main/java/com/bitsys/common/http/auth/CachingCredentialsProvider.java
@@ -13,95 +13,91 @@ import org.apache.http.client.CredentialsProvider;
  * provider. This class also provides more fine-grained control of cache
  * clearing.
  */
-public class CachingCredentialsProvider extends ChainedCredentialsProvider implements
-   ClearableCredentialsProvider
+public class CachingCredentialsProvider extends ChainedCredentialsProvider implements ClearableCredentialsProvider
 {
-   /** The mapping of cached time to authentication scope. */
-   private final Map<AuthScope, Long> cachedTimeMap;
+    /** The mapping of cached time to authentication scope. */
+    private final Map<AuthScope, Long> cachedTimeMap;
 
-   /**
-    * Constructs a new {@linkplain CachingCredentialsProvider} the uses the
-    * given provider to provide credentials not already in the cache.
-    *
-    * @param provider
-    *           the other credentials provider.
-    */
-   public CachingCredentialsProvider(final CredentialsProvider provider)
-   {
-      super(new BasicClearableCredentialsProvider(), provider);
-      cachedTimeMap =
-         Collections.synchronizedMap(new HashMap<AuthScope, Long>());
-   }
+    /**
+     * Constructs a new {@linkplain CachingCredentialsProvider} the uses the
+     * given provider to provide credentials not already in the cache.
+     *
+     * @param provider the other credentials provider.
+     */
+    public CachingCredentialsProvider(final CredentialsProvider provider)
+    {
+        super(new BasicClearableCredentialsProvider(), provider);
+        cachedTimeMap = Collections.synchronizedMap(new HashMap<AuthScope, Long>());
+    }
 
-   @Override
-   public void clear()
-   {
-      synchronized (cachedTimeMap)
-      {
-         cachedTimeMap.clear();
-         super.clear();
-      }
-   }
+    @Override
+    public void clear()
+    {
+        synchronized (cachedTimeMap)
+        {
+            cachedTimeMap.clear();
+            super.clear();
+        }
+    }
 
-   @Override
-   public void clearCredentials(final AuthScope authScope)
-   {
-      if (authScope == null)
-      {
-         throw new IllegalArgumentException("The authentication scope is null");
-      }
-      if (cachedTimeMap.containsKey(authScope))
-      {
-         final ClearableCredentialsProvider provider =
-            (ClearableCredentialsProvider)getProvider();
-         synchronized (cachedTimeMap)
-         {
-            provider.clearCredentials(authScope);
-            cachedTimeMap.remove(authScope);
-         }
-      }
-   }
+    @Override
+    public void clearCredentials(final AuthScope authScope)
+    {
+        if (authScope == null)
+        {
+            throw new IllegalArgumentException("The authentication scope is null");
+        }
+        if (cachedTimeMap.containsKey(authScope))
+        {
+            final ClearableCredentialsProvider provider = (ClearableCredentialsProvider)getProvider();
+            synchronized (cachedTimeMap)
+            {
+                provider.clearCredentials(authScope);
+                cachedTimeMap.remove(authScope);
+            }
+        }
+    }
 
-   // TODO: Add more clear methods for clearing based on time and authentication
-   // scope.
+    // TODO: Add more clear methods for clearing based on time and
+    // authentication
+    // scope.
 
-   @Override
-   public void setCredentials(final AuthScope authScope,
-                              final Credentials credentials)
-   {
-      if (authScope == null)
-      {
-         throw new IllegalArgumentException("The authentication scope is null");
-      }
-      if (credentials == null)
-      {
-         clearCredentials(authScope);
-      }
-      else
-      {
-         synchronized (cachedTimeMap)
-         {
-            super.setCredentials(authScope, credentials);
-            cachedTimeMap.put(authScope, System.currentTimeMillis());
-         }
-      }
-   }
+    @Override
+    public void setCredentials(final AuthScope authScope, final Credentials credentials)
+    {
+        if (authScope == null)
+        {
+            throw new IllegalArgumentException("The authentication scope is null");
+        }
+        if (credentials == null)
+        {
+            clearCredentials(authScope);
+        }
+        else
+        {
+            synchronized (cachedTimeMap)
+            {
+                super.setCredentials(authScope, credentials);
+                cachedTimeMap.put(authScope, Long.valueOf(System.currentTimeMillis()));
+            }
+        }
+    }
 
-   /**
-    * Returns the credentials for the given authentication scope. This method
-    * will first look internally to satisfy the request. If no credentials are
-    * found, it asks the provider given in the constructor for credentials. If
-    * it returns credentials, they are stored within this provider.
-    */
-   @Override
-   public Credentials getCredentials(final AuthScope authScope)
-   {
-      final Credentials credentials = super.getCredentials(authScope);
+    /**
+     * Returns the credentials for the given authentication scope. This method
+     * will first look internally to satisfy the request. If no credentials are
+     * found, it asks the provider given in the constructor for credentials. If
+     * it returns credentials, they are stored within this provider.
+     */
+    @Override
+    public Credentials getCredentials(final AuthScope authScope)
+    {
+        final Credentials credentials = super.getCredentials(authScope);
 
-      if (credentials != null && !cachedTimeMap.containsKey(authScope))
-      {
-         setCredentials(authScope, credentials);
-      }
-      return credentials;
-   }
+        if (credentials != null && !cachedTimeMap.containsKey(authScope))
+        {
+            setCredentials(authScope, credentials);
+        }
+        return credentials;
+    }
 }

--- a/open-sphere-base/core/src/main/java/com/bitsys/common/http/client/ProxyingHttpClient.java
+++ b/open-sphere-base/core/src/main/java/com/bitsys/common/http/client/ProxyingHttpClient.java
@@ -29,258 +29,233 @@ import org.slf4j.LoggerFactory;
 import com.bitsys.common.http.auth.ClearableCredentialsProvider;
 import com.bitsys.common.http.auth.CredentialsProviderUtils;
 import com.bitsys.common.http.proxy.ProxyHostConfig;
-import com.bitsys.common.http.proxy.ProxyResolver;
 import com.bitsys.common.http.proxy.ProxyHostConfig.ProxyType;
+import com.bitsys.common.http.proxy.ProxyResolver;
 
 /**
  * This class enables automatic HTTP proxying for HTTP clients.
  */
+@SuppressWarnings("deprecation")
 public class ProxyingHttpClient implements HttpClient, Closeable
 {
-   /**
-    * The <code>Logger</code> instance.
-    */
-   private static final Logger LOGGER = LoggerFactory
-      .getLogger(ProxyingHttpClient.class);
+    /**
+     * The <code>Logger</code> instance.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyingHttpClient.class);
 
-   /**
-    * The back-end HTTP client.
-    */
-   private final DefaultHttpClient httpClient;
+    /**
+     * The back-end HTTP client.
+     */
+    private final DefaultHttpClient httpClient;
 
-   /**
-    * The HTTP client options that contain the proxying configuration.
-    */
-   private final HttpClientOptions options;
+    /**
+     * The HTTP client options that contain the proxying configuration.
+     */
+    private final HttpClientOptions options;
 
-   /**
-    * Constructs a <code>ProxyingHttpClient</code> that automatically handles
-    * HTTP proxying on the fly.
-    *
-    * @param httpClient
-    */
-   public ProxyingHttpClient(final DefaultHttpClient httpClient,
-                             final HttpClientOptions options)
-   {
-      this.httpClient = httpClient;
-      this.options = options;
-   }
+    /**
+     * Constructs a <code>ProxyingHttpClient</code> that automatically handles
+     * HTTP proxying on the fly.
+     *
+     * @param httpClient the base client
+     * @param options the client options
+     */
+    public ProxyingHttpClient(final DefaultHttpClient httpClient, final HttpClientOptions options)
+    {
+        this.httpClient = httpClient;
+        this.options = options;
+    }
 
-   /**
-    * Returns the options.
-    *
-    * @return the options.
-    */
-   public HttpClientOptions getOptions()
-   {
-      return options;
-   }
+    /**
+     * Returns the options.
+     *
+     * @return the options.
+     */
+    public HttpClientOptions getOptions()
+    {
+        return options;
+    }
 
-   @Override
-   public HttpParams getParams()
-   {
-      return httpClient.getParams();
-   }
+    @Override
+    public HttpParams getParams()
+    {
+        return httpClient.getParams();
+    }
 
-   @Override
-   public ClientConnectionManager getConnectionManager()
-   {
-      return httpClient.getConnectionManager();
-   }
+    @Override
+    public ClientConnectionManager getConnectionManager()
+    {
+        return httpClient.getConnectionManager();
+    }
 
-   @Override
-   public HttpResponse execute(final HttpUriRequest request) throws IOException
-   {
-      configureProxy(request.getParams(), request.getURI());
-      return httpClient.execute(request);
-   }
+    @Override
+    public HttpResponse execute(final HttpUriRequest request) throws IOException
+    {
+        configureProxy(request.getParams(), request.getURI());
+        return httpClient.execute(request);
+    }
 
-   @Override
-   public HttpResponse execute(final HttpUriRequest request,
-                               final HttpContext context) throws IOException
-   {
-      configureProxy(request.getParams(), request.getURI());
-      return httpClient.execute(request, context);
-   }
+    @Override
+    public HttpResponse execute(final HttpUriRequest request, final HttpContext context) throws IOException
+    {
+        configureProxy(request.getParams(), request.getURI());
+        return httpClient.execute(request, context);
+    }
 
-   @Override
-   public HttpResponse execute(final HttpHost target, final HttpRequest request)
-      throws IOException
-   {
-      configureProxy(request.getParams(), target.toURI());
-      return httpClient.execute(target, request);
-   }
+    @Override
+    public HttpResponse execute(final HttpHost target, final HttpRequest request) throws IOException
+    {
+        configureProxy(request.getParams(), target.toURI());
+        return httpClient.execute(target, request);
+    }
 
-   @Override
-   public HttpResponse execute(final HttpHost target, final HttpRequest request,
-                               final HttpContext context) throws IOException
-   {
-      configureProxy(request.getParams(), target.toURI());
-      return httpClient.execute(target, request, context);
-   }
+    @Override
+    public HttpResponse execute(final HttpHost target, final HttpRequest request, final HttpContext context) throws IOException
+    {
+        configureProxy(request.getParams(), target.toURI());
+        return httpClient.execute(target, request, context);
+    }
 
-   @Override
-   public <T> T execute(final HttpUriRequest request,
-                        final ResponseHandler<? extends T> responseHandler)
-      throws IOException
-   {
-      configureProxy(request.getParams(), request.getURI());
-      return httpClient.execute(request, responseHandler);
-   }
+    @Override
+    public <T> T execute(final HttpUriRequest request, final ResponseHandler<? extends T> responseHandler) throws IOException
+    {
+        configureProxy(request.getParams(), request.getURI());
+        return httpClient.execute(request, responseHandler);
+    }
 
-   @Override
-   public <T> T execute(final HttpUriRequest request,
-                        final ResponseHandler<? extends T> responseHandler,
-                        final HttpContext context) throws IOException
-   {
-      configureProxy(request.getParams(), request.getURI());
-      return httpClient.execute(request, responseHandler, context);
-   }
+    @Override
+    public <T> T execute(final HttpUriRequest request, final ResponseHandler<? extends T> responseHandler,
+            final HttpContext context)
+        throws IOException
+    {
+        configureProxy(request.getParams(), request.getURI());
+        return httpClient.execute(request, responseHandler, context);
+    }
 
-   @Override
-   public <T> T execute(final HttpHost target, final HttpRequest request,
-                        final ResponseHandler<? extends T> responseHandler)
-      throws IOException
-   {
-      configureProxy(request.getParams(), target.toURI());
-      return httpClient.execute(target, request, responseHandler);
-   }
+    @Override
+    public <T> T execute(final HttpHost target, final HttpRequest request, final ResponseHandler<? extends T> responseHandler)
+        throws IOException
+    {
+        configureProxy(request.getParams(), target.toURI());
+        return httpClient.execute(target, request, responseHandler);
+    }
 
-   @Override
-   public <T> T execute(final HttpHost target, final HttpRequest request,
-                        final ResponseHandler<? extends T> responseHandler,
-                        final HttpContext context) throws IOException
-   {
-      configureProxy(request.getParams(), target.toURI());
-      return httpClient.execute(target, request, responseHandler, context);
-   }
+    @Override
+    public <T> T execute(final HttpHost target, final HttpRequest request, final ResponseHandler<? extends T> responseHandler,
+            final HttpContext context)
+        throws IOException
+    {
+        configureProxy(request.getParams(), target.toURI());
+        return httpClient.execute(target, request, responseHandler, context);
+    }
 
-   /**
-    * Attempts to configure the proxy to the given URI in the HTTP parameters.
-    *
-    * @param params
-    *           the HTTP parameters in which the proxy configuration will be
-    *           stored.
-    * @param uriString
-    *           the requested URI string.
-    * @throws IOException
-    *            if an error occurs while determining the proxy server.
-    */
-   protected void configureProxy(final HttpParams params, final String uriString)
-      throws IOException
-   {
-      try
-      {
-         configureProxy(params, new URI(uriString));
-      }
-      catch (final URISyntaxException e)
-      {
-         LOGGER.warn("Failed to convert '" + uriString
-            + "' to a URI. The proxy will not be configured.", e);
-      }
-   }
+    /**
+     * Attempts to configure the proxy to the given URI in the HTTP parameters.
+     *
+     * @param params the HTTP parameters in which the proxy configuration will
+     *            be stored.
+     * @param uriString the requested URI string.
+     * @throws IOException if an error occurs while determining the proxy
+     *             server.
+     */
+    protected void configureProxy(final HttpParams params, final String uriString) throws IOException
+    {
+        try
+        {
+            configureProxy(params, new URI(uriString));
+        }
+        catch (final URISyntaxException e)
+        {
+            LOGGER.warn("Failed to convert '" + uriString + "' to a URI. The proxy will not be configured.", e);
+        }
+    }
 
-   /**
-    * Attempts to configure the proxy to the given URI in the HTTP parameters.
-    *
-    * @param params
-    *           the HTTP parameters in which the proxy configuration will be
-    *           stored.
-    * @param uri
-    *           the requested URI.
-    * @throws IOException
-    *            if an error occurs while determining the proxy server.
-    */
-   protected void configureProxy(final HttpParams params, final URI uri)
-      throws IOException
-   {
-      try
-      {
-         configureProxy(params, uri.toURL());
-      }
-      catch (final MalformedURLException e)
-      {
-         LOGGER
-            .warn("The URI '"
-                     + uri
-                     + "' could not be converted to a URL. The proxy will not be configured.",
-                  e);
-      }
-   }
+    /**
+     * Attempts to configure the proxy to the given URI in the HTTP parameters.
+     *
+     * @param params the HTTP parameters in which the proxy configuration will
+     *            be stored.
+     * @param uri the requested URI.
+     * @throws IOException if an error occurs while determining the proxy
+     *             server.
+     */
+    protected void configureProxy(final HttpParams params, final URI uri) throws IOException
+    {
+        try
+        {
+            configureProxy(params, uri.toURL());
+        }
+        catch (final MalformedURLException e)
+        {
+            LOGGER.warn("The URI '" + uri + "' could not be converted to a URL. The proxy will not be configured.", e);
+        }
+    }
 
-   /**
-    * Attempts to configure the proxy to the given scheme, host name and port in
-    * the HTTP parameters.
-    *
-    * @param params
-    *           the HTTP parameters in which the proxy configuration will be
-    *           stored.
-    * @param url
-    *           the destination URL.
-    * @throws IOException
-    *            if an error occurs while determining the proxy server.
-    */
-   protected void configureProxy(final HttpParams params, final URL url)
-      throws IOException
-   {
-      final ProxyConfig proxyConfig = options.getProxyConfig();
-      HttpRoutePlanner routePlanner = null;
+    /**
+     * Attempts to configure the proxy to the given scheme, host name and port
+     * in the HTTP parameters.
+     *
+     * @param params the HTTP parameters in which the proxy configuration will
+     *            be stored.
+     * @param url the destination URL.
+     * @throws IOException if an error occurs while determining the proxy
+     *             server.
+     */
+    protected void configureProxy(final HttpParams params, final URL url) throws IOException
+    {
+        final ProxyConfig proxyConfig = options.getProxyConfig();
+        HttpRoutePlanner routePlanner = null;
 
-      // If the options contain a proxy configuration and the parameters do
-      // not, attempt to configure the proxy.
-      if (proxyConfig != null && proxyConfig.getProxyResolver() != null
-         && params.getParameter(ConnRoutePNames.DEFAULT_PROXY) == null)
-      {
-         final ProxyResolver resolver = proxyConfig.getProxyResolver();
-         final List<ProxyHostConfig> configs = resolver.getProxyServer(url);
-         if (!configs.isEmpty())
-         {
-            // TODO: Add support for multiple proxy configurations.
-            final ProxyHostConfig config = configs.get(0);
-
-            // If the proxy type is "PROXY", configure the proxy server.
-            if (config.getProxyType() == ProxyType.PROXY)
+        // If the options contain a proxy configuration and the parameters do
+        // not, attempt to configure the proxy.
+        if (proxyConfig != null && proxyConfig.getProxyResolver() != null
+                && params.getParameter(ConnRoutePNames.DEFAULT_PROXY) == null)
+        {
+            final ProxyResolver resolver = proxyConfig.getProxyResolver();
+            final List<ProxyHostConfig> configs = resolver.getProxyServer(url);
+            if (!configs.isEmpty())
             {
-               final HttpHost proxy =
-                  new HttpHost(config.getHost(), config.getPort());
-               routePlanner = new ProxyRoutePlanner(proxy);
-               params.setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
-               LOGGER.debug("Configuring the default proxy: " + proxy);
+                // TODO: Add support for multiple proxy configurations.
+                final ProxyHostConfig config = configs.get(0);
 
-               final AuthScope authScope = new AuthScope(proxy);
-               final CredentialsProvider credentialsProvider =
-                  httpClient.getCredentialsProvider();
+                // If the proxy type is "PROXY", configure the proxy server.
+                if (config.getProxyType() == ProxyType.PROXY)
+                {
+                    final HttpHost proxy = new HttpHost(config.getHost(), config.getPort());
+                    routePlanner = new ProxyRoutePlanner(proxy);
+                    params.setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+                    LOGGER.debug("Configuring the default proxy: " + proxy);
 
-               // If proxy credentials are set, set the credentials.
-               if (proxyConfig.getCredentials() != null)
-               {
-                  final Credentials credentials =
-                     CredentialsProviderUtils.toCredentials(proxyConfig
-                        .getCredentials());
-                  credentialsProvider.setCredentials(authScope, credentials);
-               }
+                    final AuthScope authScope = new AuthScope(proxy);
+                    final CredentialsProvider credentialsProvider = httpClient.getCredentialsProvider();
 
-               // Otherwise, clear the credentials.
-               else if (credentialsProvider instanceof ClearableCredentialsProvider)
-               {
-                  final ClearableCredentialsProvider provider =
-                     (ClearableCredentialsProvider)credentialsProvider;
-                  provider.clearCredentials(authScope);
-               }
+                    // If proxy credentials are set, set the credentials.
+                    if (proxyConfig.getCredentials() != null)
+                    {
+                        final Credentials credentials = CredentialsProviderUtils.toCredentials(proxyConfig.getCredentials());
+                        credentialsProvider.setCredentials(authScope, credentials);
+                    }
+
+                    // Otherwise, clear the credentials.
+                    else if (credentialsProvider instanceof ClearableCredentialsProvider)
+                    {
+                        final ClearableCredentialsProvider provider = (ClearableCredentialsProvider)credentialsProvider;
+                        provider.clearCredentials(authScope);
+                    }
+                }
+                else if (config.getProxyType() != ProxyType.DIRECT)
+                {
+                    throw new UnsupportedOperationException("'" + config.getProxyType() + "' proxying is not supported!");
+                }
             }
-            else if (config.getProxyType() != ProxyType.DIRECT)
-            {
-               throw new UnsupportedOperationException("'" + config.getProxyType()
-                  + "' proxying is not supported!");
-            }
-         }
-      }
+        }
 
-      httpClient.setRoutePlanner(routePlanner);
-   }
+        httpClient.setRoutePlanner(routePlanner);
+    }
 
-   @Override
-   public void close() throws IOException {
-      httpClient.close();
-   }
+    @Override
+    public void close() throws IOException
+    {
+        httpClient.close();
+    }
 }

--- a/open-sphere-base/core/src/main/java/com/bitsys/common/http/entity/MultipartEntity.java
+++ b/open-sphere-base/core/src/main/java/com/bitsys/common/http/entity/MultipartEntity.java
@@ -16,114 +16,107 @@ import com.bitsys.common.http.header.ContentType;
  * parts. It is a this wrapper around Apache's
  * {@link org.apache.http.entity.mime.MultipartEntity}.
  */
+@SuppressWarnings("deprecation")
 public class MultipartEntity implements HttpEntity
 {
-   /** Apache's MultipartEntity instance. */
-   private final org.apache.http.entity.mime.MultipartEntity entity;
+    /** Apache's MultipartEntity instance. */
+    private final org.apache.http.entity.mime.MultipartEntity entity;
 
-   /** The content type */
-   private final ContentType contentType;
+    /** The content type */
+    private final ContentType contentType;
 
-   /**
-    * Constructs a new {@linkplain MultipartEntity}.
-    */
-   public MultipartEntity()
-   {
-      entity =
-         new org.apache.http.entity.mime.MultipartEntity(
-            HttpMultipartMode.BROWSER_COMPATIBLE);
-      final Header contentTypeHeader = entity.getContentType();
-      if(contentTypeHeader != null)
-      {
-         contentType = ContentType.parse(contentTypeHeader.getValue());
-      }
-      else
-      {
-         contentType = null;
-      }
-   }
+    /**
+     * Constructs a new {@linkplain MultipartEntity}.
+     */
+    public MultipartEntity()
+    {
+        entity = new org.apache.http.entity.mime.MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE);
+        final Header contentTypeHeader = entity.getContentType();
+        if (contentTypeHeader != null)
+        {
+            contentType = ContentType.parse(contentTypeHeader.getValue());
+        }
+        else
+        {
+            contentType = null;
+        }
+    }
 
-   /**
-    * Adds a file part to the entity.
-    *
-    * @param name
-    *           the name of the part.
-    * @param bodyPart
-    *           the body part to add.
-    */
-   public void addPart(final String name, final ContentBodyPart<?> bodyPart)
-   {
-      entity.addPart(name, ContentUtils.toContentBody(bodyPart));
-   }
+    /**
+     * Adds a file part to the entity.
+     *
+     * @param name the name of the part.
+     * @param bodyPart the body part to add.
+     */
+    public void addPart(final String name, final ContentBodyPart<?> bodyPart)
+    {
+        entity.addPart(name, ContentUtils.toContentBody(bodyPart));
+    }
 
-   /**
-    * This operation is not supported.
-    *
-    * @throws UnsupportedOperationException
-    *            when invoked.
-    */
-   @Override
-   public InputStream getContent()
-   {
-      throw new UnsupportedOperationException(
-         "getContent() is not supported for multi-part entities");
-   }
+    /**
+     * This operation is not supported.
+     *
+     * @throws UnsupportedOperationException when invoked.
+     */
+    @Override
+    public InputStream getContent()
+    {
+        throw new UnsupportedOperationException("getContent() is not supported for multi-part entities");
+    }
 
-   @Override
-   public long getContentLength()
-   {
-      return entity.getContentLength();
-   }
+    @Override
+    public long getContentLength()
+    {
+        return entity.getContentLength();
+    }
 
-   @Override
-   public boolean isRepeatable()
-   {
-      return entity.isRepeatable();
-   }
+    @Override
+    public boolean isRepeatable()
+    {
+        return entity.isRepeatable();
+    }
 
-   @Override
-   public void writeTo(final OutputStream outputStream) throws IOException
-   {
-      entity.writeTo(outputStream);
-   }
+    @Override
+    public void writeTo(final OutputStream outputStream) throws IOException
+    {
+        entity.writeTo(outputStream);
+    }
 
-   /**
-    * This operation is not supported.
-    *
-    * @throws UnsupportedOperationException
-    *            when invoked.
-    */
-   @Override
-   public String asString() throws IOException
-   {
-      throw new UnsupportedOperationException(
-         "asString() is not supported for multi-part entities");
-   }
+    /**
+     * This operation is not supported.
+     *
+     * @throws UnsupportedOperationException when invoked.
+     */
+    @Override
+    public String asString() throws IOException
+    {
+        throw new UnsupportedOperationException("asString() is not supported for multi-part entities");
+    }
 
-   @Override
-   public String getContentEncoding()
-   {
-      final Header contentEncoding = entity.getContentEncoding();
-      return contentEncoding == null ? null : contentEncoding.getValue();
-   }
+    @Override
+    public String getContentEncoding()
+    {
+        final Header contentEncoding = entity.getContentEncoding();
+        return contentEncoding == null ? null : contentEncoding.getValue();
+    }
 
-   @Override
-   public ContentType getContentType()
-   {
-      return contentType;
-   }
+    @Override
+    public ContentType getContentType()
+    {
+        return contentType;
+    }
 
-   /**
-    * <span style="color:red">INTERNAL API - SUBJECT TO CHANGE AT ANY TIME - USE
-    * AT YOUR OWN RISK.</span>
-    * <p>
-    * Returns Apache's {@link org.apache.http.entity.mime.MultipartEntity
-    * MultipartEntity}.
-    *
-    * @return Apache's entity.
-    */
-   org.apache.http.entity.mime.MultipartEntity getEntity()
-   {
-      return entity;
-   }
+    /**
+     * <span style="color:red">INTERNAL API - SUBJECT TO CHANGE AT ANY TIME -
+     * USE AT YOUR OWN RISK.</span>
+     * <p>
+     * Returns Apache's {@link org.apache.http.entity.mime.MultipartEntity
+     * MultipartEntity}.
+     *
+     * @return Apache's entity.
+     */
+    org.apache.http.entity.mime.MultipartEntity getEntity()
+    {
+        return entity;
+    }
 }

--- a/open-sphere-base/core/src/main/java/com/bitsys/common/http/message/HttpRequest.java
+++ b/open-sphere-base/core/src/main/java/com/bitsys/common/http/message/HttpRequest.java
@@ -7,114 +7,113 @@ import java.net.URI;
  */
 public interface HttpRequest extends HttpMessage, Abortable
 {
-   /**
-    * This enumeration defines the standard HTTP methods.
-    */
-   enum HttpMethod
-   {
-      /** The HTTP <code>DELETE</code> method. */
-      DELETE("DELETE"),
+    /**
+     * This enumeration defines the standard HTTP methods.
+     */
+    @SuppressWarnings("hiding")
+    enum HttpMethod
+    {
+        /** The HTTP <code>DELETE</code> method. */
+        DELETE("DELETE"),
 
-      /** The HTTP <code>GET</code> method. */
-      GET("GET"),
+        /** The HTTP <code>GET</code> method. */
+        GET("GET"),
 
-      /** The HTTP <code>HEAD</code> method. */
-      HEAD("HEAD"),
+        /** The HTTP <code>HEAD</code> method. */
+        HEAD("HEAD"),
 
-      /** The HTTP <code>OPTIONS</code> method. */
-      OPTIONS("OPTIONS"),
+        /** The HTTP <code>OPTIONS</code> method. */
+        OPTIONS("OPTIONS"),
 
-      /** The HTTP <code>PATCH</code> method. */
-      PATCH("PATCH"),
+        /** The HTTP <code>PATCH</code> method. */
+        PATCH("PATCH"),
 
-      /** The HTTP <code>POST</code> method. */
-      POST("POST"),
+        /** The HTTP <code>POST</code> method. */
+        POST("POST"),
 
-      /** The HTTP <code>PUT</code> method. */
-      PUT("PUT"),
+        /** The HTTP <code>PUT</code> method. */
+        PUT("PUT"),
 
-      /** The HTTP <code>TRACE</code> method. */
-      TRACE("TRACE");
+        /** The HTTP <code>TRACE</code> method. */
+        TRACE("TRACE");
 
-      /** The HTTP method. */
-      private final String method;
+        /** The HTTP method. */
+        private final String method;
 
-      /**
-       * Constructs a new {@linkplain HttpMethod} with the given HTTP method.
-       *
-       * @param method
-       *           the HTTP method.
-       */
-      HttpMethod(final String method)
-      {
-         this.method = method;
-      }
+        /**
+         * Constructs a new {@linkplain HttpMethod} with the given HTTP method.
+         *
+         * @param method the HTTP method.
+         */
+        HttpMethod(final String method)
+        {
+            this.method = method;
+        }
 
-      /**
-       * Returns the HTTP method.
-       *
-       * @return the HTTP method.
-       */
-      public String getMethod()
-      {
-         return method;
-      }
-   }
+        /**
+         * Returns the HTTP method.
+         *
+         * @return the HTTP method.
+         */
+        public String getMethod()
+        {
+            return method;
+        }
+    }
 
-   /** The HTTP <code>DELETE</code> method. */
-   String DELETE = HttpMethod.DELETE.getMethod();
+    /** The HTTP <code>DELETE</code> method. */
+    String DELETE = HttpMethod.DELETE.getMethod();
 
-   /** The HTTP <code>GET</code> method. */
-   String GET = HttpMethod.GET.getMethod();
+    /** The HTTP <code>GET</code> method. */
+    String GET = HttpMethod.GET.getMethod();
 
-   /** The HTTP <code>HEAD</code> method. */
-   String HEAD = HttpMethod.HEAD.getMethod();
+    /** The HTTP <code>HEAD</code> method. */
+    String HEAD = HttpMethod.HEAD.getMethod();
 
-   /** The HTTP <code>OPTIONS</code> method. */
-   String OPTIONS = HttpMethod.OPTIONS.getMethod();
+    /** The HTTP <code>OPTIONS</code> method. */
+    String OPTIONS = HttpMethod.OPTIONS.getMethod();
 
-   /** The HTTP <code>PATCH</code> method. */
-   String PATCH = HttpMethod.PATCH.getMethod();
+    /** The HTTP <code>PATCH</code> method. */
+    String PATCH = HttpMethod.PATCH.getMethod();
 
-   /** The HTTP <code>POST</code> method. */
-   String POST = HttpMethod.POST.getMethod();
+    /** The HTTP <code>POST</code> method. */
+    String POST = HttpMethod.POST.getMethod();
 
-   /** The HTTP <code>PUT</code> method. */
-   String PUT = HttpMethod.PUT.getMethod();
+    /** The HTTP <code>PUT</code> method. */
+    String PUT = HttpMethod.PUT.getMethod();
 
-   /** The HTTP <code>TRACE</code> method. */
-   String TRACE = HttpMethod.TRACE.getMethod();
+    /** The HTTP <code>TRACE</code> method. */
+    String TRACE = HttpMethod.TRACE.getMethod();
 
-   /**
-    * Returns the HTTP method this request uses. For example, <code>GET</code>,
-    * <code>POST</code>, <code>PUT</code>, <code>DELETE</code>, etc.
-    *
-    * @return the HTTP method of this request.
-    */
-   String getMethod();
+    /**
+     * Returns the HTTP method this request uses. For example, <code>GET</code>,
+     * <code>POST</code>, <code>PUT</code>, <code>DELETE</code>, etc.
+     *
+     * @return the HTTP method of this request.
+     */
+    String getMethod();
 
-   /**
-    * Returns the URI of this request.
-    *
-    * @return the URI of this request.
-    */
-   URI getURI();
+    /**
+     * Returns the URI of this request.
+     *
+     * @return the URI of this request.
+     */
+    URI getURI();
 
-   /**
-    * Sets the {@link Abortable} instance that will handle aborting requests.
-    *
-    * @param abortable
-    *           the abortable.
-    */
-   void setAbortable(Abortable abortable);
+    /**
+     * Sets the {@link Abortable} instance that will handle aborting requests.
+     *
+     * @param abortable the abortable.
+     */
+    void setAbortable(Abortable abortable);
 
-   /**
-    * Returns the {@link Abortable} instance.
-    *
-    * @return the abortable.
-    * @deprecated Use the {@link #abort()} and {@link #isAborted()} methods on this class as they
-    *             can be made thread-safe.
-    */
-   @Deprecated
-   Abortable getAbortable();
+    /**
+     * Returns the {@link Abortable} instance.
+     *
+     * @return the abortable.
+     * @deprecated Use the {@link #abort()} and {@link #isAborted()} methods on
+     *             this class as they can be made thread-safe.
+     */
+    @Deprecated
+    Abortable getAbortable();
 }

--- a/open-sphere-base/core/src/main/java/com/bitsys/common/http/ssl/CachingCertificateVerifier.java
+++ b/open-sphere-base/core/src/main/java/com/bitsys/common/http/ssl/CachingCertificateVerifier.java
@@ -16,192 +16,182 @@ import com.bitsys.common.http.util.cache.CacheManager;
  */
 public class CachingCertificateVerifier implements CertificateVerifier
 {
-   /**
-    * This class contains all of the parameters to the
-    * {@link CachingCertificateVerifier#allowCertificate(X509Certificate[], String, Collection, CertificateException)}
-    * method.
-    */
-   private static class CacheKey
-   {
-      /** The certificate chain. */
-      private final X509Certificate[] chain;
+    /**
+     * This class contains all of the parameters to the
+     * {@link CachingCertificateVerifier#allowCertificate(X509Certificate[], String, Collection, CertificateException)}
+     * method.
+     */
+    private static class CacheKey
+    {
+        /** The certificate chain. */
+        private final X509Certificate[] chain;
 
-      /** The key exchange algorithm used. */
-      private final String authType;
+        /** The key exchange algorithm used. */
+        private final String authType;
 
-      /** The collection of verification issues. */
-      private final Collection<CertificateVerificationIssue> issues;
+        /** The collection of verification issues. */
+        private final Collection<CertificateVerificationIssue> issues;
 
-      /**
-       * The <code>CertificateException</code> thrown by the default trust
-       * manager.
-       */
-      private final CertificateException certificateException;
+        /**
+         * The <code>CertificateException</code> thrown by the default trust
+         * manager.
+         */
+        private final CertificateException certificateException;
 
-      /**
-       * Constructs a new {@linkplain CacheKey} from the given parameters.
-       *
-       * @param chain
-       *           the certificate chain.
-       * @param authType
-       *           the key exchange algorithm used
-       * @param issues
-       *           the collection of verification issues.
-       * @param certificateException
-       *           the <code>CertificateException</code> thrown by the default
-       *           trust manager.
-       */
-      public CacheKey(final X509Certificate[] chain, final String authType,
-                      final Collection<CertificateVerificationIssue> issues,
-                      final CertificateException certificateException)
-      {
-         this.chain = chain.clone();
-         this.authType = authType;
-         this.issues = Collections.unmodifiableCollection(issues);
-         this.certificateException = certificateException;
-      }
+        /**
+         * Constructs a new {@linkplain CacheKey} from the given parameters.
+         *
+         * @param chain the certificate chain.
+         * @param authType the key exchange algorithm used
+         * @param issues the collection of verification issues.
+         * @param certificateException the <code>CertificateException</code>
+         *            thrown by the default trust manager.
+         */
+        public CacheKey(final X509Certificate[] chain, final String authType,
+                final Collection<CertificateVerificationIssue> issues, final CertificateException certificateException)
+        {
+            this.chain = chain.clone();
+            this.authType = authType;
+            this.issues = Collections.unmodifiableCollection(issues);
+            this.certificateException = certificateException;
+        }
 
-      /**
-       * Returns the <code>CertificateException</code> thrown by the default
-       * trust manager.
-       *
-       * @return the exception thrown by the default trust manager.
-       */
-      public CertificateException getCertificateException()
-      {
-         return certificateException;
-      }
+        /**
+         * Returns the <code>CertificateException</code> thrown by the default
+         * trust manager.
+         *
+         * @return the exception thrown by the default trust manager.
+         */
+        public CertificateException getCertificateException()
+        {
+            return certificateException;
+        }
 
-      /**
-       * Returns the collection of verification issues.
-       *
-       * @return the collection of verification issues.
-       */
-      public Collection<CertificateVerificationIssue> getIssues()
-      {
-         return issues;
-      }
+        /**
+         * Returns the collection of verification issues.
+         *
+         * @return the collection of verification issues.
+         */
+        public Collection<CertificateVerificationIssue> getIssues()
+        {
+            return issues;
+        }
 
-      /**
-       * @see java.lang.Object#hashCode()
-       */
-      @Override
-      public int hashCode()
-      {
-         final int prime = 31;
-         int result = 1;
-         result = prime * result + (authType == null ? 0 : authType.hashCode());
-         result = prime * result + Arrays.hashCode(chain);
-         return result;
-      }
+        /**
+         * @see java.lang.Object#hashCode()
+         */
+        @Override
+        public int hashCode()
+        {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + (authType == null ? 0 : authType.hashCode());
+            result = prime * result + Arrays.hashCode(chain);
+            return result;
+        }
 
-      /**
-       * @see java.lang.Object#equals(java.lang.Object)
-       */
-      @Override
-      public boolean equals(final Object obj)
-      {
-         if (this == obj)
-         {
-            return true;
-         }
-         if (obj == null)
-         {
-            return false;
-         }
-         if (getClass() != obj.getClass())
-         {
-            return false;
-         }
-         final CacheKey other = (CacheKey)obj;
-         if (authType == null)
-         {
-            if (other.authType != null)
+        /**
+         * @see java.lang.Object#equals(java.lang.Object)
+         */
+        @Override
+        public boolean equals(final Object obj)
+        {
+            if (this == obj)
             {
-               return false;
+                return true;
             }
-         }
-         else if (!authType.equals(other.authType))
-         {
-            return false;
-         }
-         if (!Arrays.equals(chain, other.chain))
-         {
-            return false;
-         }
-         return true;
-      }
-   }
+            if (obj == null)
+            {
+                return false;
+            }
+            if (getClass() != obj.getClass())
+            {
+                return false;
+            }
+            final CacheKey other = (CacheKey)obj;
+            if (authType == null)
+            {
+                if (other.authType != null)
+                {
+                    return false;
+                }
+            }
+            else if (!authType.equals(other.authType))
+            {
+                return false;
+            }
+            if (!Arrays.equals(chain, other.chain))
+            {
+                return false;
+            }
+            return true;
+        }
+    }
 
-   /** The delegated certificate verifier to be cached. */
-   private final CertificateVerifier verifier;
+    /** The delegated certificate verifier to be cached. */
+    private final CertificateVerifier verifier;
 
-   /** The cache manager. */
-   private final CacheManager cacheManager = new CacheManager();
+    /** The cache manager. */
+    private final CacheManager cacheManager = new CacheManager();
 
-   /**
-    * Constructs a new {@linkplain CachingCertificateVerifier} using the given
-    * {@link CertificateVerifier}.
-    *
-    * @param verifier
-    *           the delegated certificate verifier.
-    */
-   public CachingCertificateVerifier(final CertificateVerifier verifier)
-   {
-      if (verifier == null)
-      {
-         throw new IllegalArgumentException("The certificate verifier is null");
-      }
-      this.verifier = verifier;
-   }
+    /**
+     * Constructs a new {@linkplain CachingCertificateVerifier} using the given
+     * {@link CertificateVerifier}.
+     *
+     * @param verifier the delegated certificate verifier.
+     */
+    public CachingCertificateVerifier(final CertificateVerifier verifier)
+    {
+        if (verifier == null)
+        {
+            throw new IllegalArgumentException("The certificate verifier is null");
+        }
+        this.verifier = verifier;
+    }
 
-   /**
-    *
-    * @see CertificateVerifier#allowCertificate(X509Certificate[], String,
-    *      Collection, CertificateException)
-    */
-   @Override
-   public boolean allowCertificate(final X509Certificate[] chain,
-                                   final String authType,
-                                   final Collection<CertificateVerificationIssue> issues,
-                                   final CertificateException certificateException)
-   {
-      final boolean result;
-      final CacheKey key =
-         new CacheKey(chain, authType, issues, certificateException);
-      final Boolean cachedResult = cacheManager.get(key);
-      if (cachedResult != null)
-      {
-         result = cachedResult;
-      }
-      else
-      {
-         result =
-            verifier.allowCertificate(chain, authType, issues, certificateException);
-         cacheManager.put(key, result);
-      }
-      return result;
-   }
+    /**
+     *
+     * @see CertificateVerifier#allowCertificate(X509Certificate[], String,
+     *      Collection, CertificateException)
+     */
+    @Override
+    public boolean allowCertificate(final X509Certificate[] chain, final String authType,
+            final Collection<CertificateVerificationIssue> issues, final CertificateException certificateException)
+    {
+        final boolean result;
+        final CacheKey key = new CacheKey(chain, authType, issues, certificateException);
+        final Boolean cachedResult = cacheManager.get(key);
+        if (cachedResult != null)
+        {
+            result = cachedResult.booleanValue();
+        }
+        else
+        {
+            result = verifier.allowCertificate(chain, authType, issues, certificateException);
+            cacheManager.put(key, Boolean.valueOf(result));
+        }
+        return result;
+    }
 
-   /**
-    * Clears any cached items since the given date. Data before this date will
-    * be preserved. If the parameter is <code>null</code> then the entire cache
-    * should be cleared.
-    *
-    * @param since
-    *           the starting date when the cache will be cleared.
-    */
-   public void clearCache(final Date since)
-   {
-      cacheManager.clearCache(since);
-   }
+    /**
+     * Clears any cached items since the given date. Data before this date will
+     * be preserved. If the parameter is <code>null</code> then the entire cache
+     * should be cleared.
+     *
+     * @param since the starting date when the cache will be cleared.
+     */
+    public void clearCache(final Date since)
+    {
+        cacheManager.clearCache(since);
+    }
 
-   @Override
-   public String toString() {
-      StringBuilder builder = new StringBuilder();
-      builder.append("CachingCertificateVerifier [Verifier=");
-      builder.append(verifier);
-      builder.append("]");
-      return builder.toString();
-   }
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("CachingCertificateVerifier [Verifier=");
+        builder.append(verifier);
+        builder.append("]");
+        return builder.toString();
+    }
 }

--- a/open-sphere-base/core/src/main/java/com/bitsys/common/http/ssl/CachingHostNameVerifier.java
+++ b/open-sphere-base/core/src/main/java/com/bitsys/common/http/ssl/CachingHostNameVerifier.java
@@ -15,159 +15,154 @@ import com.bitsys.common.http.util.cache.CacheManager;
  */
 public class CachingHostNameVerifier implements HostNameVerifier
 {
-   /**
-    * This class contains all of the parameters needed to identify an entry in
-    * the cache.
-    */
-   private static class CacheKey
-   {
-      /** The host name. */
-      private final String host;
+    /**
+     * This class contains all of the parameters needed to identify an entry in
+     * the cache.
+     */
+    private static class CacheKey
+    {
+        /** The host name. */
+        private final String host;
 
-      /** The Common Names from the X.509 certificate. */
-      private final String[] cns;
+        /** The Common Names from the X.509 certificate. */
+        private final String[] cns;
 
-      /** The Subject Alternate Names. */
-      private final String[] subjectAlts;
+        /** The Subject Alternate Names. */
+        private final String[] subjectAlts;
 
-      /**
-       * Constructs a new {@link CacheKey} from the given parameters.
-       *
-       * @param host
-       *           the host name.
-       * @param cns
-       *           the Common Names from the X.509 certificate.
-       * @param subjectAlts
-       *           the Subject Alternative Names.
-       */
-      public CacheKey(final String host, final String[] cns, final String[] subjectAlts)
-      {
-         this.host = host;
-         this.cns = ArrayUtils.clone(cns);
-         this.subjectAlts = ArrayUtils.clone(subjectAlts);
-      }
+        /**
+         * Constructs a new {@link CacheKey} from the given parameters.
+         *
+         * @param host the host name.
+         * @param cns the Common Names from the X.509 certificate.
+         * @param subjectAlts the Subject Alternative Names.
+         */
+        public CacheKey(final String host, final String[] cns, final String[] subjectAlts)
+        {
+            this.host = host;
+            this.cns = ArrayUtils.clone(cns);
+            this.subjectAlts = ArrayUtils.clone(subjectAlts);
+        }
 
-      /**
-       * @see java.lang.Object#hashCode()
-       */
-      @Override
-      public int hashCode()
-      {
-         final int prime = 31;
-         int result = 1;
-         result = prime * result + Objects.hashCode(host);
-         result = prime * result + Arrays.hashCode(cns);
-         result = prime * result + Arrays.hashCode(subjectAlts);
-         return result;
-      }
+        /**
+         * @see java.lang.Object#hashCode()
+         */
+        @Override
+        public int hashCode()
+        {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Objects.hashCode(host);
+            result = prime * result + Arrays.hashCode(cns);
+            result = prime * result + Arrays.hashCode(subjectAlts);
+            return result;
+        }
 
-      /**
-       * @see java.lang.Object#equals(java.lang.Object)
-       */
-      @Override
-      public boolean equals(final Object obj)
-      {
-         if (this == obj)
-         {
-            return true;
-         }
-         if (obj == null)
-         {
-            return false;
-         }
-         if (getClass() != obj.getClass())
-         {
-            return false;
-         }
-         final CacheKey other = (CacheKey)obj;
-         if (host == null)
-         {
-            if (other.host != null)
+        /**
+         * @see java.lang.Object#equals(java.lang.Object)
+         */
+        @Override
+        public boolean equals(final Object obj)
+        {
+            if (this == obj)
             {
-               return false;
+                return true;
             }
-         }
-         else if (!host.equals(other.host))
-         {
-            return false;
-         }
-         if (!Arrays.equals(cns, other.cns))
-         {
-            return false;
-         }
-         if (!Arrays.equals(subjectAlts, other.subjectAlts))
-         {
-            return false;
-         }
-         return true;
-      }
-   }
+            if (obj == null)
+            {
+                return false;
+            }
+            if (getClass() != obj.getClass())
+            {
+                return false;
+            }
+            final CacheKey other = (CacheKey)obj;
+            if (host == null)
+            {
+                if (other.host != null)
+                {
+                    return false;
+                }
+            }
+            else if (!host.equals(other.host))
+            {
+                return false;
+            }
+            if (!Arrays.equals(cns, other.cns))
+            {
+                return false;
+            }
+            if (!Arrays.equals(subjectAlts, other.subjectAlts))
+            {
+                return false;
+            }
+            return true;
+        }
+    }
 
-   /** The cached host name verifier. */
-   private final HostNameVerifier verifier;
+    /** The cached host name verifier. */
+    private final HostNameVerifier verifier;
 
-   /** The cache manager. */
-   private final CacheManager cacheManager = new CacheManager();
+    /** The cache manager. */
+    private final CacheManager cacheManager = new CacheManager();
 
-   /**
-    * Constructs a new {@link CachingHostNameVerifier} with the given
-    * {@link HostNameVerifier}.
-    *
-    * @param verifier
-    *           the verifier to cache.
-    */
-   public CachingHostNameVerifier(final HostNameVerifier verifier)
-   {
-      if (verifier == null)
-      {
-         throw new IllegalArgumentException("The host name verifier is null");
-      }
-      this.verifier = verifier;
-   }
+    /**
+     * Constructs a new {@link CachingHostNameVerifier} with the given
+     * {@link HostNameVerifier}.
+     *
+     * @param verifier the verifier to cache.
+     */
+    public CachingHostNameVerifier(final HostNameVerifier verifier)
+    {
+        if (verifier == null)
+        {
+            throw new IllegalArgumentException("The host name verifier is null");
+        }
+        this.verifier = verifier;
+    }
 
-   /**
-    * @see com.bitsys.common.http.ssl.HostNameVerifier#allowInvalidHostName(java.lang.String,
-    *      java.lang.String[], java.lang.String[], java.lang.String)
-    */
-   @Override
-   public boolean allowInvalidHostName(final String host, final String[] cns,
-                                       final String[] subjectAlts, final String reason)
-   {
-      final boolean result;
-      final CacheKey key = new CacheKey(host, cns, subjectAlts);
-      final Boolean cachedResult = cacheManager.get(key);
-      if (cachedResult != null)
-      {
-         result = cachedResult;
-      }
-      else
-      {
-         result = verifier.allowInvalidHostName(host, cns, subjectAlts, reason);
-         cacheManager.put(key, result);
-      }
+    /**
+     * @see com.bitsys.common.http.ssl.HostNameVerifier#allowInvalidHostName(java.lang.String,
+     *      java.lang.String[], java.lang.String[], java.lang.String)
+     */
+    @Override
+    public boolean allowInvalidHostName(final String host, final String[] cns, final String[] subjectAlts, final String reason)
+    {
+        final boolean result;
+        final CacheKey key = new CacheKey(host, cns, subjectAlts);
+        final Boolean cachedResult = cacheManager.get(key);
+        if (cachedResult != null)
+        {
+            result = cachedResult.booleanValue();
+        }
+        else
+        {
+            result = verifier.allowInvalidHostName(host, cns, subjectAlts, reason);
+            cacheManager.put(key, Boolean.valueOf(result));
+        }
 
-      return result;
-   }
+        return result;
+    }
 
-   /**
-    * Clears any cached items since the given date. Data before this date will
-    * be preserved. If the parameter is <code>null</code> then the entire cache
-    * should be cleared.
-    *
-    * @param since
-    *           the starting date when the cache will be cleared.
-    */
-   public void clearCache(final Date since)
-   {
-      cacheManager.clearCache(since);
-   }
+    /**
+     * Clears any cached items since the given date. Data before this date will
+     * be preserved. If the parameter is <code>null</code> then the entire cache
+     * should be cleared.
+     *
+     * @param since the starting date when the cache will be cleared.
+     */
+    public void clearCache(final Date since)
+    {
+        cacheManager.clearCache(since);
+    }
 
-   @Override
-   public String toString() {
-      StringBuilder builder = new StringBuilder();
-      builder.append("CachingHostNameVerifier [Verifier=");
-      builder.append(verifier);
-      builder.append("]");
-      return builder.toString();
-   }
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("CachingHostNameVerifier [Verifier=");
+        builder.append(verifier);
+        builder.append("]");
+        return builder.toString();
+    }
 }

--- a/open-sphere-base/core/src/main/java/com/bitsys/common/http/ssl/CertificateVerificationIssue.java
+++ b/open-sphere-base/core/src/main/java/com/bitsys/common/http/ssl/CertificateVerificationIssue.java
@@ -7,200 +7,189 @@ import java.security.cert.X509Certificate;
  */
 public class CertificateVerificationIssue
 {
-   /**
-    * Indicates the severity of an issue.
-    */
-   public enum SeverityType
-   {
-      INFORMATION, WARNING, ERROR
-   }
+    /**
+     * Indicates the severity of an issue.
+     */
+    public enum SeverityType
+    {
+        INFORMATION, WARNING, ERROR
+    }
 
-   /**
-    * This enumeration describes the different type of certificate verification
-    * issues that may occur. Issues have a {@link SeverityType severity}
-    * associated with them.
-    */
-   public enum IssueType
-   {
-      /**
-       * Indicates that the certificate is not yet valid meaning that its
-       * <code>Validity</code> period is in the future.
-       */
-      CERTIFICATE_NOT_YET_VALID(SeverityType.ERROR,
-                                "The certificate is not yet valid"),
+    /**
+     * This enumeration describes the different type of certificate verification
+     * issues that may occur. Issues have a {@link SeverityType severity}
+     * associated with them.
+     */
+    public enum IssueType
+    {
+        /**
+         * Indicates that the certificate is not yet valid meaning that its
+         * <code>Validity</code> period is in the future.
+         */
+        CERTIFICATE_NOT_YET_VALID(SeverityType.ERROR, "The certificate is not yet valid"),
 
-      /**
-       * Indicates that the certificate has expired meaning that its
-       * <code>Validity</code> period is in the past.
-       */
-      CERTIFICATE_EXPIRED(SeverityType.ERROR, "The certificate has expired"),
+        /**
+         * Indicates that the certificate has expired meaning that its
+         * <code>Validity</code> period is in the past.
+         */
+        CERTIFICATE_EXPIRED(SeverityType.ERROR, "The certificate has expired"),
 
-      /**
-       * Indicates that the certificate chain is malformed. A well-formed
-       * certificate chain starts with the lowest level of issued certificate
-       * and continues with each subsequent certificate being the issuer of the
-       * certificate before it and finally ending it a self-signed certificate.
-       */
-      MALFORMED_CERTIFICATE_CHAIN(SeverityType.WARNING,
-                                  "The certificate chain is malformed"),
+        /**
+         * Indicates that the certificate chain is malformed. A well-formed
+         * certificate chain starts with the lowest level of issued certificate
+         * and continues with each subsequent certificate being the issuer of
+         * the certificate before it and finally ending it a self-signed
+         * certificate.
+         */
+        MALFORMED_CERTIFICATE_CHAIN(SeverityType.WARNING, "The certificate chain is malformed"),
 
-      /**
-       * Indicates that certificate chain is incomplete. It could be that only
-       * the first certificate in the chain is present or the chain does not
-       * terminate with a self-signed certificate. The certificate may still be
-       * trusted but this indicates an improperly configured server.
-       */
-      INCOMPLETE_CERTIFICATE_CHAIN(SeverityType.WARNING,
-                                   "The certificate is not trusted because no issuer chain was provided."),
-      /**
-       * Indicates that a received certificate is either not in the trust store
-       * or, by following the certificate chain, not an issued ancestor of a
-       * certificate in the trust store.
-       */
-      CERTIFICATE_NOT_TRUSTED(SeverityType.ERROR, "The certificate is not trusted");
+        /**
+         * Indicates that certificate chain is incomplete. It could be that only
+         * the first certificate in the chain is present or the chain does not
+         * terminate with a self-signed certificate. The certificate may still
+         * be trusted but this indicates an improperly configured server.
+         */
+        INCOMPLETE_CERTIFICATE_CHAIN(SeverityType.WARNING,
+                "The certificate is not trusted because no issuer chain was provided."),
+        /**
+         * Indicates that a received certificate is either not in the trust
+         * store or, by following the certificate chain, not an issued ancestor
+         * of a certificate in the trust store.
+         */
+        CERTIFICATE_NOT_TRUSTED(SeverityType.ERROR, "The certificate is not trusted");
 
-      /** The severity. */
-      private final SeverityType severity;
+        /** The severity. */
+        private final SeverityType severity;
 
-      /** The default message. */
-      private final String defaultMessage;
+        /** The default message. */
+        private final String defaultMessage;
 
-      /**
-       * Constructs a new {@linkplain IssueType} with the given severity.
-       *
-       * @param severity
-       *           the severity.
-       * @param defaultMessage
-       *           the default message.
-       */
-      IssueType(final SeverityType severity, final String defaultMessage)
-      {
-         this.severity = severity;
-         this.defaultMessage = defaultMessage;
-      }
+        /**
+         * Constructs a new {@linkplain IssueType} with the given severity.
+         *
+         * @param severity the severity.
+         * @param defaultMessage the default message.
+         */
+        IssueType(final SeverityType severity, final String defaultMessage)
+        {
+            this.severity = severity;
+            this.defaultMessage = defaultMessage;
+        }
 
-      /**
-       * Returns the issue's severity.
-       *
-       * @return the issue's severity.
-       */
-      public SeverityType getSeverity()
-      {
-         return severity;
-      }
+        /**
+         * Returns the issue's severity.
+         *
+         * @return the issue's severity.
+         */
+        public SeverityType getSeverity()
+        {
+            return severity;
+        }
 
-      /**
-       * Returns the default message.
-       *
-       * @return the default message.
-       */
-      public String getDefaultMessage()
-      {
-         return defaultMessage;
-      }
-   }
+        /**
+         * Returns the default message.
+         *
+         * @return the default message.
+         */
+        public String getDefaultMessage()
+        {
+            return defaultMessage;
+        }
+    }
 
-   /** The issue type. */
-   private final IssueType issueType;
+    /** The issue type. */
+    private final IssueType issueType;
 
-   /** The certificate. */
-   private final X509Certificate certificate;
+    /** The certificate. */
+    private final X509Certificate certificate;
 
-   /** The verification issue. */
-   private final String message;
+    /** The verification issue. */
+    private final String message;
 
-   /**
-    * Constructs a new {@linkplain CertificateVerificationIssue} with the given
-    * issue type, certificate and message.
-    *
-    * @param issueType
-    *           the issue type.
-    * @param certificate
-    *           the certificate with a verification issue.
-    */
-   public CertificateVerificationIssue(final IssueType issueType,
-                                       final X509Certificate certificate)
-   {
-      this(issueType, certificate, issueType != null ? issueType.getDefaultMessage()
-         : null);
-   }
+    /**
+     * Constructs a new {@linkplain CertificateVerificationIssue} with the given
+     * issue type, certificate and message.
+     *
+     * @param issueType the issue type.
+     * @param certificate the certificate with a verification issue.
+     */
+    public CertificateVerificationIssue(final IssueType issueType, final X509Certificate certificate)
+    {
+        this(issueType, certificate, issueType != null ? issueType.getDefaultMessage() : null);
+    }
 
-   /**
-    * Constructs a new {@linkplain CertificateVerificationIssue} with the given
-    * issue type, certificate and message.
-    *
-    * @param issueType
-    *           the issue type.
-    * @param certificate
-    *           the certificate with a verification issue.
-    * @param message
-    *           the message.
-    */
-   public CertificateVerificationIssue(final IssueType issueType,
-                                       final X509Certificate certificate,
-                                       final String message)
-   {
-      if (issueType == null)
-      {
-         throw new IllegalArgumentException("The issue type is null");
-      }
-      if (certificate == null)
-      {
-         throw new IllegalArgumentException("The certificate is null");
-      }
-      if (message == null)
-      {
-         throw new IllegalArgumentException("The message is null");
-      }
-      this.issueType = issueType;
-      this.certificate = certificate;
-      this.message = message == null ? issueType.getDefaultMessage() : message;
-   }
+    /**
+     * Constructs a new {@linkplain CertificateVerificationIssue} with the given
+     * issue type, certificate and message.
+     *
+     * @param issueType the issue type.
+     * @param certificate the certificate with a verification issue.
+     * @param message the message.
+     */
+    public CertificateVerificationIssue(final IssueType issueType, final X509Certificate certificate, final String message)
+    {
+        if (issueType == null)
+        {
+            throw new IllegalArgumentException("The issue type is null");
+        }
+        if (certificate == null)
+        {
+            throw new IllegalArgumentException("The certificate is null");
+        }
+        if (message == null)
+        {
+            throw new IllegalArgumentException("The message is null");
+        }
+        this.issueType = issueType;
+        this.certificate = certificate;
+        this.message = message;
+        // == null ? issueType.getDefaultMessage() : message;
+    }
 
-   /**
-    * Returns the issue type.
-    *
-    * @return the issue type.
-    */
-   public IssueType getIssueType()
-   {
-      return issueType;
-   }
+    /**
+     * Returns the issue type.
+     *
+     * @return the issue type.
+     */
+    public IssueType getIssueType()
+    {
+        return issueType;
+    }
 
-   /**
-    * Returns the X.509 certificate with which there is a problem.
-    *
-    * @return the X.509 certificate with an error.
-    */
-   public X509Certificate getCertificate()
-   {
-      return certificate;
-   }
+    /**
+     * Returns the X.509 certificate with which there is a problem.
+     *
+     * @return the X.509 certificate with an error.
+     */
+    public X509Certificate getCertificate()
+    {
+        return certificate;
+    }
 
-   /**
-    * Returns the verification message.
-    *
-    * @return the verification message.
-    */
-   public String getMessage()
-   {
-      return message;
-   }
+    /**
+     * Returns the verification message.
+     *
+     * @return the verification message.
+     */
+    public String getMessage()
+    {
+        return message;
+    }
 
-   /**
-    * @see java.lang.Object#toString()
-    */
-   @Override
-   public String toString()
-   {
-      final StringBuilder builder = new StringBuilder();
-      builder.append("CertificateVerificationIssue [issueType=");
-      builder.append(issueType);
-      builder.append(", certificate=");
-      builder.append(certificate);
-      builder.append(", message=");
-      builder.append(message);
-      builder.append("]");
-      return builder.toString();
-   }
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("CertificateVerificationIssue [issueType=");
+        builder.append(issueType);
+        builder.append(", certificate=");
+        builder.append(certificate);
+        builder.append(", message=");
+        builder.append(message);
+        builder.append("]");
+        return builder.toString();
+    }
 }

--- a/open-sphere-base/core/src/main/java/com/bitsys/common/http/ssl/EnhancedSSLSocketFactory.java
+++ b/open-sphere-base/core/src/main/java/com/bitsys/common/http/ssl/EnhancedSSLSocketFactory.java
@@ -21,350 +21,269 @@ import org.apache.http.conn.ssl.X509HostnameVerifier;
  * class provides the ability to customize the generated {@link SSLSocket}
  * instances.
  */
+@SuppressWarnings("deprecation")
 public class EnhancedSSLSocketFactory extends SSLSocketFactory
 {
-   /**
-    * Instances of this class have the ability to customize an {@link SSLSocket}
-    * before it is used. Typical customizations include setting the protocols
-    * (e.g. SSLv3 or TLSv1) and modifying the cipher suites.
-    */
-   public interface SSLSocketCustomizer
-   {
-      /**
-       * Customizes the {@link SSLSocket} prior to its use.
-       *
-       * @param socket
-       *           the SSL socket to customize.
-       * @throws IOException
-       *            if an error occurs while customizing the socket.
-       */
-      void customize(SSLSocket socket) throws IOException;
-   }
+    /**
+     * Instances of this class have the ability to customize an
+     * {@link SSLSocket} before it is used. Typical customizations include
+     * setting the protocols (e.g. SSLv3 or TLSv1) and modifying the cipher
+     * suites.
+     */
+    public interface SSLSocketCustomizer
+    {
+        /**
+         * Customizes the {@link SSLSocket} prior to its use.
+         *
+         * @param socket the SSL socket to customize.
+         * @throws IOException if an error occurs while customizing the socket.
+         */
+        void customize(SSLSocket socket) throws IOException;
+    }
 
-   private final SSLSocketCustomizer customizer;
+    /** The customizer. */
+    private final SSLSocketCustomizer customizer;
 
-   /**
-    * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given trust
-    * store and socket customizer.
-    *
-    * @param truststore
-    *           the trust store.
-    * @param customizer
-    *           the SSL socket customizer.
-    * @throws NoSuchAlgorithmException
-    *            if unable to process the trust store.
-    * @throws KeyManagementException
-    *            if unable to process the trust store.
-    * @throws KeyStoreException
-    *            if unable to process the trust store.
-    * @throws UnrecoverableKeyException
-    *            if unable to process the trust store.
-    */
-   public EnhancedSSLSocketFactory(final KeyStore truststore,
-                                   final SSLSocketCustomizer customizer)
-      throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException,
-      UnrecoverableKeyException
-   {
-      super(truststore);
-      if (customizer == null)
-      {
-         throw new IllegalArgumentException("The SSL socket customizer is null");
-      }
-      this.customizer = customizer;
-   }
+    /**
+     * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given trust
+     * store and socket customizer.
+     *
+     * @param truststore the trust store.
+     * @param customizer the SSL socket customizer.
+     * @throws NoSuchAlgorithmException if unable to process the trust store.
+     * @throws KeyManagementException if unable to process the trust store.
+     * @throws KeyStoreException if unable to process the trust store.
+     * @throws UnrecoverableKeyException if unable to process the trust store.
+     */
+    public EnhancedSSLSocketFactory(final KeyStore truststore, final SSLSocketCustomizer customizer)
+        throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException
+    {
+        super(truststore);
+        if (customizer == null)
+        {
+            throw new IllegalArgumentException("The SSL socket customizer is null");
+        }
+        this.customizer = customizer;
+    }
 
-   /**
-    * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given trust
-    * strategy and socket customizer.
-    *
-    * @param trustStrategy
-    *           the trust strategy.
-    * @param customizer
-    *           the SSL socket customizer.
-    * @throws NoSuchAlgorithmException
-    *            if unable to process the trust store.
-    * @throws KeyManagementException
-    *            if unable to process the trust store.
-    * @throws KeyStoreException
-    *            if unable to process the trust store.
-    * @throws UnrecoverableKeyException
-    *            if unable to process the trust store.
-    */
-   public EnhancedSSLSocketFactory(final TrustStrategy trustStrategy,
-                                   final SSLSocketCustomizer customizer)
-      throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException,
-      UnrecoverableKeyException
-   {
-      super(trustStrategy);
-      if (customizer == null)
-      {
-         throw new IllegalArgumentException("The SSL socket customizer is null");
-      }
-      this.customizer = customizer;
-   }
+    /**
+     * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given trust
+     * strategy and socket customizer.
+     *
+     * @param trustStrategy the trust strategy.
+     * @param customizer the SSL socket customizer.
+     * @throws NoSuchAlgorithmException if unable to process the trust store.
+     * @throws KeyManagementException if unable to process the trust store.
+     * @throws KeyStoreException if unable to process the trust store.
+     * @throws UnrecoverableKeyException if unable to process the trust store.
+     */
+    public EnhancedSSLSocketFactory(final TrustStrategy trustStrategy, final SSLSocketCustomizer customizer)
+        throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException
+    {
+        super(trustStrategy);
+        if (customizer == null)
+        {
+            throw new IllegalArgumentException("The SSL socket customizer is null");
+        }
+        this.customizer = customizer;
+    }
 
-   /**
-    * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given SSL
-    * context and socket customizer.
-    *
-    * @param sslContext
-    * @param customizer
-    *           the SSL socket customizer.
-    */
-   public EnhancedSSLSocketFactory(final SSLContext sslContext,
-                                   final SSLSocketCustomizer customizer)
-   {
-      super(sslContext);
-      if (customizer == null)
-      {
-         throw new IllegalArgumentException("The SSL socket customizer is null");
-      }
-      this.customizer = customizer;
-   }
+    /**
+     * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given SSL
+     * context and socket customizer.
+     *
+     * @param sslContext
+     * @param customizer the SSL socket customizer.
+     */
+    public EnhancedSSLSocketFactory(final SSLContext sslContext, final SSLSocketCustomizer customizer)
+    {
+        super(sslContext);
+        if (customizer == null)
+        {
+            throw new IllegalArgumentException("The SSL socket customizer is null");
+        }
+        this.customizer = customizer;
+    }
 
-   /**
-    * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given key
-    * store, password and socket customizer.
-    *
-    * @param keystore
-    *           the key store.
-    * @param keystorePassword
-    *           the key store password.
-    * @param customizer
-    *           the SSL socket customizer.
-    * @throws NoSuchAlgorithmException
-    *            if unable to process the key store.
-    * @throws KeyManagementException
-    *            if unable to process the key store.
-    * @throws KeyStoreException
-    *            if unable to process the key store.
-    * @throws UnrecoverableKeyException
-    *            if unable to process the key store.
-    */
-   public EnhancedSSLSocketFactory(final KeyStore keystore, final String keystorePassword,
-                                   final SSLSocketCustomizer customizer)
-      throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException,
-      UnrecoverableKeyException
-   {
-      super(keystore, keystorePassword);
-      if (customizer == null)
-      {
-         throw new IllegalArgumentException("The SSL socket customizer is null");
-      }
-      this.customizer = customizer;
-   }
+    /**
+     * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given key
+     * store, password and socket customizer.
+     *
+     * @param keystore the key store.
+     * @param keystorePassword the key store password.
+     * @param customizer the SSL socket customizer.
+     * @throws NoSuchAlgorithmException if unable to process the key store.
+     * @throws KeyManagementException if unable to process the key store.
+     * @throws KeyStoreException if unable to process the key store.
+     * @throws UnrecoverableKeyException if unable to process the key store.
+     */
+    public EnhancedSSLSocketFactory(final KeyStore keystore, final String keystorePassword, final SSLSocketCustomizer customizer)
+        throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException
+    {
+        super(keystore, keystorePassword);
+        if (customizer == null)
+        {
+            throw new IllegalArgumentException("The SSL socket customizer is null");
+        }
+        this.customizer = customizer;
+    }
 
-   /**
-    * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given trust
-    * strategy, hostname verifier and socket customizer.
-    *
-    * @param trustStrategy
-    *           the trust strategy.
-    * @param hostnameVerifier
-    *           the hostname verifier.
-    * @param customizer
-    *           the SSL socket customizer.
-    * @throws NoSuchAlgorithmException
-    *            if unable to process the trust store.
-    * @throws KeyManagementException
-    *            if unable to process the trust store.
-    * @throws KeyStoreException
-    *            if unable to process the trust store.
-    * @throws UnrecoverableKeyException
-    *            if unable to process the trust store.
-    */
-   public EnhancedSSLSocketFactory(final TrustStrategy trustStrategy,
-                                   final X509HostnameVerifier hostnameVerifier,
-                                   final SSLSocketCustomizer customizer)
-      throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException,
-      UnrecoverableKeyException
-   {
-      super(trustStrategy, hostnameVerifier);
-      if (customizer == null)
-      {
-         throw new IllegalArgumentException("The SSL socket customizer is null");
-      }
-      this.customizer = customizer;
-   }
+    /**
+     * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given trust
+     * strategy, hostname verifier and socket customizer.
+     *
+     * @param trustStrategy the trust strategy.
+     * @param hostnameVerifier the hostname verifier.
+     * @param customizer the SSL socket customizer.
+     * @throws NoSuchAlgorithmException if unable to process the trust store.
+     * @throws KeyManagementException if unable to process the trust store.
+     * @throws KeyStoreException if unable to process the trust store.
+     * @throws UnrecoverableKeyException if unable to process the trust store.
+     */
+    public EnhancedSSLSocketFactory(final TrustStrategy trustStrategy, final X509HostnameVerifier hostnameVerifier,
+            final SSLSocketCustomizer customizer)
+        throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException
+    {
+        super(trustStrategy, hostnameVerifier);
+        if (customizer == null)
+        {
+            throw new IllegalArgumentException("The SSL socket customizer is null");
+        }
+        this.customizer = customizer;
+    }
 
-   /**
-    * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given SSL
-    * context, hostname verifier and socket customizer.
-    *
-    * @param sslContext
-    *           the SSL context.
-    * @param hostnameVerifier
-    *           the hostname verifier.
-    * @param customizer
-    *           the SSL socket customizer.
-    */
-   public EnhancedSSLSocketFactory(final SSLContext sslContext,
-                                   final X509HostnameVerifier hostnameVerifier,
-                                   final SSLSocketCustomizer customizer)
-   {
-      super(sslContext, hostnameVerifier);
-      if (customizer == null)
-      {
-         throw new IllegalArgumentException("The SSL socket customizer is null");
-      }
-      this.customizer = customizer;
-   }
+    /**
+     * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given SSL
+     * context, hostname verifier and socket customizer.
+     *
+     * @param sslContext the SSL context.
+     * @param hostnameVerifier the hostname verifier.
+     * @param customizer the SSL socket customizer.
+     */
+    public EnhancedSSLSocketFactory(final SSLContext sslContext, final X509HostnameVerifier hostnameVerifier,
+            final SSLSocketCustomizer customizer)
+    {
+        super(sslContext, hostnameVerifier);
+        if (customizer == null)
+        {
+            throw new IllegalArgumentException("The SSL socket customizer is null");
+        }
+        this.customizer = customizer;
+    }
 
-   /**
-    * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given Java
-    * socket factory, hostname verifier and socket customizer.
-    *
-    * @param socketfactory
-    *           the Java socket factory.
-    * @param hostnameVerifier
-    *           the hostname verifier.
-    * @param customizer
-    *           the SSL socket customizer.
-    */
-   public EnhancedSSLSocketFactory(final javax.net.ssl.SSLSocketFactory socketfactory,
-                                   final X509HostnameVerifier hostnameVerifier,
-                                   final SSLSocketCustomizer customizer)
-   {
-      super(socketfactory, hostnameVerifier);
-      if (customizer == null)
-      {
-         throw new IllegalArgumentException("The SSL socket customizer is null");
-      }
-      this.customizer = customizer;
-   }
+    /**
+     * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given Java
+     * socket factory, hostname verifier and socket customizer.
+     *
+     * @param socketfactory the Java socket factory.
+     * @param hostnameVerifier the hostname verifier.
+     * @param customizer the SSL socket customizer.
+     */
+    public EnhancedSSLSocketFactory(final javax.net.ssl.SSLSocketFactory socketfactory,
+            final X509HostnameVerifier hostnameVerifier, final SSLSocketCustomizer customizer)
+    {
+        super(socketfactory, hostnameVerifier);
+        if (customizer == null)
+        {
+            throw new IllegalArgumentException("The SSL socket customizer is null");
+        }
+        this.customizer = customizer;
+    }
 
-   /**
-    * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given key
-    * store, password, trust store and socket customizer.
-    *
-    * @param keystore
-    *           the key store.
-    * @param keystorePassword
-    *           the key store password.
-    * @param truststore
-    *           the trust store.
-    * @param customizer
-    *           the SSL socket customizer.
-    * @throws NoSuchAlgorithmException
-    *            if unable to process the key or trust store.
-    * @throws KeyManagementException
-    *            if unable to process the key or trust store.
-    * @throws KeyStoreException
-    *            if unable to process the key or trust store.
-    * @throws UnrecoverableKeyException
-    *            if unable to process the key or trust store.
-    */
-   public EnhancedSSLSocketFactory(final KeyStore keystore, final String keystorePassword,
-                                   final KeyStore truststore,
-                                   final SSLSocketCustomizer customizer)
-      throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException,
-      UnrecoverableKeyException
-   {
-      super(keystore, keystorePassword, truststore);
-      if (customizer == null)
-      {
-         throw new IllegalArgumentException("The SSL socket customizer is null");
-      }
-      this.customizer = customizer;
-   }
+    /**
+     * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given key
+     * store, password, trust store and socket customizer.
+     *
+     * @param keystore the key store.
+     * @param keystorePassword the key store password.
+     * @param truststore the trust store.
+     * @param customizer the SSL socket customizer.
+     * @throws NoSuchAlgorithmException if unable to process the key or trust
+     *             store.
+     * @throws KeyManagementException if unable to process the key or trust
+     *             store.
+     * @throws KeyStoreException if unable to process the key or trust store.
+     * @throws UnrecoverableKeyException if unable to process the key or trust
+     *             store.
+     */
+    public EnhancedSSLSocketFactory(final KeyStore keystore, final String keystorePassword, final KeyStore truststore,
+            final SSLSocketCustomizer customizer)
+        throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException
+    {
+        super(keystore, keystorePassword, truststore);
+        if (customizer == null)
+        {
+            throw new IllegalArgumentException("The SSL socket customizer is null");
+        }
+        this.customizer = customizer;
+    }
 
-   /**
-    * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given
-    * parameters.
-    *
-    * @param algorithm
-    *           the SSL/TLS algorithm.
-    * @param keystore
-    *           the key store.
-    * @param keystorePassword
-    *           the key store password.
-    * @param truststore
-    *           the trust store.
-    * @param random
-    *           the random number generator.
-    * @param hostnameVerifier
-    *           the hostname verifier.
-    * @param customizer
-    *           the SSL socket customizer.
-    * @throws NoSuchAlgorithmException
-    *            if unable to process the trust store.
-    * @throws KeyManagementException
-    *            if unable to process the trust store.
-    * @throws KeyStoreException
-    *            if unable to process the trust store.
-    * @throws UnrecoverableKeyException
-    *            if unable to process the trust store.
-    */
-   public EnhancedSSLSocketFactory(final String algorithm, final KeyStore keystore,
-                                   final String keystorePassword, final KeyStore truststore,
-                                   final SecureRandom random,
-                                   final X509HostnameVerifier hostnameVerifier,
-                                   final SSLSocketCustomizer customizer)
-      throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException,
-      UnrecoverableKeyException
-   {
-      super(algorithm, keystore, keystorePassword, truststore, random,
-         hostnameVerifier);
-      if (customizer == null)
-      {
-         throw new IllegalArgumentException("The SSL socket customizer is null");
-      }
-      this.customizer = customizer;
-   }
+    /**
+     * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given
+     * parameters.
+     *
+     * @param algorithm the SSL/TLS algorithm.
+     * @param keystore the key store.
+     * @param keystorePassword the key store password.
+     * @param truststore the trust store.
+     * @param random the random number generator.
+     * @param hostnameVerifier the hostname verifier.
+     * @param customizer the SSL socket customizer.
+     * @throws NoSuchAlgorithmException if unable to process the trust store.
+     * @throws KeyManagementException if unable to process the trust store.
+     * @throws KeyStoreException if unable to process the trust store.
+     * @throws UnrecoverableKeyException if unable to process the trust store.
+     */
+    public EnhancedSSLSocketFactory(final String algorithm, final KeyStore keystore, final String keystorePassword,
+            final KeyStore truststore, final SecureRandom random, final X509HostnameVerifier hostnameVerifier,
+            final SSLSocketCustomizer customizer)
+        throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException
+    {
+        super(algorithm, keystore, keystorePassword, truststore, random, hostnameVerifier);
+        if (customizer == null)
+        {
+            throw new IllegalArgumentException("The SSL socket customizer is null");
+        }
+        this.customizer = customizer;
+    }
 
-   /**
-    * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given
-    * parameters.
-    *
-    * @param algorithm
-    *           the SSL/TLS algorithm.
-    * @param keystore
-    *           the key store.
-    * @param keystorePassword
-    *           the key store password.
-    * @param truststore
-    *           the trust store.
-    * @param random
-    *           the random number generator.
-    * @param trustStrategy
-    *           the trust strategy.
-    * @param hostnameVerifier
-    *           the hostname verifier.
-    * @param customizer
-    *           the SSL socket customizer.
-    * @throws NoSuchAlgorithmException
-    *            if unable to process the trust store.
-    * @throws KeyManagementException
-    *            if unable to process the trust store.
-    * @throws KeyStoreException
-    *            if unable to process the trust store.
-    * @throws UnrecoverableKeyException
-    *            if unable to process the trust store.
-    */
-   public EnhancedSSLSocketFactory(final String algorithm, final KeyStore keystore,
-                                   final String keystorePassword, final KeyStore truststore,
-                                   final SecureRandom random, final TrustStrategy trustStrategy,
-                                   final X509HostnameVerifier hostnameVerifier,
-                                   final SSLSocketCustomizer customizer)
-      throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException,
-      UnrecoverableKeyException
-   {
-      super(algorithm, keystore, keystorePassword, truststore, random,
-         trustStrategy, hostnameVerifier);
-      if (customizer == null)
-      {
-         throw new IllegalArgumentException("The SSL socket customizer is null");
-      }
-      this.customizer = customizer;
-   }
+    /**
+     * Creates a new {@linkplain EnhancedSSLSocketFactory} using the given
+     * parameters.
+     *
+     * @param algorithm the SSL/TLS algorithm.
+     * @param keystore the key store.
+     * @param keystorePassword the key store password.
+     * @param truststore the trust store.
+     * @param random the random number generator.
+     * @param trustStrategy the trust strategy.
+     * @param hostnameVerifier the hostname verifier.
+     * @param customizer the SSL socket customizer.
+     * @throws NoSuchAlgorithmException if unable to process the trust store.
+     * @throws KeyManagementException if unable to process the trust store.
+     * @throws KeyStoreException if unable to process the trust store.
+     * @throws UnrecoverableKeyException if unable to process the trust store.
+     */
+    public EnhancedSSLSocketFactory(final String algorithm, final KeyStore keystore, final String keystorePassword,
+            final KeyStore truststore, final SecureRandom random, final TrustStrategy trustStrategy,
+            final X509HostnameVerifier hostnameVerifier, final SSLSocketCustomizer customizer)
+        throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException
+    {
+        super(algorithm, keystore, keystorePassword, truststore, random, trustStrategy, hostnameVerifier);
+        if (customizer == null)
+        {
+            throw new IllegalArgumentException("The SSL socket customizer is null");
+        }
+        this.customizer = customizer;
+    }
 
-   /**
-    * @see org.apache.http.conn.ssl.SSLSocketFactory#prepareSocket(javax.net.ssl.SSLSocket)
-    */
-   @Override
-   protected void prepareSocket(final SSLSocket socket) throws IOException
-   {
-      super.prepareSocket(socket);
-      customizer.customize(socket);
-   }
+    /**
+     * @see org.apache.http.conn.ssl.SSLSocketFactory#prepareSocket(javax.net.ssl.SSLSocket)
+     */
+    @Override
+    protected void prepareSocket(final SSLSocket socket) throws IOException
+    {
+        super.prepareSocket(socket);
+        customizer.customize(socket);
+    }
 }

--- a/open-sphere-base/core/src/main/java/com/bitsys/common/http/ssl/X509HostNameVerifierCourtRoom.java
+++ b/open-sphere-base/core/src/main/java/com/bitsys/common/http/ssl/X509HostNameVerifierCourtRoom.java
@@ -11,54 +11,51 @@ import org.apache.http.conn.ssl.X509HostnameVerifier;
  * {@link HostNameVerifier}) has the ability to overrule the verification
  * exception.
  */
+@SuppressWarnings("deprecation")
 public class X509HostNameVerifierCourtRoom extends AbstractVerifier
 {
-   /** The delegated X509 host name verifier. */
-   private final X509HostnameVerifier verifier;
+    /** The delegated X509 host name verifier. */
+    private final X509HostnameVerifier verifier;
 
-   /** The host name verifier that can overrule the delegated verifier. */
-   private final HostNameVerifier judge;
+    /** The host name verifier that can overrule the delegated verifier. */
+    private final HostNameVerifier judge;
 
-   /**
-    * Constructs a <code>X509HostNameVerifierDelegate</code>.
-    *
-    * @param verifier
-    *           the delegated host name verifier.
-    */
-   public X509HostNameVerifierCourtRoom(final X509HostnameVerifier verifier,
-                                        final HostNameVerifier judge)
-   {
-      if (verifier == null)
-      {
-         throw new IllegalArgumentException(
-            "The Apache X509 host name verifier is null");
-      }
-      this.verifier = verifier;
-      if (judge == null)
-      {
-         throw new IllegalArgumentException("The host name verifier is null");
-      }
-      this.judge = judge;
-   }
+    /**
+     * Constructs a <code>X509HostNameVerifierDelegate</code>.
+     *
+     * @param verifier the delegated host name verifier.
+     * @param judge the judge verifier
+     */
+    public X509HostNameVerifierCourtRoom(final X509HostnameVerifier verifier, final HostNameVerifier judge)
+    {
+        if (verifier == null)
+        {
+            throw new IllegalArgumentException("The Apache X509 host name verifier is null");
+        }
+        this.verifier = verifier;
+        if (judge == null)
+        {
+            throw new IllegalArgumentException("The host name verifier is null");
+        }
+        this.judge = judge;
+    }
 
-   @Override
-   public void verify(final String host, final String[] cns,
-                      final String[] subjectAlts) throws SSLException
-   {
-      try
-      {
-         verifier.verify(host, cns, subjectAlts);
-      }
-      catch (final SSLException e)
-      {
-         final boolean allow =
-            judge.allowInvalidHostName(host, cns, subjectAlts, e.getMessage());
+    @Override
+    public void verify(final String host, final String[] cns, final String[] subjectAlts) throws SSLException
+    {
+        try
+        {
+            verifier.verify(host, cns, subjectAlts);
+        }
+        catch (final SSLException e)
+        {
+            final boolean allow = judge.allowInvalidHostName(host, cns, subjectAlts, e.getMessage());
 
-         // If the judge sustained the objection, throw the exception.
-         if (!allow)
-         {
-            throw e;
-         }
-      }
-   }
+            // If the judge sustained the objection, throw the exception.
+            if (!allow)
+            {
+                throw e;
+            }
+        }
+    }
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/appl/versions/view/AutoUpdateDialog.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/appl/versions/view/AutoUpdateDialog.java
@@ -48,7 +48,7 @@ public class AutoUpdateDialog extends OptionDialog
 
         boolean automaticUpdate = preferencesRegistry.getPreferences(NewVersionPlugin.class)
                 .getBoolean(AutoUpdatePreferenceKeys.UPDATE_WITHOUT_PROMPT_ENABLED_KEY, false);
-        myAutomaticInstall.set(automaticUpdate);
+        myAutomaticInstall.set(Boolean.valueOf(automaticUpdate));
 
         setTitle(title);
         setComponent(component);

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/authentication/UserInteractionX509TrustManager.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/authentication/UserInteractionX509TrustManager.java
@@ -117,10 +117,14 @@ public final class UserInteractionX509TrustManager extends UserInteractionAuthen
             // Avoid starting up multiple dialogs at a time.
             synchronized (UserInteractionX509TrustManager.class)
             {
-                if (EventQueueUtilities.happyOnEdt(() -> queryUser(chain, authType)))
+                if (EventQueueUtilities.happyOnEdt(() -> queryUser(chain, authType)).booleanValue())
+                {
                     return;
+                }
                 else
+                {
                     throw ex;
+                }
             }
         }
     }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/common/connection/BasicAuthenticationConfiguration.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/common/connection/BasicAuthenticationConfiguration.java
@@ -207,7 +207,7 @@ public class BasicAuthenticationConfiguration implements Cloneable
      * Return username/password from this
      * {@link BasicAuthenticationConfiguration} as a {@link ProxyConfiguration}
      *
-     * @return
+     * @return the proxy configuration
      */
     public ProxyConfiguration getAsProxyConfiguration()
     {

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/common/math/MathUtils.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/common/math/MathUtils.java
@@ -3,13 +3,22 @@ package io.opensphere.core.common.math;
 import java.util.Arrays;
 import java.util.List;
 
+/** Common Math functions. */
+@Deprecated
 public class MathUtils
 {
 
+    /** Constructor. */
     private MathUtils()
     {
     };
 
+    /**
+     * Determines the mean value of a list of numbers.
+     *
+     * @param nums the numbers
+     * @return the mean, or NaN if nums is null or empty
+     */
     public static double mean(List<Double> nums)
     {
         if (nums == null || nums.size() == 0)
@@ -19,11 +28,20 @@ public class MathUtils
         double sum = 0.0;
         for (int i = 0; i < nums.size(); i++)
         {
-            sum += nums.get(i);
+            sum += nums.get(i).doubleValue();
         }
-        return sum / (double)nums.size();
+        return sum / nums.size();
     }
 
+    /**
+     * Determines the median value in a list of numbers.
+     * <p>
+     * The math isn't correct (the median value in an even list is the average
+     * of the two center values) but this isn't used anywhere so who cares.
+     *
+     * @param nums the numbers
+     * @return the median value, or NaN if nums is null or empty
+     */
     public static double median(List<Double> nums)
     {
         if (nums == null || nums.size() == 0)
@@ -33,10 +51,16 @@ public class MathUtils
         Double[] numbers = new Double[nums.size()];
         nums.toArray(numbers);
         Arrays.sort(numbers);
-        int medianIndex = (int)nums.size() / 2;
-        return nums.get(medianIndex);
+        int medianIndex = nums.size() / 2;
+        return numbers[medianIndex].doubleValue();
     }
 
+    /**
+     * Determines the maximum value in a list of numbers.
+     *
+     * @param nums the numbers
+     * @return the maximum value, or NaN if nums is null or empty
+     */
     public static double max(List<Double> nums)
     {
         if (nums == null || nums.size() == 0)
@@ -46,14 +70,21 @@ public class MathUtils
         double max = Double.MIN_VALUE;
         for (int i = 0; i < nums.size(); i++)
         {
-            if (nums.get(i) > max)
+            double cur = nums.get(i).doubleValue();
+            if (cur > max)
             {
-                max = nums.get(i);
+                max = cur;
             }
         }
         return max;
     }
 
+    /**
+     * Determines the minimum value in a list of numbers.
+     *
+     * @param nums the numbers
+     * @return the minimum value, or NaN if nums is null or empty
+     */
     public static double min(List<Double> nums)
     {
         if (nums == null || nums.size() == 0)
@@ -63,14 +94,24 @@ public class MathUtils
         double min = Double.MAX_VALUE;
         for (int i = 0; i < nums.size(); i++)
         {
-            if (nums.get(i) < min)
+            double cur = nums.get(i).doubleValue();
+            if (cur < min)
             {
-                min = nums.get(i);
+                min = cur;
             }
         }
         return min;
     }
 
+    /**
+     * Calculates the distance between two points.
+     *
+     * @param x1 Point 1 X-coordinate
+     * @param y1 Point 1 Y-coordinate
+     * @param x2 Point 2 X-coordinate
+     * @param y2 Point 2 Y-coordinate
+     * @return the straight-line distance
+     */
     public static double distance(int x1, int y1, int x2, int y2)
     {
         int xDist = Math.abs(x1 - x2);

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/common/util/MultiValueHashMap.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/common/util/MultiValueHashMap.java
@@ -779,7 +779,8 @@ public class MultiValueHashMap<KEY_TYPE, VALUE_TYPE> extends AbstractMultiMap<KE
         /* no need to do any checking to see if there's an existing entry here.
          * If it's null, the new entry will just assume there's no entry, and
          * overwrite it. If it is not null, the new entry will store the
-         * existing entry as its next pointer, and overwrite the bucket entry. */
+         * existing entry as its next pointer, and overwrite the bucket
+         * entry. */
         Entry<KEY_TYPE, VALUE_TYPE> existingEntry = table[bucketIndex];
 
         table[bucketIndex] = new Entry<>(pHash, pKey, pValue, existingEntry);
@@ -1443,13 +1444,12 @@ public class MultiValueHashMap<KEY_TYPE, VALUE_TYPE> extends AbstractMultiMap<KE
     @Override
     public Integer size(KEY_TYPE pKey)
     {
-
         Integer returnValue = null;
 
         Entry<KEY_TYPE, VALUE_TYPE> entry = getEntry(pKey);
         if (entry != null && entry.getValue() != null)
         {
-            returnValue = entry.getValue().size();
+            returnValue = Integer.valueOf(entry.getValue().size());
         }
 
         return returnValue;

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/common/util/ReflectionUtils.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/common/util/ReflectionUtils.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+/** Utilities for Java language reflection. */
 public class ReflectionUtils
 {
     /**
@@ -139,7 +140,7 @@ public class ReflectionUtils
      * @param <T> The expected type of the created class.
      *
      * @param className the fully qualified class name.
-     * @param classLoader the {@link ClassLoader} to use when locating the
+     * @param classloader the {@link ClassLoader} to use when locating the
      *            className.
      * @param parameters the constructor arguments or <code>null</code> if none
      *            apply.
@@ -151,7 +152,7 @@ public class ReflectionUtils
         Object instance = null;
         try
         {
-            Class<?> clazz = Class.forName(className, Boolean.TRUE, classloader);
+            Class<?> clazz = Class.forName(className, true, classloader);
             instance = newInstance(clazz, parameters);
         }
         catch (Exception e)
@@ -201,9 +202,10 @@ public class ReflectionUtils
      * Finds a matching constructor for the given class and argument types.
      *
      * @param clazz the instance belongs to this Class
-     * @param parameters the constructor arguments or <code>null</code> if none
-     *            apply. The constructor arguments can include a "null" in place
-     *            of a class if the type couldn't be inferred from the value.
+     * @param parameterTypes the constructor arguments or <code>null</code> if
+     *            none apply. The constructor arguments can include a "null" in
+     *            place of a class if the type couldn't be inferred from the
+     *            value.
      * @return the new instance.
      */
     public static Constructor<?> getConstructor(Class<?> clazz, List<Class<?>> parameterTypes)

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/control/ui/ToolbarComponent.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/control/ui/ToolbarComponent.java
@@ -77,8 +77,8 @@ public class ToolbarComponent implements Comparable<ToolbarComponent>
         {
             return false;
         }
-        return EqualsHelper.equals(myComponent, other.myComponent, myLocation, other.myLocation, myName, other.myName,
-                myUseSeparator, other.myUseSeparator);
+        return EqualsHelper.equals(myComponent, other.myComponent, Integer.valueOf(myLocation), Integer.valueOf(other.myLocation),
+                myName, other.myName, myUseSeparator, other.myUseSeparator);
     }
 
     /**

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/dialog/LoggerDialog.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/dialog/LoggerDialog.java
@@ -191,7 +191,6 @@ public class LoggerDialog extends AbstractInternalFrame
      *
      * @param text The text to search for (case insensitive).
      */
-    @SuppressWarnings("unchecked")
     private void search(String text)
     {
         mySelectedNode = null;

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/GeometryDistributor.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/GeometryDistributor.java
@@ -1407,6 +1407,7 @@ public class GeometryDistributor
 
         if (!foundKey && (myAnimationPlan != null || activeTimeSpans != null))
         {
+            @SuppressWarnings("null")
             final Collection<? extends TimeSpan> timeSpans = myAnimationPlan == null ? activeTimeSpans.getPrimary()
                     : myAnimationPlan.getTimeCoverage();
             foundKey = sortByKeys(keyToGeoms, geom, hull, null, timeSpans);

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/TextureDisposalHelper.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/pipeline/processor/TextureDisposalHelper.java
@@ -131,7 +131,6 @@ public class TextureDisposalHelper implements DisposalHelper
             @Override
             public void handleCacheContentChange(CacheContentEvent<TextureHandle> event)
             {
-                @SuppressWarnings("unchecked")
                 final Collection<? extends TextureHandle> textureHandles = event.getChangedItems();
 
                 ThreadUtilities.runBackground(new Runnable()

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegreesMinutesSeconds.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegreesMinutesSeconds.java
@@ -145,7 +145,8 @@ public final class DegreesMinutesSeconds extends Angle
         {
             degrees = magnitude > 0. ? degrees + 1 : degrees - 1;
         }
-        return String.format(getFormatString(width, precision), degrees, minutes, seconds);
+        return String.format(getFormatString(width, precision), Double.valueOf(degrees), Integer.valueOf(minutes),
+                Double.valueOf(seconds));
     }
 
     /**

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/PausingTimeBudget.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/PausingTimeBudget.java
@@ -6,6 +6,7 @@ package io.opensphere.core.util;
 public class PausingTimeBudget extends TimeBudget
 {
     /** An indefinite time budget. */
+    @SuppressWarnings("hiding")
     public static final PausingTimeBudget INDEFINITE = new PausingTimeBudget(Long.MAX_VALUE, 0L);
 
     /** The time of the pause, if the budget is currently paused. */

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/QuotingBufferedReader.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/QuotingBufferedReader.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 public class QuotingBufferedReader extends Reader
 {
     /** The buffer of characters. */
-    private final char[] myBuffer;
+    private char[] myBuffer;
 
     /** The number of characters read into the buffer. */
     private int myBufferLength;
@@ -57,6 +57,22 @@ public class QuotingBufferedReader extends Reader
         myBuffer = new char[sz];
         myQuotes = quotes == null ? new char[0] : quotes.clone();
         myEscapes = escapes == null ? new char[0] : escapes.clone();
+    }
+
+    /**
+     * Sets the buffer size and resets {@link #myBufferLength} and
+     * {@link #myIndex}.
+     * <p>
+     * This should be used instead of creating a new QuotingBufferedReader when
+     * resetting the wrapped stream.
+     *
+     * @param size the new buffer size
+     */
+    public void setBuffer(int size)
+    {
+        myBuffer = new char[size];
+        myBufferLength = 0;
+        myIndex = 0;
     }
 
     @Override
@@ -202,5 +218,11 @@ public class QuotingBufferedReader extends Reader
         {
             return myBufferLength > myIndex || myReader.ready();
         }
+    }
+
+    @Override
+    public void reset() throws IOException
+    {
+        myReader.reset();
     }
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/collections/New.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/collections/New.java
@@ -1838,7 +1838,6 @@ public final class New
      * @return The new unmodifiable collection, or {@code null} if the input is
      *         {@code null}.
      */
-    @SuppressWarnings({ "unchecked" /* suppresses javac warning */, "cast" })
     public static <T> Collection<? extends T> unmodifiableCollection(Collection<? extends T> col)
     {
         return col == null ? null
@@ -1847,7 +1846,7 @@ public final class New
                                 : col.size() == 1
                                         ? Collections.<T>singletonList(
                                                 col instanceof List ? ((List<? extends T>)col).get(0) : col.iterator().next())
-                                : Collections.unmodifiableCollection(collection(col));
+                                        : Collections.unmodifiableCollection(collection(col));
     }
 
     /**
@@ -1859,7 +1858,6 @@ public final class New
      * @return The new unmodifiable list, or {@code null} if the input is
      *         {@code null}.
      */
-    @SuppressWarnings({ "unchecked" /* suppresses javac warning */, "cast" })
     public static <T> List<T> unmodifiableList(Collection<T> col)
     {
         return col == null ? null
@@ -1868,7 +1866,7 @@ public final class New
                                 : col.size() == 1
                                         ? Collections.<T>singletonList(
                                                 col instanceof List ? ((List<? extends T>)col).get(0) : col.iterator().next())
-                                : Collections.unmodifiableList(list(col));
+                                        : Collections.unmodifiableList(list(col));
     }
 
     /**
@@ -1912,7 +1910,6 @@ public final class New
      * @return The new unmodifiable set, or {@code null} if the input is
      *         {@code null}.
      */
-    @SuppressWarnings({ "unchecked" /* suppresses javac warning */, "cast" })
     public static <T> Set<? extends T> unmodifiableSet(Collection<? extends T> col)
     {
         return col == null ? null
@@ -1921,7 +1918,7 @@ public final class New
                                 : col.size() == 1
                                         ? Collections.<T>singleton(
                                                 col instanceof List ? ((List<? extends T>)col).get(0) : col.iterator().next())
-                                : Collections.unmodifiableSet(set(col));
+                                        : Collections.unmodifiableSet(set(col));
     }
 
     /**

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/collections/TroveUtilities.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/collections/TroveUtilities.java
@@ -212,7 +212,7 @@ public final class TroveUtilities
     public static List<Long> toLongList(TLongCollection tList)
     {
         List<Long> list = New.list(tList.size());
-        tList.forEach(value -> list.add(value));
+        tList.forEach(value -> list.add(Long.valueOf(value)));
         return list;
     }
 
@@ -226,7 +226,7 @@ public final class TroveUtilities
     {
         final float loadFactor = .75f;
         Set<Long> list = New.set(Math.max((int)(tList.size() / loadFactor) + 1, 16));
-        tList.forEach(value -> list.add(value));
+        tList.forEach(value -> list.add(Long.valueOf(value)));
         return list;
     }
 

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/concurrent/InterruptingExecutor.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/concurrent/InterruptingExecutor.java
@@ -132,6 +132,7 @@ public class InterruptingExecutor implements ScheduledExecutorService
         return ((ScheduledExecutorService)myExecutor).schedule((Callable<V>)new Interruptible<V>(callable), delay, unit);
     }
 
+    @SuppressWarnings("cast")
     @Override
     public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit)
     {
@@ -191,6 +192,7 @@ public class InterruptingExecutor implements ScheduledExecutorService
         return ((ExecutorService)myExecutor).submit((Callable<T>)new Interruptible<T>(task));
     }
 
+    @SuppressWarnings("cast")
     @Override
     public Future<?> submit(Runnable task)
     {

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/concurrent/ThreadedStateMachine.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/concurrent/ThreadedStateMachine.java
@@ -910,7 +910,6 @@ public class ThreadedStateMachine<E>
      * @param toState The destination state.
      * @return A map of origin states to moving objects in those states.
      */
-    @SuppressWarnings("null")
     private Map<State, Collection<E>> determineMovingObjects(Collection<? extends E> objects, State fromState, State toState)
     {
         Map<State, Collection<E>> movingObjects = New.map();

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/AutoCompleteComboBoxListener.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/AutoCompleteComboBoxListener.java
@@ -12,6 +12,7 @@ import javafx.scene.input.KeyEvent;
  *
  * @param <T> The type in the combo box.
  */
+@Deprecated
 public class AutoCompleteComboBoxListener<T> implements EventHandler<KeyEvent>
 {
     /**
@@ -48,7 +49,7 @@ public class AutoCompleteComboBoxListener<T> implements EventHandler<KeyEvent>
         myComboBox.setEditable(true);
         myComboBox.setValue(value);
         myComboBox.setOnKeyPressed(e -> comboBox.hide());
-        myComboBox.setOnKeyReleased(AutoCompleteComboBoxListener.this);
+        myComboBox.setOnKeyReleased(this);
     }
 
     @Override

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/FXUtilities.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/FXUtilities.java
@@ -1,7 +1,5 @@
 package io.opensphere.core.util.fx;
 
-import static io.opensphere.core.util.lang.NumberUtilities.toFloat;
-
 import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.text.DecimalFormat;
@@ -463,8 +461,8 @@ public final class FXUtilities
 
         if (color != null)
         {
-            awtColor = new java.awt.Color(toFloat(color.getRed()), toFloat(color.getGreen()), toFloat(color.getBlue()),
-                    toFloat(color.getOpacity()));
+            awtColor = new java.awt.Color((float)color.getRed(), (float)color.getGreen(), (float)color.getBlue(),
+                    (float)color.getOpacity());
         }
         else
         {

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/FxIcons.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/FxIcons.java
@@ -10,7 +10,6 @@ import javafx.scene.paint.Color;
  * A container in which the icons from the font-awesome package are presented
  * for use.
  */
-@SuppressWarnings("restriction")
 public final class FxIcons
 {
     /**

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/NewAutoCompleteComboBoxListener.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/NewAutoCompleteComboBoxListener.java
@@ -1,0 +1,106 @@
+package io.opensphere.core.util.fx;
+
+import org.apache.commons.lang3.StringUtils;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.event.EventHandler;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
+
+/**
+ * Enables a javafx {@link ComboBox} to be auto completed as user types.
+ *
+ * @see AutoCompleteComboBoxListener
+ */
+public class NewAutoCompleteComboBoxListener implements EventHandler<KeyEvent>
+{
+    /** The original data. */
+    private ObservableList<? extends Object> myOriginalData;
+
+    /**
+     * Updates a ComboBox to handle KeyPressed and KeyReleased events using this
+     * Listener.
+     *
+     * @param comboBox the box
+     */
+    public void setupComboBox(final ComboBox<? extends Object> comboBox)
+    {
+        comboBox.setEditable(true);
+        comboBox.setOnKeyPressed(evt -> comboBox.hide());
+        comboBox.setOnKeyReleased(this);
+
+        myOriginalData = comboBox.getItems();
+    }
+
+    @Override
+    public void handle(KeyEvent event)
+    {
+        Object eventSource = event.getSource();
+        if (!(eventSource instanceof ComboBox<?>))
+        {
+            return;
+        }
+
+        @SuppressWarnings("unchecked")
+        ComboBox<Object> source = (ComboBox<Object>)eventSource;
+        TextField editor = source.getEditor();
+        String txt = editor.getText();
+
+        int caretPosition = -1;
+        switch (event.getCode())
+        {
+            case BACK_SPACE:
+            case DELETE:
+                caretPosition = txt.length();
+                break;
+            case DOWN:
+                show(source);
+            case UP:
+                moveCaret(editor, txt.length(), caretPosition);
+            default:
+                return;
+        }
+
+        ObservableList<Object> list = FXCollections.observableArrayList();
+        myOriginalData.stream().filter(item -> StringUtils.containsIgnoreCase(item.toString(), txt))
+                .forEach(item -> list.add(item));
+
+        source.setItems(list);
+        editor.setText(txt);
+
+        moveCaret(editor, txt.length(), caretPosition);
+
+        if (!list.isEmpty())
+        {
+            show(source);
+        }
+    }
+
+    /**
+     * Moves the caret.
+     *
+     * @param editor the text editot
+     * @param textLength the length of the text
+     * @param caretPosition where to position the caret in the editor; the end
+     *            if -1
+     */
+    private void moveCaret(TextField editor, int textLength, int caretPosition)
+    {
+        editor.positionCaret(caretPosition == -1 ? textLength : caretPosition);
+    }
+
+    /**
+     * Makes a ComboBox visible if it isn't already.
+     *
+     * @param source the box
+     */
+    private void show(ComboBox<?> source)
+    {
+        if (!source.isShowing())
+        {
+            source.show();
+        }
+    }
+}

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/PercentageTableColumn.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/PercentageTableColumn.java
@@ -12,7 +12,7 @@ import javafx.scene.control.TableColumn;
 /**
  * A simple extension of the table column to add the ability to specify column
  * width as a percentage of the table width, rather than as a fixed value.
- * 
+ *
  * @param <S> The type of the TableView generic type (i.e. S ==
  *            TableView&lt;S&gt;)
  * @param <T> The type of the content in all cells in this TableColumn.
@@ -20,7 +20,7 @@ import javafx.scene.control.TableColumn;
 public class PercentageTableColumn<S, T> extends TableColumn<S, T>
 {
     /** The property in which the width is stored as a percentage. */
-    private DoubleProperty percentageWidth = new SimpleDoubleProperty();
+    private final DoubleProperty percentageWidth = new SimpleDoubleProperty();
 
     /**
      * Creates a new table column.
@@ -37,7 +37,7 @@ public class PercentageTableColumn<S, T> extends TableColumn<S, T>
         tableViewProperty().addListener((observable, oldValue, newValue) ->
         {
             ReadOnlyDoubleProperty tableWidth = getTableView().widthProperty();
-            this.prefWidthProperty().bind(createPercentageWidthBinding(tableWidth));
+            prefWidthProperty().bind(createPercentageWidthBinding(tableWidth));
         });
     }
 
@@ -54,19 +54,19 @@ public class PercentageTableColumn<S, T> extends TableColumn<S, T>
             // If the user doesn't define the percentage
             if (percentageWidth.get() <= 0)
             {
-                return getWidth();
+                return Double.valueOf(getWidth());
             }
             else
             {
                 double tableWidthDouble = tableWidth.get();
-                return percentageWidth.get() * tableWidthDouble;
+                return Double.valueOf(percentageWidth.get() * tableWidthDouble);
             }
         }, percentageWidth, tableWidth);
     }
 
     /**
      * Gets the width of the column, expressed as a percentage.
-     * 
+     *
      * @return the width of the column, expressed as a percentage.
      */
     public double getPercentageWidth()
@@ -76,7 +76,7 @@ public class PercentageTableColumn<S, T> extends TableColumn<S, T>
 
     /**
      * Sets the width of the column, as a percentage.
-     * 
+     *
      * @param percentageWidth the width of the column, as a percentage.
      */
     public void setPercentageWidth(double percentageWidth)
@@ -86,7 +86,7 @@ public class PercentageTableColumn<S, T> extends TableColumn<S, T>
 
     /**
      * Gets the property in which the width is bound.
-     * 
+     *
      * @return the width property.
      */
     public DoubleProperty percentageWidthProperty()

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/io/StreamReader.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/io/StreamReader.java
@@ -142,7 +142,7 @@ public class StreamReader implements Reader
                 newBuffer = ByteBuffer.allocate(bufferSize);
                 if (result != null)
                 {
-                    newBuffer.put((ByteBuffer)result.rewind());
+                    newBuffer.put(result.rewind());
                 }
                 result = newBuffer;
             }
@@ -159,7 +159,7 @@ public class StreamReader implements Reader
         }
         while (lastReadLength >= 0 && (myContentLength < 0 || result.limit() < myContentLength));
 
-        return (ByteBuffer)result.flip();
+        return result.flip();
     }
 
     /**

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/javafx/input/CompoundTitledControl.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/javafx/input/CompoundTitledControl.java
@@ -3,6 +3,8 @@ package io.opensphere.core.util.javafx.input;
 import java.util.Arrays;
 import java.util.List;
 
+import io.opensphere.core.util.Visitable;
+import io.opensphere.core.util.Visitor;
 import javafx.geometry.HPos;
 import javafx.geometry.Orientation;
 import javafx.geometry.VPos;
@@ -13,14 +15,14 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 
-import io.opensphere.core.util.Visitable;
-import io.opensphere.core.util.Visitor;
-
 /**
- * Defines a control which wraps other controls. The set of child controls is arranged according to the orientation supplied with
- * the controls.If no controls are supplied in the <code>pControls</code> variable argument array during instantiation, then the
- * caller may supply the controls one time to the {@link #setControls(Orientation, boolean, IdentifiedControl...)} method. In either
- * case, the class is immutable, and controls may not be changed once they have been set.
+ * Defines a control which wraps other controls. The set of child controls is
+ * arranged according to the orientation supplied with the controls.If no
+ * controls are supplied in the <code>pControls</code> variable argument array
+ * during instantiation, then the caller may supply the controls one time to the
+ * {@link #setControls(Orientation, boolean, IdentifiedControl...)} method. In
+ * either case, the class is immutable, and controls may not be changed once
+ * they have been set.
  */
 public class CompoundTitledControl extends TitledControl
 {
@@ -35,19 +37,24 @@ public class CompoundTitledControl extends TitledControl
     private Node myNode;
 
     /**
-     * Creates a new compound control, in which multiple child controls are contained. The orientation of the child controls is
-     * determined from the supplied orientation. If no controls are supplied in the <code>pControls</code> variable argument
-     * array, then the caller may supply the controls one time to the {@link #setControls(Orientation, boolean, IdentifiedControl...)}
-     * method.
+     * Creates a new compound control, in which multiple child controls are
+     * contained. The orientation of the child controls is determined from the
+     * supplied orientation. If no controls are supplied in the
+     * <code>pControls</code> variable argument array, then the caller may
+     * supply the controls one time to the
+     * {@link #setControls(Orientation, boolean, IdentifiedControl...)} method.
      *
-     * @param pTitle the title of the compound control, which will be displayed in a center left position for vertical
-     *            orientation.
+     * @param pTitle the title of the compound control, which will be displayed
+     *            in a center left position for vertical orientation.
      * @param pOrientation the layout of the child controls.
-     * @param pShowSubtitles if true, the title of each child control will be displayed to the left of the child control, if
-     *            false, the titles of the child controls will be omitted.
-     * @param pControls the optional set of controls to encapsulate within the compound control.
+     * @param pShowSubtitles if true, the title of each child control will be
+     *            displayed to the left of the child control, if false, the
+     *            titles of the child controls will be omitted.
+     * @param pControls the optional set of controls to encapsulate within the
+     *            compound control.
      */
-    public CompoundTitledControl(String pTitle, Orientation pOrientation, boolean pShowSubtitles, IdentifiedControl<?>... pControls)
+    public CompoundTitledControl(String pTitle, Orientation pOrientation, boolean pShowSubtitles,
+            IdentifiedControl<?>... pControls)
     {
         super(pTitle);
 
@@ -62,7 +69,8 @@ public class CompoundTitledControl extends TitledControl
     /**
      * Sets the style of the internal node to the supplied value.
      *
-     * @param pStyle The inline CSS style to use for this Node. <code>null</code> is implicitly converted to an empty String.
+     * @param pStyle The inline CSS style to use for this Node.
+     *            <code>null</code> is implicitly converted to an empty String.
      */
     protected void setNodeStyle(String pStyle)
     {
@@ -70,15 +78,19 @@ public class CompoundTitledControl extends TitledControl
     }
 
     /**
-     * Sets the set of controls within the compound control. The orientation of the child controls is determined from the supplied
-     * orientation. If the controls have already been set (the {@link #myControls} field is not null), then an
-     * {@link UnsupportedOperationException} is thrown.
+     * Sets the set of controls within the compound control. The orientation of
+     * the child controls is determined from the supplied orientation. If the
+     * controls have already been set (the {@link #myControls} field is not
+     * null), then an {@link UnsupportedOperationException} is thrown.
      *
      * @param pOrientation the layout of the child controls.
-     * @param pShowSubtitles if true, the title of each child control will be displayed to the left of the child control, if
-     *            false, the titles of the child controls will be omitted.
-     * @param pControls the optional set of controls to encapsulate within the compound control.
-     * @throws UnsupportedOperationException if the controls have already been set.
+     * @param pShowSubtitles if true, the title of each child control will be
+     *            displayed to the left of the child control, if false, the
+     *            titles of the child controls will be omitted.
+     * @param pControls the optional set of controls to encapsulate within the
+     *            compound control.
+     * @throws UnsupportedOperationException if the controls have already been
+     *             set.
      */
     protected void setControls(Orientation pOrientation, boolean pShowSubtitles, IdentifiedControl<?>... pControls)
     {
@@ -102,14 +114,18 @@ public class CompoundTitledControl extends TitledControl
     }
 
     /**
-     * Creates a {@link Node} in which the child components are laid out. This node does not include the compound control's title,
-     * as the title is usually handled by the caller in a separate controller. If <code>pShowSubtitles</code> is true, the box
-     * will be created as a grid, with labels containing the title of each child component shown on the left column of the row,
-     * and the corresponding child component shown in the right column of the row. If <code>pShowSubtitles</code> is true, the box
-     * is merely a vertical box containing each of the controls.
+     * Creates a {@link Node} in which the child components are laid out. This
+     * node does not include the compound control's title, as the title is
+     * usually handled by the caller in a separate controller. If
+     * <code>pShowSubtitles</code> is true, the box will be created as a grid,
+     * with labels containing the title of each child component shown on the
+     * left column of the row, and the corresponding child component shown in
+     * the right column of the row. If <code>pShowSubtitles</code> is true, the
+     * box is merely a vertical box containing each of the controls.
      *
-     * @param pShowSubtitles if true, the title of each child control will be displayed to the left of the child control, if
-     *            false, the titles of the child controls will be omitted.
+     * @param pShowSubtitles if true, the title of each child control will be
+     *            displayed to the left of the child control, if false, the
+     *            titles of the child controls will be omitted.
      * @param pControls the set of controls to include in the vertical box.
      * @return a Node in which the child controls are rendered.
      */
@@ -126,7 +142,7 @@ public class CompoundTitledControl extends TitledControl
                 grid.addRow(rowNumber++, label, wpsControl);
                 GridPane.setHalignment(label, HPos.RIGHT);
                 GridPane.setHalignment(wpsControl, HPos.RIGHT);
-                GridPane.setFillWidth(wpsControl, true);
+                GridPane.setFillWidth(wpsControl, Boolean.TRUE);
             }
             return grid;
         }
@@ -134,14 +150,18 @@ public class CompoundTitledControl extends TitledControl
     }
 
     /**
-     * Creates a {@link Node} in which the child components are laid out. This node does not include the compound control's title,
-     * as the title is usually handled by the caller in a separate controller. If <code>pShowSubtitles</code> is true, the box
-     * will be created as a grid, with labels containing the title of each child component shown on the top row of the column, and
-     * the corresponding child component shown in the bottom row of column. If <code>pShowSubtitles</code> is true, the box is
+     * Creates a {@link Node} in which the child components are laid out. This
+     * node does not include the compound control's title, as the title is
+     * usually handled by the caller in a separate controller. If
+     * <code>pShowSubtitles</code> is true, the box will be created as a grid,
+     * with labels containing the title of each child component shown on the top
+     * row of the column, and the corresponding child component shown in the
+     * bottom row of column. If <code>pShowSubtitles</code> is true, the box is
      * merely a horizontal box containing each of the controls.
      *
-     * @param pShowSubtitles if true, the title of each child control will be displayed to above the child control, if false, the
-     *            titles of the child controls will be omitted.
+     * @param pShowSubtitles if true, the title of each child control will be
+     *            displayed to above the child control, if false, the titles of
+     *            the child controls will be omitted.
      * @param pControls the set of controls to include in the vertical box.
      * @return a Node in which the child controls are rendered.
      */

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/javafx/input/DateTimeRangeInput.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/javafx/input/DateTimeRangeInput.java
@@ -7,6 +7,10 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 
+import io.opensphere.core.Toolbox;
+import io.opensphere.core.model.time.TimeSpan;
+import io.opensphere.core.util.Visitor;
+import io.opensphere.core.util.javafx.input.view.CombinedDateTimePicker;
 import javafx.collections.FXCollections;
 import javafx.geometry.HPos;
 import javafx.geometry.Orientation;
@@ -17,19 +21,15 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
 
-import io.opensphere.core.Toolbox;
-import io.opensphere.core.model.time.TimeSpan;
-import io.opensphere.core.util.Visitor;
-import io.opensphere.core.util.javafx.input.view.CombinedDateTimePicker;
-
 /**
- * A specialized {@link CompoundTitledControl} in which a preset combo box, and paired start and end date time pickers are
- * contained.
+ * A specialized {@link CompoundTitledControl} in which a preset combo box, and
+ * paired start and end date time pickers are contained.
  */
 public class DateTimeRangeInput extends CompoundTitledControl
 {
     /**
-     * The preset used when a user manually enters a date / time in either of the pickers.
+     * The preset used when a user manually enters a date / time in either of
+     * the pickers.
      */
     private static final String CUSTOM_PRESET = "-- Custom --";
 
@@ -54,8 +54,9 @@ public class DateTimeRangeInput extends CompoundTitledControl
     private final Toolbox myToolbox;
 
     /**
-     * A flag used to determine if the preset selector caused the change, and if so, allows change handlers to not react to value
-     * changes within the picker.
+     * A flag used to determine if the preset selector caused the change, and if
+     * so, allows change handlers to not react to value changes within the
+     * picker.
      */
     private boolean myPresetCausedChanged;
 
@@ -104,8 +105,10 @@ public class DateTimeRangeInput extends CompoundTitledControl
     /**
      * Creates a new {@link DateTimeRangeInput} using the supplied parameters.
      *
-     * @param pTitle the display title of the component to be displayed on the form.
-     * @param pStartControl the identified control to use for the start input field.
+     * @param pTitle the display title of the component to be displayed on the
+     *            form.
+     * @param pStartControl the identified control to use for the start input
+     *            field.
      * @param pEndControl the identified control to use for the end input field.
      * @param pToolbox the toolbox through which the time manager is referenced.
      */
@@ -160,7 +163,7 @@ public class DateTimeRangeInput extends CompoundTitledControl
                 if (rowNumber > 0)
                 {
                     GridPane.setHalignment(wpsControl, HPos.RIGHT);
-                    GridPane.setFillWidth(wpsControl, true);
+                    GridPane.setFillWidth(wpsControl, Boolean.TRUE);
                 }
                 rowNumber++;
             }
@@ -170,8 +173,9 @@ public class DateTimeRangeInput extends CompoundTitledControl
     }
 
     /**
-     * An event handler method used to react to a value change in either of the date / time pickers. This allows for the preset
-     * {@link ComboBox}'s selected item to be changed to {@link #CUSTOM_PRESET}.
+     * An event handler method used to react to a value change in either of the
+     * date / time pickers. This allows for the preset {@link ComboBox}'s
+     * selected item to be changed to {@link #CUSTOM_PRESET}.
      */
     protected void valueChanged()
     {
@@ -182,7 +186,8 @@ public class DateTimeRangeInput extends CompoundTitledControl
     }
 
     /**
-     * An event handler method used to react to the selection of a choice within the preset selector.
+     * An event handler method used to react to the selection of a choice within
+     * the preset selector.
      *
      * @param pPresetType The preset value selected by the user.
      */
@@ -253,7 +258,8 @@ public class DateTimeRangeInput extends CompoundTitledControl
     /**
      * Convenience method used to get the start of the current week.
      *
-     * @return a {@link LocalDateTime} instance representing the preceding Sunday of the current week.
+     * @return a {@link LocalDateTime} instance representing the preceding
+     *         Sunday of the current week.
      */
     protected LocalDateTime getStartOfCurrentWeek()
     {
@@ -266,12 +272,16 @@ public class DateTimeRangeInput extends CompoundTitledControl
     }
 
     /**
-     * Adjusts the date / time pickers by the supplied offset. The offset direction is determined by the sign of the supplied
-     * offset. For example to adjust backwards by 24 hours, supply the offset parameter with -24, and the type parameter with
-     * {@link ChronoUnit#HOURS}. Likewise, to adjust forward by 24 hours, supply the offset parameter with 24 and the type
-     * parameter with {@link ChronoUnit#HOURS}. If the offset is negative, the method assumes the current date / time for the end
-     * time, and adjusts the start time by the offset. If the offset is positive, the method assumes the current date / time for
-     * the start time, and adjusts the end time by the offset.
+     * Adjusts the date / time pickers by the supplied offset. The offset
+     * direction is determined by the sign of the supplied offset. For example
+     * to adjust backwards by 24 hours, supply the offset parameter with -24,
+     * and the type parameter with {@link ChronoUnit#HOURS}. Likewise, to adjust
+     * forward by 24 hours, supply the offset parameter with 24 and the type
+     * parameter with {@link ChronoUnit#HOURS}. If the offset is negative, the
+     * method assumes the current date / time for the end time, and adjusts the
+     * start time by the offset. If the offset is positive, the method assumes
+     * the current date / time for the start time, and adjusts the end time by
+     * the offset.
      *
      * @param offset the amount by which to offset the picker.
      * @param type the units by which to adjust.
@@ -283,12 +293,16 @@ public class DateTimeRangeInput extends CompoundTitledControl
     }
 
     /**
-     * Adjusts the date / time pickers by the supplied offset. The offset direction is determined by the sign of the supplied
-     * offset. For example to adjust backwards by 24 hours, supply the offset parameter with -24, and the type parameter with
-     * {@link ChronoUnit#HOURS}. Likewise, to adjust forward by 24 hours, supply the offset parameter with 24 and the type
-     * parameter with {@link ChronoUnit#HOURS}. If the offset is negative, the method uses the supplied base date / time for the
-     * end time, and adjusts the start time by the offset. If the offset is positive, the method uses the supplied base date /
-     * time for the start time, and adjusts the end time by the offset.
+     * Adjusts the date / time pickers by the supplied offset. The offset
+     * direction is determined by the sign of the supplied offset. For example
+     * to adjust backwards by 24 hours, supply the offset parameter with -24,
+     * and the type parameter with {@link ChronoUnit#HOURS}. Likewise, to adjust
+     * forward by 24 hours, supply the offset parameter with 24 and the type
+     * parameter with {@link ChronoUnit#HOURS}. If the offset is negative, the
+     * method uses the supplied base date / time for the end time, and adjusts
+     * the start time by the offset. If the offset is positive, the method uses
+     * the supplied base date / time for the start time, and adjusts the end
+     * time by the offset.
      *
      * @param pBaseTime the time from which adjustments are made.
      * @param offset the amount by which to offset the picker.

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/javafx/input/view/AbstractComboBoxSkin.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/javafx/input/view/AbstractComboBoxSkin.java
@@ -12,7 +12,8 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 
 /**
- * An abstract base class for custom editable combo boxes, with a display node and custom popup.
+ * An abstract base class for custom editable combo boxes, with a display node
+ * and custom popup.
  *
  * @param <T> The datatype contained within the combo box.
  */
@@ -24,7 +25,8 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     private static final int DEFAULT_EDITOR_HEIGHT = 21;
 
     /**
-     * The content area in which the value is displayed when the popup is not shown.
+     * The content area in which the value is displayed when the popup is not
+     * shown.
      */
     private Node myDisplayNode;
 
@@ -34,7 +36,8 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     private final StackPane myPopupLauncher;
 
     /**
-     * The component in which the graphic is displayed. This is used as the {@link StackPane}'s graphic.
+     * The component in which the graphic is displayed. This is used as the
+     * {@link StackPane}'s graphic.
      */
     private final Region myIcon;
 
@@ -86,21 +89,23 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     }
 
     /**
-     * This method should return a Node that will be positioned within the ComboBox 'button' area.
+     * This method should return a Node that will be positioned within the
+     * ComboBox 'button' area.
      *
      * @return the component used as the display / editor node.
      */
     public abstract Node getDisplayNode();
 
     /**
-     * This method will be called when the ComboBox popup should be displayed. It is up to specific skin implementations to
-     * determine how this is handled.
+     * This method will be called when the ComboBox popup should be displayed.
+     * It is up to specific skin implementations to determine how this is
+     * handled.
      */
     public abstract void show();
 
     /**
-     * This method will be called when the ComboBox popup should be hidden. It is up to specific skin implementations to determine
-     * how this is handled.
+     * This method will be called when the ComboBox popup should be hidden. It
+     * is up to specific skin implementations to determine how this is handled.
      */
     public abstract void hide();
 
@@ -117,12 +122,14 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     /**
      * {@inheritDoc}
      *
-     * @see javafx.scene.control.SkinBase#layoutChildren(double, double, double, double)
+     * @see javafx.scene.control.SkinBase#layoutChildren(double, double, double,
+     *      double)
      */
     @Override
     protected void layoutChildren(double pContentX, double pContentY, double pContentWidth, double pContentHeight)
     {
-        // if the display / editor node hasn't been initialized, take care of that now:
+        // if the display / editor node hasn't been initialized, take care of
+        // that now:
         if (myDisplayNode == null)
         {
             updateDisplayArea();
@@ -143,8 +150,10 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     }
 
     /**
-     * This method lazily initializes the display node, updating it from the implementing subclass. This also allows for the
-     * editable state of the editor to be changed at runtime, and for the display node to be changed by the subclass.
+     * This method lazily initializes the display node, updating it from the
+     * implementing subclass. This also allows for the editable state of the
+     * editor to be changed at runtime, and for the display node to be changed
+     * by the subclass.
      */
     protected void updateDisplayArea()
     {
@@ -168,7 +177,8 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     /**
      * {@inheritDoc}
      *
-     * @see javafx.scene.control.SkinBase#computePrefWidth(double, double, double, double, double)
+     * @see javafx.scene.control.SkinBase#computePrefWidth(double, double,
+     *      double, double, double)
      */
     @Override
     protected double computePrefWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset)
@@ -189,7 +199,8 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     /**
      * {@inheritDoc}
      *
-     * @see javafx.scene.control.SkinBase#computePrefHeight(double, double, double, double, double)
+     * @see javafx.scene.control.SkinBase#computePrefHeight(double, double,
+     *      double, double, double)
      */
     @Override
     protected double computePrefHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset)
@@ -216,7 +227,8 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     /**
      * {@inheritDoc}
      *
-     * @see javafx.scene.control.SkinBase#computeMaxWidth(double, double, double, double, double)
+     * @see javafx.scene.control.SkinBase#computeMaxWidth(double, double,
+     *      double, double, double)
      */
     @Override
     protected double computeMaxWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset)
@@ -227,7 +239,8 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     /**
      * {@inheritDoc}
      *
-     * @see javafx.scene.control.SkinBase#computeMaxHeight(double, double, double, double, double)
+     * @see javafx.scene.control.SkinBase#computeMaxHeight(double, double,
+     *      double, double, double)
      */
     @Override
     protected double computeMaxHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset)
@@ -238,7 +251,8 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     /**
      * {@inheritDoc}
      *
-     * @see javafx.scene.control.SkinBase#computeBaselineOffset(double, double, double, double)
+     * @see javafx.scene.control.SkinBase#computeBaselineOffset(double, double,
+     *      double, double)
      */
     @Override
     protected double computeBaselineOffset(double topInset, double rightInset, double bottomInset, double leftInset)
@@ -257,22 +271,23 @@ public abstract class AbstractComboBoxSkin<T> extends AbstractBehaviorSkin<Combo
     }
 
     /**
-     * An event handler method used to handle a focus change. When the focus is lost, the {@link #handleFocusLoss()} method is
-     * called.
+     * An event handler method used to handle a focus change. When the focus is
+     * lost, the {@link #handleFocusLoss()} method is called.
      *
      * @param pFocused true if the focus was gained, false otherwise.
      */
     protected void focusChanged(Boolean pFocused)
     {
-        if (!pFocused)
+        if (!pFocused.booleanValue())
         {
             handleFocusLoss();
         }
     }
 
     /**
-     * An overridable focus handler method in which the skin handles the loss of focus. The default implementation hides the
-     * underlying {@link Skinnable} component.
+     * An overridable focus handler method in which the skin handles the loss of
+     * focus. The default implementation hides the underlying {@link Skinnable}
+     * component.
      */
     protected void handleFocusLoss()
     {

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/javafx/input/view/BoundNumericSpinner.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/javafx/input/view/BoundNumericSpinner.java
@@ -14,9 +14,11 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 
 /**
- * A stylized spinner, in which the up and down arrows are presented above and below the content area, respectively. This spinner
- * was developed for use in the time picker, to allow for each component of a clock to be spun independently. The component was
- * developed generically to allow for any numeric values to be represented.
+ * A stylized spinner, in which the up and down arrows are presented above and
+ * below the content area, respectively. This spinner was developed for use in
+ * the time picker, to allow for each component of a clock to be spun
+ * independently. The component was developed generically to allow for any
+ * numeric values to be represented.
  */
 public class BoundNumericSpinner extends VBox
 {
@@ -66,7 +68,8 @@ public class BoundNumericSpinner extends VBox
     private final IntegerProperty myValue;
 
     /**
-     * Creates a new numeric spinner, with the a minimum value of zero, and a maximum value of the supplied value.
+     * Creates a new numeric spinner, with the a minimum value of zero, and a
+     * maximum value of the supplied value.
      *
      * @param pMaxValue the maximum value of the spinner.
      */
@@ -129,9 +132,10 @@ public class BoundNumericSpinner extends VBox
     }
 
     /**
-     * Validates the supplied value. This method is used as an event handler, and is called when the {@link #myContent} field
-     * changes. This method has a side-effect of resetting the value of the {@link #myContent} field to the old value if the new
-     * value fails validation.
+     * Validates the supplied value. This method is used as an event handler,
+     * and is called when the {@link #myContent} field changes. This method has
+     * a side-effect of resetting the value of the {@link #myContent} field to
+     * the old value if the new value fails validation.
      *
      * @param pObservable the item that triggered the event.
      * @param pOldValue the original value of the field before it was changed.
@@ -156,7 +160,7 @@ public class BoundNumericSpinner extends VBox
                 }
                 else
                 {
-                    myContent.textProperty().set(String.format("%02d", value));
+                    myContent.textProperty().set(String.format("%02d", Integer.valueOf(value)));
                 }
             }
         }
@@ -179,12 +183,13 @@ public class BoundNumericSpinner extends VBox
      */
     public void set(int pValue)
     {
-        myContent.textProperty().set(String.format("%02d", pValue));
+        myContent.textProperty().set(String.format("%02d", Integer.valueOf(pValue)));
         myValue.set(pValue);
     }
 
     /**
-     * Adjusts the value of the spinner, and fires off notification through the {@link #myValue} property.
+     * Adjusts the value of the spinner, and fires off notification through the
+     * {@link #myValue} property.
      */
     public void increment()
     {
@@ -193,12 +198,13 @@ public class BoundNumericSpinner extends VBox
         {
             value -= myFieldSpan;
         }
-        myContent.textProperty().set(String.format("%02d", value));
+        myContent.textProperty().set(String.format("%02d", Integer.valueOf(value)));
         myValue.set(value);
     }
 
     /**
-     * Adjusts the value of the spinner, and fires off notification through the {@link #myValue} property.
+     * Adjusts the value of the spinner, and fires off notification through the
+     * {@link #myValue} property.
      */
     public void decrement()
     {
@@ -207,7 +213,7 @@ public class BoundNumericSpinner extends VBox
         {
             value += myFieldSpan;
         }
-        myContent.textProperty().set(String.format("%02d", value));
+        myContent.textProperty().set(String.format("%02d", Integer.valueOf(value)));
         myValue.set(value);
     }
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/javafx/input/view/TimePickerContent.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/javafx/input/view/TimePickerContent.java
@@ -114,7 +114,8 @@ public class TimePickerContent extends VBox
         int minutes = myMinuteSpinner.value().get();
         int seconds = mySecondSpinner.value().get();
 
-        String value = String.format("%1$02d:%2$02d:%3$02d", hours, minutes, seconds);
+        String value = String.format("%1$02d:%2$02d:%3$02d", Integer.valueOf(hours), Integer.valueOf(minutes),
+                Integer.valueOf(seconds));
         LocalTime time = myTimePicker.getConverter().fromString(value);
         myTimePicker.setValue(time);
         myTimePicker.hide();

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/net/UrlUtilities.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/net/UrlUtilities.java
@@ -93,7 +93,7 @@ public final class UrlUtilities
             host = host.substring(0, portIndex);
         }
 
-        return new ThreeTuple<>(protocol, host, rtmpPort);
+        return new ThreeTuple<>(protocol, host, Integer.valueOf(rtmpPort));
     }
 
     /**

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/predicate/AndPredicate.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/predicate/AndPredicate.java
@@ -32,7 +32,6 @@ public class AndPredicate<T> implements Predicate<T>
      * @param arg1 The first predicate.
      * @param arg2 The second predicate.
      */
-    @SuppressWarnings("unchecked")
     public AndPredicate(Predicate<? super T> arg1, Predicate<? super T> arg2)
     {
         this(Arrays.<Predicate<? super T>>asList(arg1, arg2));

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/ExtendedComboPopup.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/ExtendedComboPopup.java
@@ -26,6 +26,7 @@ public class ExtendedComboPopup extends BasicComboPopup
      *
      * @param combo The combo box.
      */
+    @SuppressWarnings("unchecked")
     public ExtendedComboPopup(ExtendedComboBox<?> combo)
     {
         super((JComboBox<Object>)combo);

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/input/controller/ControllerFactory.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/input/controller/ControllerFactory.java
@@ -146,7 +146,6 @@ public final class ControllerFactory
     public static <T, U extends JComponent> AbstractController<T, ? extends ViewModel<T>, U> createController(ViewModel<T> model,
             Class<U> preferredComponent, ViewSettings<T> viewSettings)
     {
-        @SuppressWarnings("unchecked")
         AbstractController<T, ? extends ViewModel<T>, U> castController = createControllerDetached(model, preferredComponent,
                 viewSettings);
 

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/input/model/WrappedModel.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/input/model/WrappedModel.java
@@ -100,7 +100,7 @@ public abstract class WrappedModel<T> extends StrongObservableValue<T> implement
     }
 
     @Override
-    public String getErrorMessage()
+    public synchronized String getErrorMessage()
     {
         String firstError = null;
 
@@ -136,7 +136,7 @@ public abstract class WrappedModel<T> extends StrongObservableValue<T> implement
     }
 
     @Override
-    public T get()
+    public synchronized T get()
     {
         return myValue;
     }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/tree/ButtonModelTreeUtilities.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/tree/ButtonModelTreeUtilities.java
@@ -14,7 +14,6 @@ import io.opensphere.core.util.collections.New;
  * Utilities for managing the state of tree nodes which are backed by button
  * models.
  */
-@SuppressWarnings("unchecked")
 public final class ButtonModelTreeUtilities
 {
     /**

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/tree/TreeTableTreeNode.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/tree/TreeTableTreeNode.java
@@ -68,11 +68,10 @@ public class TreeTableTreeNode implements MutableTreeNode
         myChildren.add(child);
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
-    public Enumeration children()
+    public Enumeration<? extends TreeNode> children()
     {
-        return new Enumeration()
+        return new Enumeration<TreeTableTreeNode>()
         {
             private final Iterator<TreeTableTreeNode> myNodeIterator = getChildren().iterator();
 
@@ -83,7 +82,7 @@ public class TreeTableTreeNode implements MutableTreeNode
             }
 
             @Override
-            public Object nextElement()
+            public TreeTableTreeNode nextElement()
             {
                 return myNodeIterator.next();
             }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/video/KLVVideoEncoder.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/video/KLVVideoEncoder.java
@@ -15,6 +15,7 @@ public interface KLVVideoEncoder extends Closeable
     /**
      * Completes the encoding process.
      */
+    @Override
     void close();
 
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/common/convolve/LeastSqLineTestSuite.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/common/convolve/LeastSqLineTestSuite.java
@@ -14,51 +14,51 @@ import javax.swing.JPanel;
 
 /**
  * This class encapsulates a suite of test routines for LeastSqLineLocator and
- * LeastSqLineSupport.  See below for details on how to use it.
+ * LeastSqLineSupport. See below for details on how to use it.
  */
 public class LeastSqLineTestSuite
 {
     /** Minimum value of x. */
-    private double minX = -10.0;
+    private final double minX = -10.0;
 
     /** Maximum value of x. */
-    private double maxX = 10.0;
+    private final double maxX = 10.0;
 
     /** Minimum value of y. */
-    private double minY = -10.0;
+    private final double minY = -10.0;
 
     /** Maximum value of y. */
-    private double maxY = 10.0;
+    private final double maxY = 10.0;
 
     /** Display background color. */
-    private Color bgColor = Color.BLACK;
+    private final Color bgColor = Color.BLACK;
 
     /** Display color of x- and y-axes. */
-    private Color axisColor = Color.BLUE;
+    private final Color axisColor = Color.BLUE;
 
     /** Display color of lines other than coordinate axes. */
-    private Color lineColor = Color.WHITE;
+    private final Color lineColor = Color.WHITE;
 
     /** Display color of the points. */
-    private Color ptColor = Color.RED;
+    private final Color ptColor = Color.RED;
 
     /** Display color of ellipses. */
-    private Color ellipseColor = Color.GREEN;
+    private final Color ellipseColor = Color.GREEN;
 
     /** The displayable x-axis. */
-    private LineG xAxis = new LineG(minX, 0.0, maxX, 0.0);
+    private final LineG xAxis = new LineG(minX, 0.0, maxX, 0.0);
 
     /** The displayable y-axis. */
-    private LineG yAxis = new LineG(0.0, minY, 0.0, maxY);
+    private final LineG yAxis = new LineG(0.0, minY, 0.0, maxY);
 
     /** The list of lines to be displayed. */
-    private LinkedList<LineG> lines = new LinkedList<>();
+    private final LinkedList<LineG> lines = new LinkedList<>();
 
     /** The list of points to be displayed. */
-    private LinkedList<PointG> points = new LinkedList<>();
+    private final LinkedList<PointG> points = new LinkedList<>();
 
     /** The list of ellipses to be dsiplayed. */
-    private LinkedList<EllipseG> ellipses = new LinkedList<>();
+    private final LinkedList<EllipseG> ellipses = new LinkedList<>();
 
     /** A class for representing a line segment in model space. */
     private static class LineG
@@ -114,7 +114,9 @@ public class LeastSqLineTestSuite
         {
             double mag = Math.sqrt(sq(x) + sq(y));
             if (mag == 0.0)
+            {
                 return null;
+            }
             return new PointG(x / mag, y / mag);
         }
     }
@@ -133,12 +135,14 @@ public class LeastSqLineTestSuite
          * @param confR scale factor of the ellipse
          * @return the generated ellipse
          */
-        public static EllipseG create (double[][] cov, double[] x, double confR) {
+        public static EllipseG create(double[][] cov, double[] x, double confR)
+        {
             int n = 32;
             EllipseG ell = new EllipseG();
-            for (int i = 0; i < n; i++) {
+            for (int i = 0; i < n; i++)
+            {
                 double theta = i * 2.0 * Math.PI / n;
-                double[] u = new double[] {Math.cos(theta), Math.sin(theta)};
+                double[] u = new double[] { Math.cos(theta), Math.sin(theta) };
                 LeastSqLineSupport.scalarMult(confR, u);
                 double[] v = LeastSqLineSupport.multVec(cov, u);
                 LeastSqLineSupport.add(v, x);
@@ -186,7 +190,7 @@ public class LeastSqLineTestSuite
     }
 
     /**
-     * Main.  Change the scenario number to select the desired test.
+     * Main. Change the scenario number to select the desired test.
      *
      * @param argv ignored
      */
@@ -201,7 +205,7 @@ public class LeastSqLineTestSuite
      */
     protected void scenario7()
     {
-        double[][] m = new double[][] {{2.0, 1.0}, {0.5, 3.0}};
+        double[][] m = new double[][] { { 2.0, 1.0 }, { 0.5, 3.0 } };
         double[][] mInv = LeastSqLineSupport.inverse2x2(m);
         double[][] id1 = LeastSqLineSupport.multMatrix(m, mInv);
         System.out.println("id1:");
@@ -214,35 +218,45 @@ public class LeastSqLineTestSuite
     }
 
     /**
-     * Test the eigenvalue and eigenvector functions for 2x2 matrices.  Each
+     * Test the eigenvalue and eigenvector functions for 2x2 matrices. Each
      * eigenvector is tested by multiplying by the matrix and dividing by the
      * eigenvalue, which should leave the vector nearly unchanged.
      */
     protected void scenario6()
     {
         System.out.println("CONF_95_RADIUS = " + PlaneUtils.CONF_95_RADIUS);
-        double[][] m = new double[][] {{2.0, 1.0}, {1.0, 3.0}};
+        double[][] m = new double[][] { { 2.0, 1.0 }, { 1.0, 3.0 } };
         double[] lambda = LeastSqLineSupport.eigenVal2x2(m);
         System.out.println("eigenvals:");
         for (int i = 0; i < lambda.length; i++)
+        {
             System.out.println(" -> " + lambda[i]);
+        }
         double[][] basis = LeastSqLineSupport.eigenVec2x2(m, lambda);
         System.out.println("basis[0]:");
         for (int i = 0; i < basis[0].length; i++)
+        {
             System.out.println(" -> " + basis[0][i]);
+        }
         double[] dopple0 = LeastSqLineSupport.multVec(m, basis[0]);
         LeastSqLineSupport.scalarMult(1.0 / lambda[0], dopple0);
         System.out.println("dopple0:");
         for (int i = 0; i < dopple0.length; i++)
+        {
             System.out.println(" -> " + dopple0[i]);
+        }
         System.out.println("basis[1]:");
         for (int i = 0; i < basis[1].length; i++)
+        {
             System.out.println(" -> " + basis[1][i]);
+        }
         double[] dopple1 = LeastSqLineSupport.multVec(m, basis[1]);
         LeastSqLineSupport.scalarMult(1.0 / lambda[1], dopple1);
         System.out.println("dopple1:");
         for (int i = 0; i < dopple1.length; i++)
+        {
             System.out.println(" -> " + dopple1[i]);
+        }
     }
 
     /**
@@ -266,7 +280,9 @@ public class LeastSqLineTestSuite
     {
         List<LineG> lineList = new LinkedList<>();
         for (int i = 0; i < 4; i++)
+        {
             lineList.add(lineOfBearing(bell(0.0, 10.0), bell(0.0, 10.0), 0.5 + bell(0.0, 1.0), bell(0.0, 1.0)));
+        }
         convolveForScenario(lineList);
         show();
     }
@@ -325,8 +341,8 @@ public class LeastSqLineTestSuite
     }
 
     /**
-     * Setup and run the least-squares localization algorithm using the
-     * resident lines.
+     * Setup and run the least-squares localization algorithm using the resident
+     * lines.
      *
      * @return the locator containing a solution
      */
@@ -348,8 +364,10 @@ public class LeastSqLineTestSuite
     {
         cw.setNumLines(lines.size());
         int i = 0;
-        for (LineG ln :  lines)
+        for (LineG ln : lines)
+        {
             cw.addLine(ln.p0.x, ln.p0.y, ln.p1.x - ln.p0.x, ln.p1.y - ln.p0.y, i++);
+        }
     }
 
     /**
@@ -359,7 +377,7 @@ public class LeastSqLineTestSuite
      * @param y y-coordinate of a point on the line
      * @param dx x-coordinate of the direction vector
      * @param dy y-coordinate of the direction vector
-     * @return
+     * @return lineg
      */
     private static LineG lineOfBearing(double x, double y, double dx, double dy)
     {
@@ -376,7 +394,9 @@ public class LeastSqLineTestSuite
     private static LineG lineOfBearing(PointG pt, PointG dir)
     {
         if (dir.x == 0.0 && dir.y == 0.0)
+        {
             return null;
+        }
         PointG dirUnit = dir.unit();
         double txNeg = -100;
         double txPos = 100;
@@ -394,13 +414,10 @@ public class LeastSqLineTestSuite
             tyPos = (10.0 - pt.y) / dirUnit.y;
         }
 
-        double tNeg = Math.min(0.0,
-                maxNeg(maxNeg(txNeg, tyNeg), maxNeg(txPos, tyPos)));
-        double tPos = Math.max(0.0,
-                minPos(minPos(txPos, tyPos), minPos(txNeg, tyNeg)));
+        double tNeg = Math.min(0.0, maxNeg(maxNeg(txNeg, tyNeg), maxNeg(txPos, tyPos)));
+        double tPos = Math.max(0.0, minPos(minPos(txPos, tyPos), minPos(txNeg, tyNeg)));
 
-        return new LineG(pt.x + tNeg * dirUnit.x, pt.y + tNeg * dirUnit.y,
-                pt.x + tPos * dirUnit.x, pt.y + tPos * dirUnit.y);
+        return new LineG(pt.x + tNeg * dirUnit.x, pt.y + tNeg * dirUnit.y, pt.x + tPos * dirUnit.x, pt.y + tPos * dirUnit.y);
     }
 
     /**
@@ -414,9 +431,13 @@ public class LeastSqLineTestSuite
     private static double minPos(double x, double y)
     {
         if (x < 0.0)
+        {
             return y;
+        }
         if (y < 0.0)
+        {
             return x;
+        }
         return Math.min(x, y);
     }
 
@@ -431,9 +452,13 @@ public class LeastSqLineTestSuite
     private static double maxNeg(double x, double y)
     {
         if (x > 0.0)
+        {
             return y;
+        }
         if (y > 0.0)
+        {
             return x;
+        }
         return Math.max(x, y);
     }
 
@@ -454,6 +479,9 @@ public class LeastSqLineTestSuite
      */
     private class Graph extends JPanel
     {
+        /** serial */
+        private static final long serialVersionUID = 1L;
+
         @Override
         public void paint(Graphics g)
         {
@@ -472,7 +500,9 @@ public class LeastSqLineTestSuite
     private void draw(Graphics g, int w, int h)
     {
         if (w <= 0 || h <= 0)
+        {
             return;
+        }
         double x0 = (w - 1) / 2.0;
         double y0 = (h - 1) / 2.0;
         double c = Math.min(w / (maxX - minX), h / (maxY - minY));
@@ -483,14 +513,20 @@ public class LeastSqLineTestSuite
         drawLine(xAxis, g, x0, y0, c);
         drawLine(yAxis, g, x0, y0, c);
         g.setColor(lineColor);
-        for (LineG ln :  lines)
+        for (LineG ln : lines)
+        {
             drawLine(ln, g, x0, y0, c);
+        }
         g.setColor(ellipseColor);
-        for (EllipseG el :  ellipses)
+        for (EllipseG el : ellipses)
+        {
             drawEllipse(el, g, x0, y0, c);
+        }
         g.setColor(ptColor);
-        for (PointG pt :  points)
+        for (PointG pt : points)
+        {
             drawPoint(pt, g, x0, y0, c);
+        }
     }
 
     /**
@@ -519,8 +555,7 @@ public class LeastSqLineTestSuite
      */
     private static void drawLine(PointG p0, PointG p1, Graphics g, double x0, double y0, double c)
     {
-        g.drawLine(rint(x0 + c * p0.x), rint(y0 - c * p0.y),
-                rint(x0 + c * p1.x), rint(y0 - c * p1.y));
+        g.drawLine(rint(x0 + c * p0.x), rint(y0 - c * p0.y), rint(x0 + c * p1.x), rint(y0 - c * p1.y));
     }
 
     /**
@@ -550,15 +585,22 @@ public class LeastSqLineTestSuite
     {
         PointG p0 = null;
         PointG p1 = null;
-        for (PointG p2 :  e.points) {
+        for (PointG p2 : e.points)
+        {
             if (p1 != null)
+            {
                 drawLine(p1, p2, g, x0, y0, c);
+            }
             p1 = p2;
             if (p0 == null)
+            {
                 p0 = p1;
+            }
         }
         if (p1 != p0 && p1 != null)
+        {
             drawLine(p1, p0, g, x0, y0, c);
+        }
     }
 
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/CircularMeshGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/CircularMeshGeometryTest.java
@@ -1,5 +1,6 @@
 package io.opensphere.core.geometry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -10,9 +11,9 @@ import io.opensphere.core.geometry.renderproperties.PolygonMeshRenderProperties;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link CircularMeshGeometry}. */
+@SuppressWarnings("boxing")
 public class CircularMeshGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/EllipseGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/EllipseGeometryTest.java
@@ -1,5 +1,6 @@
 package io.opensphere.core.geometry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -11,9 +12,9 @@ import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.LineType;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link EllipseGeometry}. */
+@SuppressWarnings("boxing")
 public class EllipseGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/EllipseScalableGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/EllipseScalableGeometryTest.java
@@ -1,5 +1,6 @@
 package io.opensphere.core.geometry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -10,9 +11,9 @@ import io.opensphere.core.geometry.renderproperties.ScalableRenderProperties;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link EllipseScalableGeometry}. */
+@SuppressWarnings("boxing")
 public class EllipseScalableGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/FrustumGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/FrustumGeometryTest.java
@@ -1,5 +1,6 @@
 package io.opensphere.core.geometry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -10,9 +11,9 @@ import io.opensphere.core.geometry.renderproperties.ScalableMeshRenderProperties
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link FrustumGeometry}. */
+@SuppressWarnings("boxing")
 public class FrustumGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/GeoScreenBubbleGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/GeoScreenBubbleGeometryTest.java
@@ -18,6 +18,7 @@ import io.opensphere.core.model.ScreenPosition;
 import io.opensphere.core.model.time.TimeSpan;
 
 /** Test for {@link GeoScreenBubbleGeometry}. */
+@SuppressWarnings("boxing")
 public class GeoScreenBubbleGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/GeoScreenPolylineGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/GeoScreenPolylineGeometryTest.java
@@ -3,6 +3,7 @@ package io.opensphere.core.geometry;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -15,9 +16,9 @@ import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.LineType;
 import io.opensphere.core.model.ScreenPosition;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link GeoScreenPolylineGeometry}. */
+@SuppressWarnings("boxing")
 public class GeoScreenPolylineGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/LabelGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/LabelGeometryTest.java
@@ -1,5 +1,6 @@
 package io.opensphere.core.geometry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -9,9 +10,9 @@ import io.opensphere.core.geometry.renderproperties.LabelRenderProperties;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link LabelGeometry}. */
+@SuppressWarnings("boxing")
 public class LabelGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/LineOfBearingGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/LineOfBearingGeometryTest.java
@@ -1,5 +1,6 @@
 package io.opensphere.core.geometry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -10,9 +11,9 @@ import io.opensphere.core.geometry.renderproperties.PolylineRenderProperties;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link LineOfBearingGeometry}. */
+@SuppressWarnings("boxing")
 public class LineOfBearingGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PointGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PointGeometryTest.java
@@ -1,5 +1,6 @@
 package io.opensphere.core.geometry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -9,9 +10,9 @@ import io.opensphere.core.geometry.renderproperties.PointRenderProperties;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link PointGeometry}. */
+@SuppressWarnings("boxing")
 public class PointGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PointSetGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PointSetGeometryTest.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.renderproperties.BaseRenderProperties;
@@ -11,9 +12,9 @@ import io.opensphere.core.geometry.renderproperties.DefaultPointRenderProperties
 import io.opensphere.core.geometry.renderproperties.PointRenderProperties;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
-import org.junit.Assert;
 
 /** Test for {@link PointSetGeometry}. */
+@SuppressWarnings("boxing")
 public class PointSetGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PointSpriteGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PointSpriteGeometryTest.java
@@ -1,5 +1,6 @@
 package io.opensphere.core.geometry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -10,9 +11,9 @@ import io.opensphere.core.geometry.renderproperties.PointRenderProperties;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link PointSpriteGeometry}. */
+@SuppressWarnings("boxing")
 public class PointSpriteGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PolygonGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PolygonGeometryTest.java
@@ -2,6 +2,7 @@ package io.opensphere.core.geometry;
 
 import java.util.Arrays;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -13,9 +14,9 @@ import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.LineType;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link PolygonGeometry}. */
+@SuppressWarnings("boxing")
 public class PolygonGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PolygonMeshGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PolygonMeshGeometryTest.java
@@ -3,6 +3,7 @@ package io.opensphere.core.geometry;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -18,9 +19,9 @@ import io.opensphere.core.model.time.TimeSpan;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.collections.petrifyable.PetrifyableTIntArrayList;
 import io.opensphere.core.util.collections.petrifyable.PetrifyableTIntList;
-import org.junit.Assert;
 
 /** Test for {@link LabelGeometry}. */
+@SuppressWarnings("boxing")
 public class PolygonMeshGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PolylineGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PolylineGeometryTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -17,11 +18,11 @@ import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.LineType;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /**
  * Test for {@link PolylineGeometry}.
  */
+@SuppressWarnings("boxing")
 public class PolylineGeometryTest
 {
     /** The builder. */

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PolylineGeometryUtilsTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/PolylineGeometryUtilsTest.java
@@ -51,6 +51,7 @@ import io.opensphere.core.model.time.TimeSpan;
  * from (2,3) to (2,4), and once in reverse, from (2,4) to (2,3). This is done
  * to verify that the algorithm properly handles repeated directed lines.
  */
+@SuppressWarnings("boxing")
 public class PolylineGeometryUtilsTest
 {
     /** Test data. */

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/TorusMeshGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/TorusMeshGeometryTest.java
@@ -1,5 +1,6 @@
 package io.opensphere.core.geometry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -11,9 +12,9 @@ import io.opensphere.core.math.Matrix3d;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link TorusMeshGeometry}. */
+@SuppressWarnings("boxing")
 public class TorusMeshGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/TriangleScalableGeometryTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/geometry/TriangleScalableGeometryTest.java
@@ -1,5 +1,6 @@
 package io.opensphere.core.geometry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.geometry.constraint.Constraints;
@@ -10,9 +11,9 @@ import io.opensphere.core.geometry.renderproperties.ScalableMeshRenderProperties
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.time.TimeSpan;
-import org.junit.Assert;
 
 /** Test for {@link TriangleScalableGeometry}. */
+@SuppressWarnings("boxing")
 public class TriangleScalableGeometryTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/model/LatLonAltParserTestFunctional.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/model/LatLonAltParserTestFunctional.java
@@ -50,5 +50,6 @@ public class LatLonAltParserTestFunctional
                 }
             }
         }
+        formatter.close();
     }
 }

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/model/LatLonAltTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/model/LatLonAltTest.java
@@ -1,10 +1,10 @@
 package io.opensphere.core.model;
 
+import org.junit.Assert;
 import org.junit.Test;
 
-import org.junit.Assert;
-
 /** Test for {@link LatLonAlt}. */
+@SuppressWarnings("boxing")
 public class LatLonAltTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/model/time/DefaultTimeSpanSetTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/model/time/DefaultTimeSpanSetTest.java
@@ -25,6 +25,7 @@ import io.opensphere.core.util.rangeset.RangeLongBlock;
 /**
  * Test Cases TimeSpanSet.
  */
+@SuppressWarnings("unlikely-arg-type")
 public class DefaultTimeSpanSetTest
 {
     // TODO: Fix this doc
@@ -190,6 +191,7 @@ public class DefaultTimeSpanSetTest
      * {@link DefaultTimeSpanSet#test(DefaultTimeSpanSet.MembershipTest, TimeSpan, boolean)}
      * .
      */
+    @SuppressWarnings("javadoc")
     @Test
     public void testTest()
     {

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/model/time/TimeSpanTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/model/time/TimeSpanTest.java
@@ -30,7 +30,7 @@ import io.opensphere.core.util.Constants;
 import io.opensphere.core.util.DateTimeFormats;
 
 /** Test for {@link TimeSpan}. */
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings({ "PMD.GodClass", "boxing" })
 public class TimeSpanTest
 {
     /** Test for {@link TimeSpan#clamp(TimeInstant)}. */

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/projection/AbstractGeographicProjectionTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/projection/AbstractGeographicProjectionTest.java
@@ -309,6 +309,7 @@ public class AbstractGeographicProjectionTest
     @Test
     public void testCacheEllipsoid()
     {
+        @SuppressWarnings("unchecked")
         BoundingBox<GeographicPosition> mockBox = createStrictMock(BoundingBox.class);
         Ellipsoid mockEllipsoid = createStrictMock(Ellipsoid.class);
 

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/projection/GeographicBody3DTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/projection/GeographicBody3DTest.java
@@ -1,12 +1,13 @@
 package io.opensphere.core.projection;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.opensphere.core.math.WGS84EarthConstants;
 import io.opensphere.core.model.LatLonAlt;
-import org.junit.Assert;
 
 /** Test for {@link GeographicBody3D}. */
+@SuppressWarnings("boxing")
 public class GeographicBody3DTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/QuotingBufferedReaderTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/QuotingBufferedReaderTest.java
@@ -62,11 +62,12 @@ public class QuotingBufferedReaderTest
         }
 
         Reader in = new CharArrayReader(sb.toString().toCharArray());
+        QuotingBufferedReader reader = new QuotingBufferedReader(in, null, new char[] { '\\' });
 
         for (int sz = 1; sz < sb.length() + 1; ++sz)
         {
             in.reset();
-            QuotingBufferedReader reader = new QuotingBufferedReader(in, sz, null, new char[] { '\\' });
+            reader.setBuffer(sz);
 
             List<String> actual = New.list(5);
             for (String line; (line = reader.readLine()) != null;)
@@ -75,6 +76,8 @@ public class QuotingBufferedReaderTest
             }
             Assert.assertEquals("Lines do not match when buffer size is " + sz, expected, actual);
         }
+
+        reader.close();
     }
 
     /**
@@ -104,6 +107,7 @@ public class QuotingBufferedReaderTest
 
         String line = reader.readLine();
         Assert.assertEquals(dataLine, line);
+        reader.close();
     }
 
     /**
@@ -119,6 +123,7 @@ public class QuotingBufferedReaderTest
         QuotingBufferedReader reader = new QuotingBufferedReader(in, new char[] { '"', '\'' }, new char[] { '\\' });
 
         Assert.assertEquals(null, reader.readLine());
+        reader.close();
     }
 
     /**
@@ -141,11 +146,12 @@ public class QuotingBufferedReaderTest
         }
 
         Reader in = new CharArrayReader(sb.toString().toCharArray());
+        QuotingBufferedReader reader = new QuotingBufferedReader(in, null, null);
 
         for (int sz = 1; sz < sb.length() + 1; ++sz)
         {
-            in.reset();
-            QuotingBufferedReader reader = new QuotingBufferedReader(in, sz, null, null);
+            reader.reset();
+            reader.setBuffer(sz);
 
             List<String> actual = New.list(5);
             for (String line; (line = reader.readLine()) != null;)
@@ -154,6 +160,8 @@ public class QuotingBufferedReaderTest
             }
             Assert.assertEquals("Lines do not match when buffer size is " + sz, expected, actual);
         }
+
+        reader.close();
     }
 
     /**
@@ -178,11 +186,12 @@ public class QuotingBufferedReaderTest
         }
 
         Reader in = new CharArrayReader(sb.toString().toCharArray());
+        QuotingBufferedReader reader = new QuotingBufferedReader(in, new char[] { '"', '\'' }, null);
 
         for (int sz = 1; sz < sb.length() + 1; ++sz)
         {
-            in.reset();
-            QuotingBufferedReader reader = new QuotingBufferedReader(in, sz, new char[] { '"', '\'' }, null);
+            reader.reset();
+            reader.setBuffer(sz);
 
             List<String> actual = New.list(5);
             for (String line; (line = reader.readLine()) != null;)
@@ -191,6 +200,8 @@ public class QuotingBufferedReaderTest
             }
             Assert.assertEquals("Lines do not match when buffer size is " + sz, expected, actual);
         }
+
+        reader.close();
     }
 
     /**
@@ -215,11 +226,12 @@ public class QuotingBufferedReaderTest
         }
 
         Reader in = new CharArrayReader(sb.toString().toCharArray());
+        QuotingBufferedReader reader = new QuotingBufferedReader(in, new char[] { '"', '\'' }, new char[] { '\\' });
 
         for (int sz = 1; sz < sb.length() + 1; ++sz)
         {
-            in.reset();
-            QuotingBufferedReader reader = new QuotingBufferedReader(in, sz, new char[] { '"', '\'' }, new char[] { '\\' });
+            reader.reset();
+            reader.setBuffer(sz);
 
             List<String> actual = New.list(5);
             for (String line; (line = reader.readLine()) != null;)
@@ -228,5 +240,7 @@ public class QuotingBufferedReaderTest
             }
             Assert.assertEquals("Lines do not match when buffer size is " + sz, expected, actual);
         }
+
+        reader.close();
     }
 }

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/collections/CollectionUtilitiesTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/collections/CollectionUtilitiesTest.java
@@ -26,14 +26,15 @@ import org.junit.Test;
 /**
  * Test for {@link CollectionUtilities}.
  */
-@SuppressWarnings({ "PMD.GodClass", "PMD.AvoidDuplicateLiterals" })
+@SuppressWarnings({ "PMD.GodClass", "PMD.AvoidDuplicateLiterals", "boxing" })
 public class CollectionUtilitiesTest
 {
     /** Logger reference. */
     private static final Logger LOGGER = Logger.getLogger(CollectionUtilitiesTest.class);
 
     /**
-     * Test for {@link CollectionUtilities#addIfNotContained(Collection, Collection, BiPredicate)}.
+     * Test for
+     * {@link CollectionUtilities#addIfNotContained(Collection, Collection, BiPredicate)}.
      */
     @Test
     public void testAddIfNotContained()

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/collections/LazyMapTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/collections/LazyMapTest.java
@@ -112,6 +112,7 @@ public class LazyMapTest
     /**
      * Test for {@link LazyMap#get(Object)}.
      */
+    @SuppressWarnings("unlikely-arg-type")
     @Test
     public void testGet()
     {

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/collections/NewTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/collections/NewTest.java
@@ -12,6 +12,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /** Test for {@link New}. */
+@SuppressWarnings("boxing")
 public class NewTest
 {
     /** Test message. */

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/collections/StreamUtilitiesTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/collections/StreamUtilitiesTest.java
@@ -7,9 +7,8 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
-
 import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Test for {@link StreamUtilities}.
@@ -55,7 +54,7 @@ public class StreamUtilitiesTest
     }
 
     /**
-     * Test {@link StreamUtilities#filter(Iterable, Predicate)}.
+     * Test {@link StreamUtilities#filter(Collection, Predicate)}.
      */
     @Test
     public void testFilter()
@@ -147,7 +146,8 @@ public class StreamUtilitiesTest
     }
 
     /**
-     * Test {@link StreamUtilities#filterDowncast(java.util.stream.Stream, Class)}.
+     * Test
+     * {@link StreamUtilities#filterDowncast(java.util.stream.Stream, Class)}.
      */
     @Test
     public void testFilterDowcast()

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/io/ByteBufferInputStreamTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/io/ByteBufferInputStreamTest.java
@@ -11,6 +11,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /** Tests for {@link ByteBufferInputStream}. */
 @SuppressFBWarnings("OS_OPEN_STREAM")
+@SuppressWarnings("resource")
 public class ByteBufferInputStreamTest
 {
     /** The capacity to use for the buffer. */

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/io/UncloseableInputStreamTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/io/UncloseableInputStreamTest.java
@@ -8,6 +8,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /** Test for {@link UncloseableInputStream}. */
+@SuppressWarnings("resource")
 public class UncloseableInputStreamTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/lang/StringUtilitiesTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/lang/StringUtilitiesTest.java
@@ -178,9 +178,8 @@ public class StringUtilitiesTest
     }
 
     /**
-     * Test {@link StringUtilities#concat(StringBuilder, Object...)}.
+     * Test {@link StringUtilities#concat(StringBuilder, String...)}.
      */
-    @SuppressWarnings("boxing")
     @Test
     public void testConcat2()
     {

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/rangeset/DefaultRangedLongSetTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/rangeset/DefaultRangedLongSetTest.java
@@ -2,9 +2,8 @@ package io.opensphere.core.util.rangeset;
 
 import java.util.Iterator;
 
-import org.junit.Test;
-
 import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Test Cases for DefaultRangedLongSet.
@@ -14,6 +13,7 @@ public class DefaultRangedLongSetTest
     /**
      * Test some of the basic functions.
      */
+    @SuppressWarnings("unlikely-arg-type")
     @Test
     public void test()
     {

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/swing/input/model/DoubleModelTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/swing/input/model/DoubleModelTest.java
@@ -8,6 +8,7 @@ import io.opensphere.core.util.ValidationStatus;
 /**
  * Test for {@link DoubleModel}.
  */
+@SuppressWarnings("boxing")
 public class DoubleModelTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/swing/input/model/IntegerModelTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/swing/input/model/IntegerModelTest.java
@@ -8,6 +8,7 @@ import io.opensphere.core.util.ValidationStatus;
 /**
  * Test for {@link IntegerModel}.
  */
+@SuppressWarnings("boxing")
 public class IntegerModelTest
 {
     /**

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/util/taskactivity/CancellableTaskActivityTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/util/taskactivity/CancellableTaskActivityTest.java
@@ -1,11 +1,11 @@
 package io.opensphere.core.util.taskactivity;
 
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
-
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.Test;
+
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 
 /**
  * Tests the {@link CancellableTaskActivity} class.
@@ -29,6 +29,7 @@ public class CancellableTaskActivityTest
         activity.setProgress(.5);
 
         support.verifyAll();
+        activity.close();
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/controller/impl/DataTypeControllerImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/controller/impl/DataTypeControllerImpl.java
@@ -70,29 +70,29 @@ public class DataTypeControllerImpl implements DataTypeController
     static
     {
         // conversion for feet (which was the observed use case)
-        Double meterPerFt = Length.METERS_PER_FOOT;
+        Double meterPerFt = Double.valueOf(Length.METERS_PER_FOOT);
         scaleMap.put(Feet.FEET_LONG_LABEL1.toUpperCase(), meterPerFt);
         scaleMap.put(Feet.FEET_LONG_LABEL2.toUpperCase(), meterPerFt);
         scaleMap.put(Feet.FEET_SHORT_LABEL.toUpperCase(), meterPerFt);
 
         // conversion for nautical miles
-        Double meterPerNm = (double)NauticalMiles.METERS_PER_NAUTICAL_MILE;
+        Double meterPerNm = Double.valueOf(NauticalMiles.METERS_PER_NAUTICAL_MILE);
         scaleMap.put(NauticalMiles.NM_LONG_LABEL.toUpperCase(), meterPerNm);
         scaleMap.put(NauticalMiles.NM_SHORT_LABEL.toUpperCase(), meterPerNm);
 
         // conversion for miles
-        Double meterPerMi = StatuteMiles.FEET_PER_STATUTE_MILE * Length.METERS_PER_FOOT;
+        Double meterPerMi = Double.valueOf(StatuteMiles.FEET_PER_STATUTE_MILE * Length.METERS_PER_FOOT);
         scaleMap.put(StatuteMiles.MILES_LONG_LABEL.toUpperCase(), meterPerMi);
         scaleMap.put(StatuteMiles.MILES_SHORT_LABEL.toUpperCase(), meterPerMi);
 
         // conversion for kilometers
-        Double meterPerKm = 1000.0;
+        Double meterPerKm = Double.valueOf(1000.0);
         scaleMap.put(Kilometers.KILOMETERS_LONG_LABEL.toUpperCase(), meterPerKm);
         scaleMap.put(Kilometers.KILOMETERS_SHORT_LABEL.toUpperCase(), meterPerKm);
 
         // "conversion" for meters; actually, short-circuit to avoid unnecessary
         // work
-        Double meterPerMeter = 1.0;
+        Double meterPerMeter = Double.valueOf(1.0);
         scaleMap.put(Meters.METERS_LONG_LABEL.toUpperCase(), meterPerMeter);
         scaleMap.put(Meters.METERS_SHORT_LABEL.toUpperCase(), meterPerMeter);
     }
@@ -145,7 +145,8 @@ public class DataTypeControllerImpl implements DataTypeController
      *
      * @param toolbox the {@link Toolbox}
      * @param deCache the data element cache
-     * @param columnTypeDetector the column type detector used to find special keys.
+     * @param columnTypeDetector the column type detector used to find special
+     *            keys.
      */
     public DataTypeControllerImpl(Toolbox toolbox, DataElementCacheImpl deCache, ColumnTypeDetector columnTypeDetector)
     {
@@ -618,7 +619,6 @@ public class DataTypeControllerImpl implements DataTypeController
      * @param data the data elements to be inserted
      * @param xFormer if present, a transformer for map data elements
      * @return the ids of the inserted elements
-     * @throws CacheException in case the cache has a problem
      */
     private long[] cacheDataElements(String category, String source, Collection<? extends DataElement> data,
             Consumer<long[]> xFormer)
@@ -693,7 +693,7 @@ public class DataTypeControllerImpl implements DataTypeController
 
             // replace the "metadata"
             mdp.setValue(unitKey, "M");
-            mdp.setValue(altKey, newAlt);
+            mdp.setValue(altKey, Double.valueOf(newAlt));
 
             // alter the map geometry
             MapGeometrySupport geom = elt.getMapGeometrySupport();
@@ -720,7 +720,7 @@ public class DataTypeControllerImpl implements DataTypeController
         Double ret = scaleMap.get(unit.toUpperCase());
         if (ret != null)
         {
-            return ret;
+            return ret.doubleValue();
         }
         return 1.0;
     }
@@ -750,10 +750,6 @@ public class DataTypeControllerImpl implements DataTypeController
         if (val == null)
         {
             return Double.NaN;
-        }
-        if (val instanceof Double)
-        {
-            return (Double)val;
         }
         if (val instanceof Number)
         {

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/cache/impl/DynamicEnumDecoder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/cache/impl/DynamicEnumDecoder.java
@@ -21,6 +21,7 @@ public final class DynamicEnumDecoder
      *         the values are dynamic enumeration types the original list is
      *         returned.
      */
+    @SuppressWarnings("null")
     public static List<Object> decode(DynamicEnumerationRegistry reg, List<Object> source)
     {
         List<Object> result = null;

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/columns/gui/ColumnMappingCell.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/columns/gui/ColumnMappingCell.java
@@ -6,6 +6,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import io.opensphere.core.datafilter.columns.ColumnMapping;
+import io.opensphere.core.util.fx.FXUtilities;
+import io.opensphere.core.util.fx.NewAutoCompleteComboBoxListener;
+import io.opensphere.core.util.image.IconUtil.IconType;
 import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.scene.control.Button;
@@ -15,11 +19,6 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
-
-import io.opensphere.core.datafilter.columns.ColumnMapping;
-import io.opensphere.core.util.fx.AutoCompleteComboBoxListener;
-import io.opensphere.core.util.fx.FXUtilities;
-import io.opensphere.core.util.image.IconUtil.IconType;
 
 /** A column mapping ListCell. */
 class ColumnMappingCell extends ListCell<ColumnMapping>
@@ -39,17 +38,17 @@ class ColumnMappingCell extends ListCell<ColumnMapping>
     /** Column selection widget. */
     private final ComboBox<String> columnSel = new ComboBox<>();
 
-    /** Set to true when events originating here come back.  Ignore them. */
+    /** Set to true when events originating here come back. Ignore them. */
     private boolean ignoreEdits;
 
     /** Index of types by display name. */
-    private Map<String, DataTypeRef> nameIndex = new TreeMap<>();
+    private final Map<String, DataTypeRef> nameIndex = new TreeMap<>();
 
     /** Index of types by type key. */
-    private Map<String, DataTypeRef> keyIndex = new TreeMap<>();
+    private final Map<String, DataTypeRef> keyIndex = new TreeMap<>();
 
     /** List of display names of active types. */
-    private List<String> activeList = new LinkedList<>();
+    private final List<String> activeList = new LinkedList<>();
 
     /**
      * Constructor.
@@ -62,7 +61,7 @@ class ColumnMappingCell extends ListCell<ColumnMapping>
     {
         rsc = cmr;
         model = m;
-        for (DataTypeRef r :  layers)
+        for (DataTypeRef r : layers)
         {
             nameIndex.put(r.getType().getDisplayName(), r);
             keyIndex.put(r.getType().getTypeKey(), r);
@@ -80,7 +79,9 @@ class ColumnMappingCell extends ListCell<ColumnMapping>
         columnSel.setTooltip(new Tooltip("The column to " + Constants.MAP_VERB));
 
         // new AutoCompleteComboBoxListener<>(layerSel);
-        new AutoCompleteComboBoxListener<>(columnSel);
+//        new AutoCompleteComboBoxListener<>(columnSel);
+        NewAutoCompleteComboBoxListener listener = new NewAutoCompleteComboBoxListener();
+        listener.setupComboBox(columnSel);
 
         layerSel.setPrefWidth(262);
         columnSel.setPrefWidth(262);
@@ -92,8 +93,8 @@ class ColumnMappingCell extends ListCell<ColumnMapping>
         Button delB = FXUtilities.newIconButton(IconType.CLOSE, Color.RED);
         delB.setTooltip(new Tooltip("Remove"));
         delB.setOnAction(e -> model.remove(getIndex()));
-        rootPane.getChildren().addAll(new Label("Layer:"), layerSel,
-                new Label(" Column:"), columnSel, FXUtilities.newHSpacer(0), delB);
+        rootPane.getChildren().addAll(new Label("Layer:"), layerSel, new Label(" Column:"), columnSel, FXUtilities.newHSpacer(0),
+                delB);
     }
 
     @Override
@@ -154,7 +155,7 @@ class ColumnMappingCell extends ListCell<ColumnMapping>
     /** Writes an updated ColumnMapping instance to the model (i.e., List). */
     private void updateModel()
     {
-        // Note:  do not write to the model synchronously lest the resulting
+        // Note: do not write to the model synchronously lest the resulting
         // events cause conflicts in access to the model.
         String lay = keyOf(layerSel.getValue());
         String col = columnSel.getValue();
@@ -163,6 +164,7 @@ class ColumnMappingCell extends ListCell<ColumnMapping>
 
     /**
      * Lookup the display name for a given type key
+     *
      * @param key key
      * @return name
      */
@@ -178,6 +180,7 @@ class ColumnMappingCell extends ListCell<ColumnMapping>
 
     /**
      * Lookup the type key for a given display name.
+     *
      * @param name name
      * @return key
      */
@@ -193,6 +196,7 @@ class ColumnMappingCell extends ListCell<ColumnMapping>
 
     /**
      * Null-tolerant get method.
+     *
      * @param m a Map
      * @param k a key
      * @return a value, or null

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/columns/gui/ColumnMappingCell.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/columns/gui/ColumnMappingCell.java
@@ -78,10 +78,11 @@ class ColumnMappingCell extends ListCell<ColumnMapping>
         layerSel.setTooltip(new Tooltip("The layer to " + Constants.MAP_VERB));
         columnSel.setTooltip(new Tooltip("The column to " + Constants.MAP_VERB));
 
-        // new AutoCompleteComboBoxListener<>(layerSel);
-//        new AutoCompleteComboBoxListener<>(columnSel);
         NewAutoCompleteComboBoxListener listener = new NewAutoCompleteComboBoxListener();
         listener.setupComboBox(columnSel);
+
+        NewAutoCompleteComboBoxListener listener2 = new NewAutoCompleteComboBoxListener();
+        listener2.setupComboBox(layerSel);
 
         layerSel.setPrefWidth(262);
         columnSel.setPrefWidth(262);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/factory/impl/MapCircleGeometryConverter.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/factory/impl/MapCircleGeometryConverter.java
@@ -62,7 +62,8 @@ public final class MapCircleGeometryConverter extends AbstractGeometryConverter
         int zOrder = visState.isSelected() ? ZOrderRenderProperties.TOP_Z : mapVisInfo == null ? 1000 : mapVisInfo.getZOrder();
 
         Constraints constraints = null;
-        if (mapVisInfo != null && basicVisInfo.getLoadsTo().isTimelineEnabled() && !geomSupport.getTimeSpan().isTimeless())
+        if (mapVisInfo != null && basicVisInfo != null && basicVisInfo.getLoadsTo().isTimelineEnabled()
+                && !geomSupport.getTimeSpan().isTimeless())
         {
             constraints = createTimeConstraints(getToolbox(), dti, geomSupport.getTimeSpan());
         }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/factory/impl/MapEllipseGeometryConverter.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/factory/impl/MapEllipseGeometryConverter.java
@@ -63,7 +63,8 @@ public final class MapEllipseGeometryConverter extends AbstractGeometryConverter
         int zOrder = visState.isSelected() ? ZOrderRenderProperties.TOP_Z : mapVisInfo == null ? 1000 : mapVisInfo.getZOrder();
 
         Constraints constraints = null;
-        if (mapVisInfo != null && basicVisInfo.getLoadsTo().isTimelineEnabled() && !geomSupport.getTimeSpan().isTimeless())
+        if (mapVisInfo != null && basicVisInfo != null && basicVisInfo.getLoadsTo().isTimelineEnabled()
+                && !geomSupport.getTimeSpan().isTimeless())
         {
             constraints = createTimeConstraints(getToolbox(), dti, geomSupport.getTimeSpan());
         }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/AbstractFrustumGeometryFeatureVisualizationStyle.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/AbstractFrustumGeometryFeatureVisualizationStyle.java
@@ -153,14 +153,16 @@ public abstract class AbstractFrustumGeometryFeatureVisualizationStyle extends A
 
     @Override
     public void createCombinedGeometry(Set<Geometry> setToAddTo, FeatureCombinedGeometryBuilderData builderData,
-            RenderPropertyPool renderPropertyPool) throws IllegalArgumentException
+            RenderPropertyPool renderPropertyPool)
+        throws IllegalArgumentException
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void createIndividualGeometry(Set<Geometry> setToAddTo, FeatureIndividualGeometryBuilderData builderData,
-            RenderPropertyPool renderPropertyPool) throws IllegalArgumentException
+            RenderPropertyPool renderPropertyPool)
+        throws IllegalArgumentException
     {
         FrustumGeometry geom = createFrustumGeometry(builderData, renderPropertyPool);
         if (geom != null)
@@ -600,7 +602,7 @@ public abstract class AbstractFrustumGeometryFeatureVisualizationStyle extends A
             {
                 try
                 {
-                    result = StyleUtils.convertValueToDouble(mdp.getValue(heightByColKey));
+                    result = Double.valueOf(StyleUtils.convertValueToDouble(mdp.getValue(heightByColKey)));
                 }
                 catch (NumberFormatException e)
                 {
@@ -675,8 +677,8 @@ public abstract class AbstractFrustumGeometryFeatureVisualizationStyle extends A
             builder.setBaseRadius(baseR);
             builder.setTopRadius(topR);
 
-            resultGeom = new FrustumGeometry(builder, featureProps, StyleUtils.createTimeConstraintsIfApplicable(basicVisInfo, mapVisInfo,
-                    bd.getMGS(), StyleUtils.getDataGroupInfoFromDti(getToolbox(), bd.getDataType())));
+            resultGeom = new FrustumGeometry(builder, featureProps, StyleUtils.createTimeConstraintsIfApplicable(basicVisInfo,
+                    mapVisInfo, bd.getMGS(), StyleUtils.getDataGroupInfoFromDti(getToolbox(), bd.getDataType())));
         }
         return resultGeom;
     }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/AbstractLOBFeatureVisualizationStyle.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/AbstractLOBFeatureVisualizationStyle.java
@@ -213,6 +213,7 @@ public abstract class AbstractLOBFeatureVisualizationStyle extends AbstractLocat
     private static final Length MAX_LOB_LENGTH = new Kilometers(20000.0f);
 
     /** The Constant MAX_ARROW_LENGTH_KILOMETERS. */
+    @SuppressWarnings("unused")
     private static final Length MAX_ARROW_LENGTH = new Kilometers(500.0f);
 
     /** The minimum arrow length. */
@@ -260,6 +261,7 @@ public abstract class AbstractLOBFeatureVisualizationStyle extends AbstractLocat
         throw new UnsupportedOperationException();
     }
 
+    @SuppressWarnings("null")
     @Override
     public void createIndividualGeometry(Set<Geometry> setToAddTo, FeatureIndividualGeometryBuilderData bd,
             RenderPropertyPool renderPropertyPool)

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/PolygonFeatureVisualizationStyle.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/PolygonFeatureVisualizationStyle.java
@@ -61,6 +61,7 @@ import io.opensphere.mantle.util.MantleConstants;
 public class PolygonFeatureVisualizationStyle extends AbstractPathVisualizationStyle
 {
     /** The Constant ourPropertyKeyPrefix. */
+    @SuppressWarnings("hiding")
     public static final String ourPropertyKeyPrefix = "PolygonFeatureVisualizationStyle";
 
     /** The Constant ourFilledPropertyKey. */
@@ -76,8 +77,8 @@ public class PolygonFeatureVisualizationStyle extends AbstractPathVisualizationS
 
     /** The Constant ourFillOpacityParameter. */
     public static final VisualizationStyleParameter ourFillOpacityParameter = new VisualizationStyleParameter(
-            ourFillOpacityPropertyKey, "Fill Opacity", 0.3f, Float.class, new VisualizationStyleParameterFlags(false, false),
-            ParameterHint.hint(false, false));
+            ourFillOpacityPropertyKey, "Fill Opacity", Float.valueOf(0.3f), Float.class,
+            new VisualizationStyleParameterFlags(false, false), ParameterHint.hint(false, false));
 
     /**
      * Instantiates a new polygon feature visualization style.
@@ -108,14 +109,16 @@ public class PolygonFeatureVisualizationStyle extends AbstractPathVisualizationS
 
     @Override
     public void createCombinedGeometry(Set<Geometry> setToAddTo, FeatureCombinedGeometryBuilderData builderData,
-            RenderPropertyPool renderPropertyPool) throws IllegalArgumentException
+            RenderPropertyPool renderPropertyPool)
+        throws IllegalArgumentException
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void createIndividualGeometry(Set<Geometry> setToAddTo, FeatureIndividualGeometryBuilderData bd,
-            RenderPropertyPool renderPropertyPool) throws IllegalArgumentException
+            RenderPropertyPool renderPropertyPool)
+        throws IllegalArgumentException
     {
         PolygonGeometry polygonGeom = null;
         if (bd.getMGS() instanceof MapPolygonGeometrySupport)
@@ -255,7 +258,7 @@ public class PolygonFeatureVisualizationStyle extends AbstractPathVisualizationS
         paramList.add(fillOpacityPanel);
 
         EditorPanelVisibilityDependency visDepend = new EditorPanelVisibilityDependency(panel, fillOpacityPanel);
-        visDepend.addConstraint(new ParameterVisibilityConstraint(ourFilledPropertyKey, Boolean.TRUE, true));
+        visDepend.addConstraint(new ParameterVisibilityConstraint(ourFilledPropertyKey, true, Boolean.TRUE));
         visDepend.evaluateStyle();
         panel.addVisibilityDependency(visDepend);
 
@@ -454,6 +457,7 @@ public class PolygonFeatureVisualizationStyle extends AbstractPathVisualizationS
             }
         }
 
+        @SuppressWarnings("null")
         Vector2d center1 = longestPair.getFirstObject().getCenter();
         Vector2d center2 = longestPair.getSecondObject().getCenter();
         // Since the second segment is co-linear with the first segment's

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/SurfaceFeatureVisualizationStyle.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/SurfaceFeatureVisualizationStyle.java
@@ -133,7 +133,8 @@ public class SurfaceFeatureVisualizationStyle extends AbstractFeatureVisualizati
 
     @Override
     public void createCombinedGeometry(Set<Geometry> setToAddTo, FeatureCombinedGeometryBuilderData builderData,
-            RenderPropertyPool renderPropertyPool) throws IllegalArgumentException
+            RenderPropertyPool renderPropertyPool)
+        throws IllegalArgumentException
     {
         DefaultMeshScalableRenderProperties props = new DefaultMeshScalableRenderProperties(0, true, false);
         props.setBaseAltitude((float)getLift());
@@ -193,7 +194,8 @@ public class SurfaceFeatureVisualizationStyle extends AbstractFeatureVisualizati
 
     @Override
     public void createIndividualGeometry(Set<Geometry> setToAddTo, FeatureIndividualGeometryBuilderData builderData,
-            RenderPropertyPool renderPropertyPool) throws IllegalArgumentException
+            RenderPropertyPool renderPropertyPool)
+        throws IllegalArgumentException
     {
         throw new UnsupportedOperationException("Can't create individual geometry.");
     }
@@ -261,7 +263,7 @@ public class SurfaceFeatureVisualizationStyle extends AbstractFeatureVisualizati
         paramList.add(ccPanel);
 
         EditorPanelVisibilityDependency visDepend = new EditorPanelVisibilityDependency(panel, ccPanel);
-        visDepend.addConstraint(new ParameterVisibilityConstraint(ourDifferntTopColorKey, Boolean.TRUE, true));
+        visDepend.addConstraint(new ParameterVisibilityConstraint(ourDifferntTopColorKey, true, Boolean.TRUE));
         visDepend.evaluateStyle();
         panel.addVisibilityDependency(visDepend);
 
@@ -355,7 +357,7 @@ public class SurfaceFeatureVisualizationStyle extends AbstractFeatureVisualizati
         paramList.add(ccPanel);
 
         EditorPanelVisibilityDependency visDepend = new EditorPanelVisibilityDependency(panel, ccPanel);
-        visDepend.addConstraint(new ParameterVisibilityConstraint(ourDifferntTopColorKey, Boolean.TRUE, true));
+        visDepend.addConstraint(new ParameterVisibilityConstraint(ourDifferntTopColorKey, true, Boolean.TRUE));
         visDepend.evaluateStyle();
         panel.addVisibilityDependency(visDepend);
 

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/FloatSliderStyleParameterEditorPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/FloatSliderStyleParameterEditorPanel.java
@@ -109,7 +109,7 @@ public class FloatSliderStyleParameterEditorPanel extends AbstractStyleParameter
         ht.put(Integer.valueOf(iMin), new JLabel(myConvertor.labelValue(min)));
         ht.put(Integer.valueOf(iMax), new JLabel(myConvertor.labelValue(max)));
         mySlider.setLabelTable(ht);
-        mySlider.setPaintLabels((Boolean)myPanelBuilder.getOtherParameter(SHOW_SLIDER_LABELS, Boolean.TRUE));
+        mySlider.setPaintLabels(((Boolean)myPanelBuilder.getOtherParameter(SHOW_SLIDER_LABELS, Boolean.TRUE)).booleanValue());
 
         myValueLabel = new JLabel(myTextEntry ? myConvertor.getUnit() : createLabelWithUnit(initialVal, myConvertor));
         myTextField = new JTextField(myConvertor.labelValue(myConvertor.intToFloat(mySlider.getValue())));
@@ -379,7 +379,7 @@ public class FloatSliderStyleParameterEditorPanel extends AbstractStyleParameter
         @Override
         public String labelValue(double val)
         {
-            return String.format(myStringFormat, val);
+            return String.format(myStringFormat, Double.valueOf(val));
         }
     }
 

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/MultiComboEditor.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/MultiComboEditor.java
@@ -31,8 +31,10 @@ import io.opensphere.mantle.data.geom.style.MutableVisualizationStyle;
 import io.opensphere.mantle.data.geom.util.ListSupport;
 
 /**
- * An editor that supports editing a list of String values. A finite Collection of allowed values is specified, and then presented
- * to the user as the options. This class also enforces a configurable maximum number of values for which the default is five.
+ * An editor that supports editing a list of String values. A finite Collection
+ * of allowed values is specified, and then presented to the user as the
+ * options. This class also enforces a configurable maximum number of values for
+ * which the default is five.
  */
 @SuppressWarnings("unchecked")
 public class MultiComboEditor extends AbstractStyleParameterEditorPanel
@@ -91,7 +93,8 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
     }
 
     /**
-     * Specify the maximum number of values allowed by this editor. The default is five.
+     * Specify the maximum number of values allowed by this editor. The default
+     * is five.
      *
      * @param n the maximum number of combo-boxes
      */
@@ -101,8 +104,9 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
     }
 
     /**
-     * Provide a ListSupport object for parsing and writing a list as a String. This allows the creator of the editor to control
-     * the format of its input/output.
+     * Provide a ListSupport object for parsing and writing a list as a String.
+     * This allows the creator of the editor to control the format of its
+     * input/output.
      *
      * @param ls support for list formatting
      */
@@ -112,8 +116,9 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
     }
 
     /**
-     * Create and layout subcomponents for this editor. Currently selected values are loaded into the editor before it is
-     * presented to the user. The superclass setup method is also called before any other work is done.
+     * Create and layout subcomponents for this editor. Currently selected
+     * values are loaded into the editor before it is presented to the user. The
+     * superclass setup method is also called before any other work is done.
      *
      * @param num true if and only if the values are numeric
      * @param opts a Collection of options to be presented in the drop-down
@@ -193,7 +198,8 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
     {
         mainPanel.removeAll();
         rowList.stream().forEach(r -> mainPanel.add(r.mainPanel));
-        // include a button and message to add another one, if less than the maximum
+        // include a button and message to add another one, if less than the
+        // maximum
         if (rowList.size() < maxBoxes)
         {
             JLabel label = new JLabel("Click the plus button to add labels.");
@@ -214,6 +220,7 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
     }
 
     // only call on AWT thread when visible
+    @SuppressWarnings("null")
     private void selectValues(List<String> vals, boolean internal)
     {
         int count = 0;
@@ -375,8 +382,9 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
     }
 
     /**
-     * This simple class unites the components associated with one displayed row within the containing editor class. It also
-     * includes some convenience methods.
+     * This simple class unites the components associated with one displayed row
+     * within the containing editor class. It also includes some convenience
+     * methods.
      */
     private class ComboRow
     {
@@ -396,6 +404,7 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
         public JButton del = new IconButton(IconType.CLOSE, Color.RED);
 
         /** root container for GUI components. */
+        @SuppressWarnings("hiding")
         public JPanel mainPanel = new JPanel();
 
         {
@@ -436,8 +445,10 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
         }
 
         /**
-         * Install the specified value for this row. The value should be a formatted list where the first element is a boolean and
-         * is attributed to the checkbox and the second element is a general String and is attributed to the combo-box.
+         * Install the specified value for this row. The value should be a
+         * formatted list where the first element is a boolean and is attributed
+         * to the checkbox and the second element is a general String and is
+         * attributed to the combo-box.
          *
          * @param v the formatted list of fields
          */
@@ -448,7 +459,7 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
             String sel = null;
             if (fields.size() > 1)
             {
-                check = Boolean.valueOf(fields.get(0));
+                check = Boolean.parseBoolean(fields.get(0));
                 sel = fields.get(1);
             }
             else if (fields.size() == 1)
@@ -460,8 +471,9 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
         }
 
         /**
-         * Obtain a formatted list representing the current state of this row. The values are, in order, a boolean value for the
-         * checkbox and the selection from the combo-box.
+         * Obtain a formatted list representing the current state of this row.
+         * The values are, in order, a boolean value for the checkbox and the
+         * selection from the combo-box.
          *
          * @return the formatted list of fields
          */
@@ -481,9 +493,10 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
     }
 
     /**
-     * A null-tolerant wrapper for drop-down options. The toString method returns "NONE" in case the embedded reference is null;
-     * otherwise, it delegates to value's toString method. This class also implements comparison methods useful for numerical and
-     * lexical ordering.
+     * A null-tolerant wrapper for drop-down options. The toString method
+     * returns "NONE" in case the embedded reference is null; otherwise, it
+     * delegates to value's toString method. This class also implements
+     * comparison methods useful for numerical and lexical ordering.
      *
      * @param <T> the type of wrapped object
      */
@@ -516,9 +529,10 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
         }
 
         /**
-         * Compare this OptionProxy to another according to lexical order. As is common practice in Java, return a negative number
-         * if this one is less than the other, a positive number if it is greater, or zero if they are equivalent. Note: this
-         * operation is not null-tolerant.
+         * Compare this OptionProxy to another according to lexical order. As is
+         * common practice in Java, return a negative number if this one is less
+         * than the other, a positive number if it is greater, or zero if they
+         * are equivalent. Note: this operation is not null-tolerant.
          *
          * @param p the other OptionProxy
          * @return an integer result (see above)
@@ -529,10 +543,12 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
         }
 
         /**
-         * Compare this OptionProxy to another according to numerical order, if possible. If the embedded values are Numbers or
-         * are Strings that can be parsed as such, then they are compared as floating-point numerical values. If that comparison
-         * fails for any reason, then lexical comparison of String values is used as a fallback. Note: this operation is not
-         * null-tolerant.
+         * Compare this OptionProxy to another according to numerical order, if
+         * possible. If the embedded values are Numbers or are Strings that can
+         * be parsed as such, then they are compared as floating-point numerical
+         * values. If that comparison fails for any reason, then lexical
+         * comparison of String values is used as a fallback. Note: this
+         * operation is not null-tolerant.
          *
          * @param p the other OptionProxy
          * @return an integer result (see above)
@@ -565,7 +581,8 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
     }
 
     /**
-     * Construct a mutable List containing the specified element. If a null given, then the result is an empty List.
+     * Construct a mutable List containing the specified element. If a null
+     * given, then the result is an empty List.
      *
      * @param e the sole element of the resulting list or null
      * @param <E> the element type

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/tilecontroller/TileStyleTransformController.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/tilecontroller/TileStyleTransformController.java
@@ -317,7 +317,7 @@ public class TileStyleTransformController implements VisualizationStyleRegistryC
                             @Override
                             public void run()
                             {
-                                if (dti != null && dti.getMapVisualizationInfo() != null
+                                if (dti.getMapVisualizationInfo() != null
                                         && dti.getMapVisualizationInfo().getTileRenderProperties() != null)
                                 {
                                     tileStyle.updateTileRenderProperties(dti.getMapVisualizationInfo().getTileRenderProperties());

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/merge/KeySpecification.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/merge/KeySpecification.java
@@ -118,17 +118,17 @@ public class KeySpecification
             catch (ClassNotFoundException e)
             {
                 LOGGER.error("Could not find SpecialKey class: " + specialKeyClassName, e);
-                sk = null;
+//                sk = null;
             }
             catch (NoSuchMethodException | InvocationTargetException | InstantiationException e)
             {
                 LOGGER.error("Could not instantiate SpecialKey class: " + specialKeyClassName, e);
-                sk = null;
+//                sk = null;
             }
             catch (IllegalAccessException e)
             {
                 LOGGER.error(e);
-                sk = null;
+//                sk = null;
             }
         }
         return sk;

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/util/impl/DataElementLookupUtilsImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/util/impl/DataElementLookupUtilsImpl.java
@@ -202,6 +202,20 @@ public class DataElementLookupUtilsImpl implements DataElementLookupUtils
     @Override
     public DataElement getDataElement(long dataElementId, DataTypeInfo dtiHint, String dataTypeInfoKeyHint)
     {
+        return getDataElement(Long.valueOf(dataElementId), dtiHint, dataTypeInfoKeyHint);
+    }
+
+    /**
+     * Long overload.
+     *
+     * @see #getDataElement(long, DataTypeInfo, String)
+     * @param dataElementId
+     * @param dtiHint
+     * @param dataTypeInfoKeyHint
+     * @return the data element
+     */
+    public DataElement getDataElement(Long dataElementId, DataTypeInfo dtiHint, String dataTypeInfoKeyHint)
+    {
         DataElement result = null;
         try
         {
@@ -377,6 +391,18 @@ public class DataElementLookupUtilsImpl implements DataElementLookupUtils
     @Override
     public MapGeometrySupport getMapGeometrySupport(long dataElementId)
     {
+        return getMapGeometrySupport(Long.valueOf(dataElementId));
+    }
+
+    /**
+     * Long overload.
+     *
+     * @see #getMapGeometrySupport(long)
+     * @param dataElementId
+     * @return the MapGeometrySupport or null if not found.
+     */
+    public MapGeometrySupport getMapGeometrySupport(Long dataElementId)
+    {
         SimpleResultCacheIdQuery<MapGeometrySupport> query = new SimpleResultCacheIdQuery<MapGeometrySupport>(
                 Collections.singletonList(dataElementId), new QueryAccessConstraint(false, false, false, false, true))
         {
@@ -398,6 +424,18 @@ public class DataElementLookupUtilsImpl implements DataElementLookupUtils
 
     @Override
     public List<Object> getMetaData(long dataElementId)
+    {
+        return getMetaData(Long.valueOf(dataElementId));
+    }
+
+    /**
+     * Long overload.
+     *
+     * @see #getMetaData(long)
+     * @param dataElementId
+     * @return the meta data List or null if id not found.
+     */
+    public List<Object> getMetaData(Long dataElementId)
     {
         SimpleResultCacheIdQuery<List<Object>> query = new SimpleResultCacheIdQuery<List<Object>>(
                 Collections.singletonList(dataElementId), new QueryAccessConstraint(false, false, false, true, false))
@@ -433,6 +471,7 @@ public class DataElementLookupUtilsImpl implements DataElementLookupUtils
             dataElementIds = dataElementIds.subList(0, maxToQuery);
         }
 
+        @SuppressWarnings("null")
         final int keyIndex = dti.getMetaDataInfo().getKeyIndex(keyName);
 
         SimpleResultCacheIdQuery<List<Object>> query = new SimpleResultCacheIdQuery<List<Object>>(dataElementIds,
@@ -505,6 +544,19 @@ public class DataElementLookupUtilsImpl implements DataElementLookupUtils
     @Override
     public MetaDataProvider getMetaDataProvider(long dataElementId)
     {
+        return getMetaDataProvider(Long.valueOf(dataElementId));
+    }
+
+    /**
+     * Long overload.
+     *
+     * @see #getMetaDataProvider(long)
+     * @param dataElementId
+     * @return the MetaDataProvider or null if the id is not in the registry or
+     *         the DataTypeInfo cannot be located for the data element.
+     */
+    public MetaDataProvider getMetaDataProvider(Long dataElementId)
+    {
         SimpleResultCacheIdQuery<Pair<String, List<Object>>> query = new SimpleResultCacheIdQuery<Pair<String, List<Object>>>(
                 Collections.singletonList(dataElementId), new QueryAccessConstraint(false, false, false, true, false))
         {
@@ -543,6 +595,18 @@ public class DataElementLookupUtilsImpl implements DataElementLookupUtils
     @Override
     public Long getOriginId(long dataElementId)
     {
+        return getOriginId(Long.valueOf(dataElementId));
+    }
+
+    /**
+     * Long overload.
+     *
+     * @see #getOriginId(long)
+     * @param dataElementId
+     * @return the origin id or -1 if not found.
+     */
+    public Long getOriginId(Long dataElementId)
+    {
         Long origId = null;
         SimpleResultCacheIdQuery<Long> ciq = new SimpleResultCacheIdQuery<Long>(Collections.singletonList(dataElementId),
                 new QueryAccessConstraint(false, false, true, false, false))
@@ -558,7 +622,7 @@ public class DataElementLookupUtilsImpl implements DataElementLookupUtils
 
         if (origId == null)
         {
-            return -1L;
+            return Long.valueOf(-1L);
         }
         else
         {
@@ -637,20 +701,28 @@ public class DataElementLookupUtilsImpl implements DataElementLookupUtils
     }
 
     /**
-     * Retrieves the DataElements by id. The dtiHint and dataTypeInfoKeyHint can help prevent multiple queries from running
-     * against the data model. They are used in the dtiHint first, then the dataTypeInfoKeyHint second. If neither hint is
-     * provided then they will be queried first so that the remainder of the element can be retrieved and reformed.
+     * Retrieves the DataElements by id. The dtiHint and dataTypeInfoKeyHint can
+     * help prevent multiple queries from running against the data model. They
+     * are used in the dtiHint first, then the dataTypeInfoKeyHint second. If
+     * neither hint is provided then they will be queried first so that the
+     * remainder of the element can be retrieved and reformed.
      *
-     * All of the id's requested must be of the same data type or an exception will be generated.
+     * All of the id's requested must be of the same data type or an exception
+     * will be generated.
      *
      * @param dataElementIds the data element ids to lookup
-     * @param dtiHint the {@link DataTypeInfo} for the point if known ( null if not known is okay )
-     * @param dataTypeInfoKeyHint the key for the DataTypeInfo if known ( null if not known is okay )
-     * @param ignoreMapGeometrySupport the ignore map data elements map geometry support ( don't get the extra MGS parts )
+     * @param dtiHint the {@link DataTypeInfo} for the point if known ( null if
+     *            not known is okay )
+     * @param dataTypeInfoKeyHint the key for the DataTypeInfo if known ( null
+     *            if not known is okay )
+     * @param ignoreMapGeometrySupport the ignore map data elements map geometry
+     *            support ( don't get the extra MGS parts )
      * @return the resulting data elements
-     * @throws DataElementLookupException if the dtiHint or dataTypeInfoKeyHint are the wrong type for any of the ids provided, or
-     *             if the types retrieved are of different data types, or if the data type cannot be determined, or if all the ids
-     *             cannot be retrieved.
+     * @throws DataElementLookupException if the dtiHint or dataTypeInfoKeyHint
+     *             are the wrong type for any of the ids provided, or if the
+     *             types retrieved are of different data types, or if the data
+     *             type cannot be determined, or if all the ids cannot be
+     *             retrieved.
      */
     private List<DataElement> retrieveDataElements(List<Long> dataElementIds, DataTypeInfo dtiHint, String dataTypeInfoKeyHint,
             boolean ignoreMapGeometrySupport)

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/mp/impl/DefaultMapAnnotationPoint.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/mp/impl/DefaultMapAnnotationPoint.java
@@ -489,7 +489,8 @@ public class DefaultMapAnnotationPoint implements MutableMapAnnotationPoint
     /**
      * {@inheritDoc}
      *
-     * @see io.opensphere.mantle.mp.MutableMapAnnotationPoint#setTimeEnabled(boolean, Object)
+     * @see io.opensphere.mantle.mp.MutableMapAnnotationPoint#setTimeEnabled(boolean,
+     *      Object)
      */
     @Override
     public void setTimeEnabled(boolean timeEnabled, Object source)
@@ -497,7 +498,7 @@ public class DefaultMapAnnotationPoint implements MutableMapAnnotationPoint
         if (timeEnabled != myTimeEnabled)
         {
             myTimeEnabled = timeEnabled;
-            fireChangeEvent(new MapAnnotationPointChangeEvent(this, myTimeEnabled, source));
+            fireChangeEvent(new MapAnnotationPointChangeEvent(this, Boolean.valueOf(myTimeEnabled), source));
         }
     }
 

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/util/columnanalyzer/ColumnDataAnalyzer.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/util/columnanalyzer/ColumnDataAnalyzer.java
@@ -84,7 +84,7 @@ public class ColumnDataAnalyzer
                 {
                     try
                     {
-                        doubleResult = Double.parseDouble(value);
+                        doubleResult = Double.valueOf(value);
                         doubleSuccess = true;
                         myData.incrementDoubleCount();
                         doubleSuccess = checkDoubleForInfinateAndNan(doubleSuccess, doubleResult);
@@ -99,7 +99,7 @@ public class ColumnDataAnalyzer
                 {
                     try
                     {
-                        floatResult = Float.parseFloat(value);
+                        floatResult = Float.valueOf(value);
                         myData.incrementFloatCount();
                         floatSuccess = checkFloatForInfNanAndPrecision(doubleSuccess, doubleResult, floatResult);
                     }

--- a/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/JRELocatorHelper.java
+++ b/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/JRELocatorHelper.java
@@ -173,7 +173,7 @@ public class JRELocatorHelper
         catch (Exception e)
         {
             // Will only be happen if registry handler is good, but an
-           // exception at performing was thrown. This is an error...
+            // exception at performing was thrown. This is an error...
             e.printStackTrace();
         }
         finally
@@ -317,7 +317,7 @@ public class JRELocatorHelper
 
         for (i = 0; i < currentRange; ++i)
         {
-            if (useNotIdentifier != null && interestedEntries[i].contains(useNotIdentifier))
+            if (interestedEntries[i].contains(useNotIdentifier))
             {
                 continue;
             }

--- a/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/JRELocatorPanel.java
+++ b/open-sphere-install/open-sphere-install-panels/src/main/java/io/opensphere/installer/panels/jre/JRELocatorPanel.java
@@ -67,8 +67,10 @@ public class JRELocatorPanel extends IzPanel implements ActionListener, Hyperlin
      */
     protected final PathSelectionPanel pathSelectionPanel;
 
+    /** The Empty Target message. */
     protected final String emptyTargetMsg;
 
+    /** The Warning message. */
     protected final String warnMsg;
 
     /**
@@ -256,6 +258,7 @@ public class JRELocatorPanel extends IzPanel implements ActionListener, Hyperlin
     /**
      * Determines if required files exist relative to the specified path
      *
+     * @param path the path to check
      * @return {@code true} if no files are required, or they exist
      */
     protected boolean checkRequiredFilesExist(String path)
@@ -329,11 +332,13 @@ public class JRELocatorPanel extends IzPanel implements ActionListener, Hyperlin
      */
     protected boolean modifyInstallation()
     {
-        return Boolean.valueOf(installData.getVariable(InstallData.MODIFY_INSTALLATION));
+        return Boolean.valueOf(installData.getVariable(InstallData.MODIFY_INSTALLATION)).booleanValue();
     }
 
     /**
      * Same as calling {@link #pathIsValid(boolean) pathIsValid(false)}.
+     *
+     * @return if path is valid
      */
     protected boolean pathIsValid()
     {
@@ -346,6 +351,7 @@ public class JRELocatorPanel extends IzPanel implements ActionListener, Hyperlin
      * can be also implemented in derived classes to handle special verification
      * of the path.
      *
+     * @param notifyUserIfInvalid whether or not to notify user on invalid path
      * @return true if existFiles are exist or not defined, else false
      */
     protected boolean pathIsValid(boolean notifyUserIfInvalid)
@@ -420,6 +426,11 @@ public class JRELocatorPanel extends IzPanel implements ActionListener, Hyperlin
         return false;
     }
 
+    /**
+     * Test the validity of the path.
+     *
+     * @return if path is valid
+     */
     protected boolean testValidPath()
     {
         String path = getPath();

--- a/open-sphere-plugins/arcgis/src/main/java/io/opensphere/arcgis2/esri/EsriPictureMarkerSymbol.java
+++ b/open-sphere-plugins/arcgis/src/main/java/io/opensphere/arcgis2/esri/EsriPictureMarkerSymbol.java
@@ -84,7 +84,8 @@ public class EsriPictureMarkerSymbol extends EsriSymbolWithOffset
         }
         catch (IOException e)
         {
-            image = null;
+            // image is either null or an IOException wasn't thrown
+            // image = null;
         }
         return image;
     }

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/DateRater.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/DateRater.java
@@ -92,32 +92,33 @@ public class DateRater
                     for (Pair<DateColumn, Integer> result : results)
                     {
                         DateColumn dateColumn = result.getFirstObject();
+                        int secondObject = result.getSecondObject().intValue();
 
                         removePotentials(potentials, dateColumn);
 
                         if (firstDate == null)
                         {
                             firstDate = dateColumn;
-                            firstDateScore = result.getSecondObject();
+                            firstDateScore = secondObject;
                         }
                         else if (secondDate == null)
                         {
                             secondDate = dateColumn;
-                            secondDateScore = result.getSecondObject();
+                            secondDateScore = secondObject;
                         }
-                        else if (firstDateScore <= result.getSecondObject()
+                        else if (firstDateScore <= result.getSecondObject().intValue()
                                 && firstDate.getPrimaryColumnIndex() > dateColumn.getPrimaryColumnIndex()
                                 && firstDate.getDateColumnType() == dateColumn.getDateColumnType())
                         {
                             firstDate = dateColumn;
-                            firstDateScore = result.getSecondObject();
+                            firstDateScore = secondObject;
                         }
-                        else if (secondDateScore <= result.getSecondObject()
+                        else if (secondDateScore <= result.getSecondObject().intValue()
                                 && secondDate.getPrimaryColumnIndex() > dateColumn.getPrimaryColumnIndex()
                                 && secondDate.getDateColumnType() == dateColumn.getDateColumnType())
                         {
                             secondDate = dateColumn;
-                            secondDateScore = result.getSecondObject();
+                            secondDateScore = secondObject;
                         }
                         else
                         {

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/DateTimeFinder.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/DateTimeFinder.java
@@ -88,7 +88,7 @@ public class DateTimeFinder
                 {
                     if (headerCell.toUpperCase().contains(excludeColumn.toUpperCase()))
                     {
-                        potentials.remove(columnIndex);
+                        potentials.remove(Integer.valueOf(columnIndex));
                     }
                 }
 

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/MatchMaker.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/MatchMaker.java
@@ -59,16 +59,18 @@ public class MatchMaker
                 for (int columnIndex = 0; columnIndex < row.size(); ++columnIndex)
                 {
                     String cell = row.get(columnIndex);
+                    Integer numColumnIndex = Integer.valueOf(columnIndex);
                     if (StringUtils.isNotEmpty(cell))
                     {
                         if (!hasCellsBeenCounted)
                         {
-                            if (!numberOfNonBlankCells.containsKey(columnIndex))
+                            if (!numberOfNonBlankCells.containsKey(numColumnIndex))
                             {
-                                numberOfNonBlankCells.put(columnIndex, 0);
+                                numberOfNonBlankCells.put(numColumnIndex, Integer.valueOf(0));
                             }
 
-                            numberOfNonBlankCells.put(columnIndex, numberOfNonBlankCells.get(columnIndex) + 1);
+                            numberOfNonBlankCells.put(numColumnIndex,
+                                    Integer.valueOf(numberOfNonBlankCells.get(numColumnIndex).intValue() + 1));
                         }
 
                         boolean matches = isEmptyRegex;
@@ -80,15 +82,15 @@ public class MatchMaker
 
                         if (matches)
                         {
-                            if (!potentialDates.containsKey(columnIndex))
+                            if (!potentialDates.containsKey(numColumnIndex))
                             {
                                 PotentialColumn potential = new PotentialColumn();
                                 potential.setColumnIndex(columnIndex);
 
-                                potentialDates.put(columnIndex, potential);
+                                potentialDates.put(numColumnIndex, potential);
                             }
 
-                            PotentialColumn potential = potentialDates.get(columnIndex);
+                            PotentialColumn potential = potentialDates.get(numColumnIndex);
 
                             String formatKey = format.getSdf();
 
@@ -144,7 +146,7 @@ public class MatchMaker
             float numberOfNonBlankCells = 0f;
             if (nonBlankCells.containsKey(entry.getKey()))
             {
-                numberOfNonBlankCells = nonBlankCells.get(entry.getKey());
+                numberOfNonBlankCells = nonBlankCells.get(entry.getKey()).floatValue();
             }
 
             PotentialColumn column = entry.getValue();

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/CompositeDateTimeDecider.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/CompositeDateTimeDecider.java
@@ -7,7 +7,6 @@ import io.opensphere.core.common.configuration.date.DateFormat.Type;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.lang.Pair;
 import io.opensphere.csvcommon.common.datetime.DateColumn;
-import io.opensphere.csvcommon.detect.datetime.algorithm.deciders.Decider;
 import io.opensphere.csvcommon.detect.datetime.model.PotentialColumn;
 import io.opensphere.csvcommon.detect.datetime.model.SuccessfulFormat;
 import io.opensphere.csvcommon.detect.datetime.util.Constants;
@@ -38,13 +37,13 @@ public class CompositeDateTimeDecider implements Decider
         Set<Integer> dateColumns = New.set();
         for (Pair<PotentialColumn, Integer> pair : dateScores)
         {
-            dateColumns.add(pair.getFirstObject().getColumnIndex());
+            dateColumns.add(Integer.valueOf(pair.getFirstObject().getColumnIndex()));
         }
 
         List<PotentialColumn> timePotentials = New.list();
         for (PotentialColumn column : potentials)
         {
-            if (!dateColumns.contains(column.getColumnIndex()))
+            if (!dateColumns.contains(Integer.valueOf(column.getColumnIndex())))
             {
                 timePotentials.add(column);
             }
@@ -118,9 +117,9 @@ public class CompositeDateTimeDecider implements Decider
             column.setSecondaryColumnFormat(timeFormat.getFormat().getSdf());
             column.setSecondaryColumnIndex(timePart.getColumnIndex());
 
-            Integer score = (datePartScore + timePartScore) / 2;
+            int score = (datePartScore.intValue() + timePartScore.intValue()) / 2;
 
-            result.add(new Pair<DateColumn, Integer>(column, score));
+            result.add(new Pair<DateColumn, Integer>(column, Integer.valueOf(score)));
         }
 
         return result;
@@ -143,7 +142,7 @@ public class CompositeDateTimeDecider implements Decider
     {
         Pair<PotentialColumn, Integer> bestPassing = null;
 
-        Integer maxScore = Constants.THRESHOLD_SCORE;
+        Integer maxScore = Integer.valueOf(Constants.THRESHOLD_SCORE);
 
         for (Pair<PotentialColumn, Integer> score : scores)
         {

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/OneDayMultipleTimesDecider.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/OneDayMultipleTimesDecider.java
@@ -10,7 +10,6 @@ import io.opensphere.core.common.configuration.date.DateFormat.Type;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.lang.Pair;
 import io.opensphere.csvcommon.common.datetime.DateColumn;
-import io.opensphere.csvcommon.detect.datetime.algorithm.deciders.Decider;
 import io.opensphere.csvcommon.detect.datetime.model.PotentialColumn;
 import io.opensphere.csvcommon.detect.datetime.util.DateColumnValueProvider;
 
@@ -117,11 +116,13 @@ public class OneDayMultipleTimesDecider implements Decider
                         secondDate.setSecondaryColumnFormat(secondTime.getFirstObject().getPrimaryColumnFormat());
                         secondDate.setSecondaryColumnIndex(secondTime.getFirstObject().getPrimaryColumnIndex());
 
-                        int firstDateScore = (dateColumn.getSecondObject() + firstTime.getSecondObject()) / 2;
-                        int secondDateScore = (dateColumn.getSecondObject() + secondTime.getSecondObject()) / 2;
+                        int firstDateScore = (dateColumn.getSecondObject().intValue() + firstTime.getSecondObject().intValue())
+                                / 2;
+                        int secondDateScore = (dateColumn.getSecondObject().intValue() + secondTime.getSecondObject().intValue())
+                                / 2;
 
-                        results.add(new Pair<DateColumn, Integer>(firstDate, firstDateScore));
-                        results.add(new Pair<DateColumn, Integer>(secondDate, secondDateScore));
+                        results.add(new Pair<DateColumn, Integer>(firstDate, Integer.valueOf(firstDateScore)));
+                        results.add(new Pair<DateColumn, Integer>(secondDate, Integer.valueOf(secondDateScore)));
                     }
                 }
             }

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/SingleValueDecider.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/SingleValueDecider.java
@@ -11,7 +11,6 @@ import io.opensphere.core.common.configuration.date.DateFormat.Type;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.lang.Pair;
 import io.opensphere.csvcommon.common.datetime.DateColumn;
-import io.opensphere.csvcommon.detect.datetime.algorithm.deciders.Decider;
 import io.opensphere.csvcommon.detect.datetime.model.PotentialColumn;
 import io.opensphere.csvcommon.detect.datetime.model.SuccessfulFormat;
 import io.opensphere.csvcommon.detect.datetime.util.Constants;
@@ -98,7 +97,7 @@ public abstract class SingleValueDecider implements Decider
                 if (score > getPassingScore())
                 {
                     potential.setMostSuccessfulFormat(format);
-                    Pair<PotentialColumn, Integer> pair = new Pair<>(potential, score);
+                    Pair<PotentialColumn, Integer> pair = new Pair<>(potential, Integer.valueOf(score));
                     scores.add(pair);
                     break;
                 }
@@ -111,7 +110,7 @@ public abstract class SingleValueDecider implements Decider
     @Override
     public List<Pair<DateColumn, Integer>> compileResults(List<Pair<PotentialColumn, Integer>> potentials)
     {
-        Integer maxScore = -1;
+        Integer maxScore = Integer.valueOf(-1);
         PotentialColumn bestColumn = null;
 
         for (Pair<PotentialColumn, Integer> pair : potentials)

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/columndefinition/controller/ColumnTypeLocationComparator.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/columndefinition/controller/ColumnTypeLocationComparator.java
@@ -27,11 +27,11 @@ public class ColumnTypeLocationComparator implements Comparator<ColumnType>, Ser
      */
     public ColumnTypeLocationComparator()
     {
-        myLocationOrders.put(ColumnType.LAT, 0);
-        myLocationOrders.put(ColumnType.LON, 1);
-        myLocationOrders.put(ColumnType.MGRS, 2);
-        myLocationOrders.put(ColumnType.POSITION, 3);
-        myLocationOrders.put(ColumnType.WKT_GEOMETRY, 4);
+        myLocationOrders.put(ColumnType.LAT, Integer.valueOf(0));
+        myLocationOrders.put(ColumnType.LON, Integer.valueOf(1));
+        myLocationOrders.put(ColumnType.MGRS, Integer.valueOf(2));
+        myLocationOrders.put(ColumnType.POSITION, Integer.valueOf(3));
+        myLocationOrders.put(ColumnType.WKT_GEOMETRY, Integer.valueOf(4));
     }
 
     @Override
@@ -54,7 +54,7 @@ public class ColumnTypeLocationComparator implements Comparator<ColumnType>, Ser
         Integer order = myLocationOrders.get(columnType);
         if (order == null)
         {
-            order = Integer.MAX_VALUE;
+            order = Integer.valueOf(Integer.MAX_VALUE);
         }
 
         return order;

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/columndefinition/controller/TypeController.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/columndefinition/controller/TypeController.java
@@ -235,18 +235,18 @@ public class TypeController implements Observer
             LatLonColumnResults latLonResult = result.getMostLikelyLatLonColumnPair();
             PotentialLocationColumn locationColumn = result.getMostLikelyLocationColumn();
             if (latLonResult != null && latLonResult.getLatColumn() != null
-                    && latLonResult.getLatColumn().getColumnIndex() == columnId)
+                    && latLonResult.getLatColumn().getColumnIndex() == columnId.intValue())
             {
                 isPotentialLocation = true;
                 break;
             }
             else if (latLonResult != null && latLonResult.getLonColumn() != null
-                    && latLonResult.getLonColumn().getColumnIndex() == columnId)
+                    && latLonResult.getLonColumn().getColumnIndex() == columnId.intValue())
             {
                 isPotentialLocation = true;
                 break;
             }
-            else if (locationColumn != null && locationColumn.getColumnIndex() == columnId)
+            else if (locationColumn != null && locationColumn.getColumnIndex() == columnId.intValue())
             {
                 isPotentialLocation = true;
                 break;

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/columndefinition/model/ColumnDefinitionTableModel.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/columndefinition/model/ColumnDefinitionTableModel.java
@@ -183,7 +183,7 @@ public class ColumnDefinitionTableModel extends AbstractTableModel
 
         if (columnIndex == 0)
         {
-            row.setIsImport((Boolean)aValue);
+            row.setIsImport(((Boolean)aValue).booleanValue());
         }
         else if (columnIndex == 1 && StringUtils.isNotEmpty((String)aValue))
         {

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/columndefinition/ui/ColumnDefinitionTableBinder.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/columndefinition/ui/ColumnDefinitionTableBinder.java
@@ -59,8 +59,7 @@ public class ColumnDefinitionTableBinder implements Observer, ListSelectionListe
         {
             int currentSelection = myTable.getSelectionModel().getAnchorSelectionIndex();
             ColumnDefinitionRow selectedRow = myModel.getSelectedDefinition();
-            if (currentSelection < 0 && selectedRow != null
-                    || selectedRow != null && selectedRow.getColumnId() != currentSelection)
+            if (selectedRow != null && (currentSelection < 0 || selectedRow.getColumnId() != currentSelection))
             {
                 myTable.getSelectionModel().setSelectionInterval(selectedRow.getColumnId(), selectedRow.getColumnId());
             }

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/controller/ImportableColumnController.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/controller/ImportableColumnController.java
@@ -36,7 +36,7 @@ public class ImportableColumnController
             int index = 0;
             for (String columnName : parameters.getColumnNames())
             {
-                upperCasedColumnNames.put(columnName.toUpperCase(), index);
+                upperCasedColumnNames.put(columnName.toUpperCase(), Integer.valueOf(index));
                 index++;
             }
 

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/common/datetime/ConfigurationProviderImplTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/common/datetime/ConfigurationProviderImplTest.java
@@ -11,12 +11,12 @@ import io.opensphere.core.common.configuration.date.DateFormat;
 import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.preferences.Preferences;
 import io.opensphere.core.preferences.PreferencesRegistry;
-import io.opensphere.csvcommon.common.datetime.ConfigurationProviderImpl;
 import io.opensphere.mantle.util.MantleConstants;
 
 /**
  * Tests the ConfigurationProviderImpl class.
  */
+@SuppressWarnings("boxing")
 public class ConfigurationProviderImplTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/common/datetime/MigratorTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/common/datetime/MigratorTest.java
@@ -12,20 +12,19 @@ import org.easymock.IAnswer;
 import org.junit.Test;
 
 import io.opensphere.core.common.configuration.date.DateFormat;
-import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.common.configuration.date.DateFormat.Type;
+import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.preferences.Preferences;
 import io.opensphere.core.preferences.PreferencesRegistry;
 import io.opensphere.core.util.DateTimeFormats;
 import io.opensphere.core.util.collections.New;
-import io.opensphere.csvcommon.common.datetime.ConfigurationProvider;
-import io.opensphere.csvcommon.common.datetime.Migrator;
 import io.opensphere.mantle.util.MantleConstants;
 
 /**
  * Tests the Migrator class.
  *
  */
+@SuppressWarnings("boxing")
 public class MigratorTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/controller/DetectionControllerImplTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/controller/DetectionControllerImplTest.java
@@ -24,6 +24,7 @@ import io.opensphere.csvcommon.util.LocationTestUtils;
 import io.opensphere.mantle.util.MantleConstants;
 
 /** Test {@link DetectionControllerImpl}. */
+@SuppressWarnings("boxing")
 public class DetectionControllerImplTest extends EasyMockSupport
 {
     /** Test the test. */

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/DateTimeDetectorTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/DateTimeDetectorTest.java
@@ -11,8 +11,8 @@ import org.easymock.EasyMockSupport;
 import org.junit.Test;
 
 import io.opensphere.core.common.configuration.date.DateFormat;
-import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.common.configuration.date.DateFormat.Type;
+import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.preferences.ClasspathPreferencesPersistenceManager;
 import io.opensphere.core.preferences.InternalPreferencesIF;
 import io.opensphere.core.preferences.Preferences;
@@ -21,7 +21,6 @@ import io.opensphere.core.util.collections.New;
 import io.opensphere.csvcommon.common.CellSampler;
 import io.opensphere.csvcommon.common.datetime.DateColumnResults;
 import io.opensphere.csvcommon.detect.ValuesWithConfidence;
-import io.opensphere.csvcommon.detect.datetime.DateTimeDetector;
 import io.opensphere.csvcommon.detect.datetime.util.DateDataGenerator;
 import io.opensphere.csvcommon.detect.util.CSVColumnPrefsUtil;
 import io.opensphere.importer.config.ColumnType;
@@ -109,7 +108,7 @@ public class DateTimeDetectorTest
         preferences.getStringList(EasyMock.cmpEq(ColumnType.TIMESTAMP.name() + "_exclude"), (List<String>)EasyMock.isNull());
         EasyMock.expectLastCall().andReturn(New.list("mod"));
         preferences.getBoolean(EasyMock.isA(String.class), EasyMock.eq(false));
-        EasyMock.expectLastCall().andReturn(true);
+        EasyMock.expectLastCall().andReturn(Boolean.TRUE);
 
         PreferencesRegistry registry = support.createMock(PreferencesRegistry.class);
         registry.getPreferences(EasyMock.cmpEq(MantleConstants.USER_DATE_FORMAT_CONFIG_FILE_TOPIC));

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/DateRaterTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/DateRaterTest.java
@@ -15,7 +15,6 @@ import io.opensphere.core.util.DateTimeFormats;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.csvcommon.common.datetime.DateColumnResults;
 import io.opensphere.csvcommon.detect.ValueWithConfidence;
-import io.opensphere.csvcommon.detect.datetime.algorithm.DateRater;
 import io.opensphere.csvcommon.detect.datetime.model.PotentialColumn;
 import io.opensphere.csvcommon.detect.datetime.model.SuccessfulFormat;
 import io.opensphere.csvcommon.detect.datetime.util.DateDataGenerator;
@@ -24,7 +23,7 @@ import io.opensphere.csvcommon.detect.datetime.util.DateDataGenerator;
  * Tests the DateRater class.
  *
  */
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings({ "PMD.GodClass", "boxing" })
 public class DateRaterTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/DateRaterTestFunctional.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/DateRaterTestFunctional.java
@@ -10,15 +10,14 @@ import java.util.Map;
 import org.junit.Test;
 
 import io.opensphere.core.common.configuration.date.DateFormat;
-import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.common.configuration.date.DateFormat.Type;
+import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.preferences.ClasspathPreferencesPersistenceManager;
 import io.opensphere.core.preferences.InternalPreferencesIF;
 import io.opensphere.core.util.DateTimeFormats;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.csvcommon.common.datetime.DateColumnResults;
 import io.opensphere.csvcommon.detect.ValueWithConfidence;
-import io.opensphere.csvcommon.detect.datetime.algorithm.DateRater;
 import io.opensphere.csvcommon.detect.datetime.model.PotentialColumn;
 import io.opensphere.csvcommon.detect.datetime.model.SuccessfulFormat;
 import io.opensphere.csvcommon.detect.datetime.util.DateDataGenerator;
@@ -28,7 +27,7 @@ import io.opensphere.mantle.util.MantleConstants;
  * Tests the DateRater class.
  *
  */
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings({ "PMD.GodClass", "boxing" })
 public class DateRaterTestFunctional
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/MatchMakerTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/MatchMakerTest.java
@@ -12,12 +12,11 @@ import org.easymock.EasyMockSupport;
 import org.junit.Test;
 
 import io.opensphere.core.common.configuration.date.DateFormat;
-import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.common.configuration.date.DateFormat.Type;
+import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.preferences.ClasspathPreferencesPersistenceManager;
 import io.opensphere.core.preferences.InternalPreferencesIF;
 import io.opensphere.csvcommon.common.datetime.ConfigurationProvider;
-import io.opensphere.csvcommon.detect.datetime.algorithm.MatchMaker;
 import io.opensphere.csvcommon.detect.datetime.model.PotentialColumn;
 import io.opensphere.csvcommon.detect.datetime.model.SuccessfulFormat;
 import io.opensphere.csvcommon.util.CsvTestUtils;
@@ -27,6 +26,7 @@ import io.opensphere.mantle.util.MantleConstants;
  * Tests the MatchMaker class.
  *
  */
+@SuppressWarnings("boxing")
 public class MatchMakerTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/CompositeDateTimeDeciderTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/CompositeDateTimeDeciderTest.java
@@ -11,7 +11,6 @@ import io.opensphere.core.common.configuration.date.DateFormat.Type;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.lang.Pair;
 import io.opensphere.csvcommon.common.datetime.DateColumn;
-import io.opensphere.csvcommon.detect.datetime.algorithm.deciders.CompositeDateTimeDecider;
 import io.opensphere.csvcommon.detect.datetime.model.PotentialColumn;
 import io.opensphere.csvcommon.detect.datetime.model.SuccessfulFormat;
 import io.opensphere.csvcommon.util.CsvTestUtils;
@@ -20,6 +19,7 @@ import io.opensphere.csvcommon.util.CsvTestUtils;
  * Tests the DateDecider class.
  *
  */
+@SuppressWarnings("boxing")
 public class CompositeDateTimeDeciderTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/DateDeciderTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/DateDeciderTest.java
@@ -11,7 +11,6 @@ import io.opensphere.core.common.configuration.date.DateFormat.Type;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.lang.Pair;
 import io.opensphere.csvcommon.common.datetime.DateColumn;
-import io.opensphere.csvcommon.detect.datetime.algorithm.deciders.DateDecider;
 import io.opensphere.csvcommon.detect.datetime.model.PotentialColumn;
 import io.opensphere.csvcommon.detect.datetime.model.SuccessfulFormat;
 import io.opensphere.csvcommon.util.CsvTestUtils;
@@ -20,6 +19,7 @@ import io.opensphere.csvcommon.util.CsvTestUtils;
  * Tests the DateDecider class.
  *
  */
+@SuppressWarnings("boxing")
 public class DateDeciderTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/DateTimeDeciderTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/DateTimeDeciderTest.java
@@ -11,7 +11,6 @@ import io.opensphere.core.common.configuration.date.DateFormat.Type;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.lang.Pair;
 import io.opensphere.csvcommon.common.datetime.DateColumn;
-import io.opensphere.csvcommon.detect.datetime.algorithm.deciders.DateTimeDecider;
 import io.opensphere.csvcommon.detect.datetime.model.PotentialColumn;
 import io.opensphere.csvcommon.detect.datetime.model.SuccessfulFormat;
 import io.opensphere.csvcommon.util.CsvTestUtils;
@@ -20,6 +19,7 @@ import io.opensphere.csvcommon.util.CsvTestUtils;
  * Tests the DateDecider class.
  *
  */
+@SuppressWarnings("boxing")
 public class DateTimeDeciderTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/TimeDeciderTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/algorithm/deciders/TimeDeciderTest.java
@@ -11,7 +11,6 @@ import io.opensphere.core.common.configuration.date.DateFormat.Type;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.lang.Pair;
 import io.opensphere.csvcommon.common.datetime.DateColumn;
-import io.opensphere.csvcommon.detect.datetime.algorithm.deciders.TimeDecider;
 import io.opensphere.csvcommon.detect.datetime.model.PotentialColumn;
 import io.opensphere.csvcommon.detect.datetime.model.SuccessfulFormat;
 import io.opensphere.csvcommon.util.CsvTestUtils;
@@ -20,6 +19,7 @@ import io.opensphere.csvcommon.util.CsvTestUtils;
  * Tests the DateDecider class.
  *
  */
+@SuppressWarnings("boxing")
 public class TimeDeciderTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/util/DateDataGenerator.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/detect/datetime/util/DateDataGenerator.java
@@ -16,6 +16,7 @@ import io.opensphere.csvcommon.util.CsvTestUtils;
 /**
  * Generates different combinations of csv date data used for testing.
  */
+@SuppressWarnings("boxing")
 public final class DateDataGenerator
 {
     /**
@@ -47,7 +48,8 @@ public final class DateDataGenerator
      * @throws ParseException Bad parse.
      */
     public static List<List<String>> generateDayTimeUpTimeDown(DateFormat dateFormat, DateFormat timeFormat1,
-            DateFormat timeFormat2) throws ParseException
+            DateFormat timeFormat2)
+        throws ParseException
     {
         List<List<String>> data = createJunkData(2);
 
@@ -79,8 +81,7 @@ public final class DateDataGenerator
         }
 
         List<List<String>> convertToRowsColumns = convertToRowsColumns(data, new Pair<>(dateValues1, 1),
-                new Pair<>(timeValues1, 2), new Pair<>(additionalTimes, 3),
-                new Pair<>(timeValues2, 4));
+                new Pair<>(timeValues1, 2), new Pair<>(additionalTimes, 3), new Pair<>(timeValues2, 4));
 
         return convertToRowsColumns;
     }
@@ -167,8 +168,7 @@ public final class DateDataGenerator
         List<String> timeValues2 = createDateValues(timeSimpleFormat2, System.currentTimeMillis() + ourStepSize);
 
         List<List<String>> convertToRowsColumns = convertToRowsColumns(data, new Pair<>(dateValues1, 1),
-                new Pair<>(dateValues2, 2), new Pair<>(timeValues1, 4),
-                new Pair<>(timeValues2, 5));
+                new Pair<>(dateValues2, 2), new Pair<>(timeValues1, 4), new Pair<>(timeValues2, 5));
 
         return convertToRowsColumns;
     }

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/format/datetime/TestDateTimeUtils.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/format/datetime/TestDateTimeUtils.java
@@ -7,8 +7,8 @@ import org.easymock.EasyMockSupport;
 import org.easymock.IAnswer;
 
 import io.opensphere.core.common.configuration.date.DateFormat;
-import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.common.configuration.date.DateFormat.Type;
+import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.preferences.ClasspathPreferencesPersistenceManager;
 import io.opensphere.core.preferences.InternalPreferencesIF;
 import io.opensphere.core.preferences.ListToolPreferences;
@@ -37,7 +37,7 @@ public final class TestDateTimeUtils
                 EasyMock.isA(DateFormatsConfig.class));
         EasyMock.expectLastCall().andReturn(config);
         preferences.getBoolean(EasyMock.isA(String.class), EasyMock.eq(false));
-        EasyMock.expectLastCall().andReturn(true);
+        EasyMock.expectLastCall().andReturn(Boolean.TRUE);
         EasyMock.expectLastCall().atLeastOnce();
 
         PreferencesRegistry registry = support.createMock(PreferencesRegistry.class);
@@ -62,7 +62,7 @@ public final class TestDateTimeUtils
                 EasyMock.isA(DateFormatsConfig.class));
         EasyMock.expectLastCall().andReturn(formats);
         preferences.getBoolean(EasyMock.isA(String.class), EasyMock.eq(false));
-        EasyMock.expectLastCall().andReturn(true);
+        EasyMock.expectLastCall().andReturn(Boolean.TRUE);
 
         PreferencesRegistry registry = support.createMock(PreferencesRegistry.class);
         registry.getPreferences(EasyMock.cmpEq(MantleConstants.USER_DATE_FORMAT_CONFIG_FILE_TOPIC));
@@ -81,7 +81,7 @@ public final class TestDateTimeUtils
     {
         Preferences preferences = support.createMock(Preferences.class);
         preferences.getBoolean(EasyMock.isA(String.class), EasyMock.eq(false));
-        EasyMock.expectLastCall().andReturn(true);
+        EasyMock.expectLastCall().andReturn(Boolean.TRUE);
         EasyMock.expectLastCall().atLeastOnce();
 
         PreferencesRegistry registry = support.createMock(PreferencesRegistry.class);
@@ -105,7 +105,7 @@ public final class TestDateTimeUtils
     {
         Preferences listPreferences = support.createMock(Preferences.class);
         listPreferences.getInt(EasyMock.cmpEq(ListToolPreferences.LIST_TOOL_TIME_PRECISION_DIGITS), EasyMock.eq(0));
-        EasyMock.expectLastCall().andReturn(precision);
+        EasyMock.expectLastCall().andReturn(Integer.valueOf(precision));
 
         PreferencesRegistry registry = support.createMock(PreferencesRegistry.class);
         registry.getPreferences(EasyMock.eq(ListToolPreferences.class));
@@ -113,7 +113,7 @@ public final class TestDateTimeUtils
 
         Preferences preferences = support.createMock(Preferences.class);
         preferences.getBoolean(EasyMock.isA(String.class), EasyMock.eq(false));
-        EasyMock.expectLastCall().andReturn(true);
+        EasyMock.expectLastCall().andReturn(Boolean.TRUE);
 
         registry.getPreferences(EasyMock.cmpEq(MantleConstants.USER_DATE_FORMAT_CONFIG_FILE_TOPIC));
         EasyMock.expectLastCall().andReturn(preferences);
@@ -164,7 +164,7 @@ public final class TestDateTimeUtils
         EasyMock.expectLastCall().atLeastOnce();
 
         preferences.getBoolean(EasyMock.isA(String.class), EasyMock.eq(false));
-        EasyMock.expectLastCall().andReturn(true);
+        EasyMock.expectLastCall().andReturn(Boolean.TRUE);
 
         PreferencesRegistry registry = support.createMock(PreferencesRegistry.class);
         registry.getPreferences(EasyMock.cmpEq(MantleConstants.USER_DATE_FORMAT_CONFIG_FILE_TOPIC));

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/format/position/LatitudeFormatterTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/format/position/LatitudeFormatterTest.java
@@ -13,13 +13,13 @@ import org.junit.Test;
 import io.opensphere.core.model.LatLonAlt.CoordFormat;
 import io.opensphere.core.preferences.PreferencesRegistry;
 import io.opensphere.core.util.collections.New;
-import io.opensphere.csvcommon.format.position.LatitudeFormatter;
 import io.opensphere.csvcommon.util.LocationTestUtils;
 
 /**
  * Tests the LatitudeFormatter class.
  *
  */
+@SuppressWarnings("boxing")
 public class LatitudeFormatterTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/format/position/LongitudeFormatterTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/format/position/LongitudeFormatterTest.java
@@ -13,13 +13,13 @@ import org.junit.Test;
 import io.opensphere.core.model.LatLonAlt.CoordFormat;
 import io.opensphere.core.preferences.PreferencesRegistry;
 import io.opensphere.core.util.collections.New;
-import io.opensphere.csvcommon.format.position.LongitudeFormatter;
 import io.opensphere.csvcommon.util.LocationTestUtils;
 
 /**
  * Tests the LongitudeFormatter class.
  *
  */
+@SuppressWarnings("boxing")
 public class LongitudeFormatterTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/ui/columndefinition/controller/BeforeAfterControllerTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/ui/columndefinition/controller/BeforeAfterControllerTest.java
@@ -29,6 +29,7 @@ import io.opensphere.mantle.util.MantleConstants;
  * Tests the BeforeAfterController class.
  *
  */
+@SuppressWarnings("boxing")
 public class BeforeAfterControllerTest
 {
     /**
@@ -304,7 +305,7 @@ public class BeforeAfterControllerTest
 
         Preferences formatPrefs = support.createNiceMock(Preferences.class);
         formatPrefs.getBoolean(EasyMock.isA(String.class), EasyMock.eq(false));
-        EasyMock.expectLastCall().andReturn(true);
+        EasyMock.expectLastCall().andReturn(Boolean.TRUE);
         EasyMock.expectLastCall().atLeastOnce();
 
         registry.getPreferences(EasyMock.eq(MantleConstants.USER_DATE_FORMAT_CONFIG_FILE_TOPIC));

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/ui/columndefinition/controller/FormatControllerTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/ui/columndefinition/controller/FormatControllerTest.java
@@ -14,8 +14,8 @@ import org.easymock.IAnswer;
 import org.junit.Test;
 
 import io.opensphere.core.common.configuration.date.DateFormat;
-import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.common.configuration.date.DateFormat.Type;
+import io.opensphere.core.common.configuration.date.DateFormatsConfig;
 import io.opensphere.core.preferences.ClasspathPreferencesPersistenceManager;
 import io.opensphere.core.preferences.InternalPreferencesIF;
 import io.opensphere.core.preferences.Preferences;
@@ -400,7 +400,7 @@ public class FormatControllerTest
         EasyMock.expectLastCall().andReturn(config);
         EasyMock.expectLastCall().atLeastOnce();
         preferences.getBoolean(EasyMock.isA(String.class), EasyMock.eq(false));
-        EasyMock.expectLastCall().andReturn(true);
+        EasyMock.expectLastCall().andReturn(Boolean.TRUE);
         EasyMock.expectLastCall().atLeastOnce();
 
         preferences.getStringList(EasyMock.isA(String.class), (List<String>)EasyMock.isNull());

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/ui/columndefinition/model/ColumnDefinitionTableModelTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/ui/columndefinition/model/ColumnDefinitionTableModelTest.java
@@ -15,13 +15,12 @@ import org.easymock.IAnswer;
 import org.junit.Test;
 
 import io.opensphere.core.util.collections.New;
-import io.opensphere.csvcommon.ui.columndefinition.model.ColumnDefinitionRow;
-import io.opensphere.csvcommon.ui.columndefinition.model.ColumnDefinitionTableModel;
 
 /**
  * Tests ColumnDefinitionTableModel class.
  *
  */
+@SuppressWarnings("boxing")
 public class ColumnDefinitionTableModelTest
 {
     /**

--- a/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/ui/controller/ImportableColumnControllerTest.java
+++ b/open-sphere-plugins/csv-common/src/test/java/io/opensphere/csvcommon/ui/controller/ImportableColumnControllerTest.java
@@ -13,12 +13,12 @@ import io.opensphere.core.preferences.PreferencesRegistry;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.csvcommon.config.v2.CSVParseParameters;
 import io.opensphere.csvcommon.detect.util.CSVColumnPrefsUtil;
-import io.opensphere.csvcommon.ui.controller.ImportableColumnController;
 
 /**
  * Tests the ImportableColumnController class.
  *
  */
+@SuppressWarnings("boxing")
 public class ImportableColumnControllerTest
 {
     /**

--- a/open-sphere-plugins/csv/src/main/java/io/opensphere/csv/ui/columndefinition/controller/ColumnDefinitionController.java
+++ b/open-sphere-plugins/csv/src/main/java/io/opensphere/csv/ui/columndefinition/controller/ColumnDefinitionController.java
@@ -152,7 +152,7 @@ public class ColumnDefinitionController extends BaseSelectedColumnObserver
 
             if (!row.isImport())
             {
-                ignoreColumns.add(row.getColumnId());
+                ignoreColumns.add(Integer.valueOf(row.getColumnId()));
             }
         }
 
@@ -206,7 +206,7 @@ public class ColumnDefinitionController extends BaseSelectedColumnObserver
             columnRow.setColumnId(index);
             columnRow.setColumnName(columnName);
 
-            if (myModel.getSelectedParameters().getColumnsToIgnore().contains(index))
+            if (myModel.getSelectedParameters().getColumnsToIgnore().contains(Integer.valueOf(index)))
             {
                 columnRow.setIsImport(false);
             }

--- a/open-sphere-plugins/csv/src/test/java/io/opensphere/csv/detect/datetime/util/DateDataGenerator.java
+++ b/open-sphere-plugins/csv/src/test/java/io/opensphere/csv/detect/datetime/util/DateDataGenerator.java
@@ -16,6 +16,7 @@ import io.opensphere.csv.util.CsvTestUtils;
 /**
  * Generates different combinations of csv date data used for testing.
  */
+@SuppressWarnings("boxing")
 public final class DateDataGenerator
 {
     /**
@@ -47,7 +48,8 @@ public final class DateDataGenerator
      * @throws ParseException Bad parse.
      */
     public static List<List<String>> generateDayTimeUpTimeDown(DateFormat dateFormat, DateFormat timeFormat1,
-            DateFormat timeFormat2) throws ParseException
+            DateFormat timeFormat2)
+        throws ParseException
     {
         List<List<String>> data = createJunkData(2);
 
@@ -79,8 +81,7 @@ public final class DateDataGenerator
         }
 
         List<List<String>> convertToRowsColumns = convertToRowsColumns(data, new Pair<>(dateValues1, 1),
-                new Pair<>(timeValues1, 2), new Pair<>(additionalTimes, 3),
-                new Pair<>(timeValues2, 4));
+                new Pair<>(timeValues1, 2), new Pair<>(additionalTimes, 3), new Pair<>(timeValues2, 4));
 
         return convertToRowsColumns;
     }
@@ -167,8 +168,7 @@ public final class DateDataGenerator
         List<String> timeValues2 = createDateValues(timeSimpleFormat2, System.currentTimeMillis() + ourStepSize);
 
         List<List<String>> convertToRowsColumns = convertToRowsColumns(data, new Pair<>(dateValues1, 1),
-                new Pair<>(dateValues2, 2), new Pair<>(timeValues1, 4),
-                new Pair<>(timeValues2, 5));
+                new Pair<>(dateValues2, 2), new Pair<>(timeValues1, 4), new Pair<>(timeValues2, 5));
 
         return convertToRowsColumns;
     }

--- a/open-sphere-plugins/csv/src/test/java/io/opensphere/csv/ui/columndefinition/controller/ColumnDefinitionControllerTest.java
+++ b/open-sphere-plugins/csv/src/test/java/io/opensphere/csv/ui/columndefinition/controller/ColumnDefinitionControllerTest.java
@@ -230,12 +230,12 @@ public class ColumnDefinitionControllerTest
         EasyMock.expectLastCall().andReturn(getDateFormats());
         EasyMock.expectLastCall().atLeastOnce();
         formatPreferences.getBoolean(EasyMock.isA(String.class), EasyMock.eq(false));
-        EasyMock.expectLastCall().andReturn(true);
+        EasyMock.expectLastCall().andReturn(Boolean.TRUE);
         EasyMock.expectLastCall().atLeastOnce();
 
         Preferences listToolPreferences = support.createMock(Preferences.class);
         listToolPreferences.getInt(EasyMock.isA(String.class), EasyMock.eq(0));
-        EasyMock.expectLastCall().andReturn(0);
+        EasyMock.expectLastCall().andReturn(Integer.valueOf(0));
         EasyMock.expectLastCall().atLeastOnce();
 
         PreferencesRegistry registry = support.createMock(PreferencesRegistry.class);

--- a/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/controller/StyleApplier.java
+++ b/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/controller/StyleApplier.java
@@ -76,7 +76,8 @@ public class StyleApplier implements ActionApplier
                 {
                     waitForGeometries(provider, elements);
 
-                    // Run it on the right executor because the mantle style code is
+                    // Run it on the right executor because the mantle style
+                    // code is
                     // not thread-safe
                     provider.getExecutor().execute(() -> applyStyle(style, elements, provider, actions));
                 }
@@ -215,7 +216,8 @@ public class StyleApplier implements ActionApplier
     }
 
     /**
-     * Waits for geometries to show up in the provider. We need to do this to ensure we can remove the old geometries.
+     * Waits for geometries to show up in the provider. We need to do this to
+     * ensure we can remove the old geometries.
      *
      * @param provider the data provider
      * @param elements the data elements
@@ -237,7 +239,8 @@ public class StyleApplier implements ActionApplier
     }
 
     /**
-     * Worker that updates the data element's geometry's styles. This uses a single style for all geometries passed to it.
+     * Worker that updates the data element's geometry's styles. This uses a
+     * single style for all geometries passed to it.
      */
     private static class StyleUpdater extends StyleBasedUpdateGeometriesWorker
     {

--- a/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/editor/ui/SimpleFeatureActionRow.java
+++ b/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/editor/ui/SimpleFeatureActionRow.java
@@ -4,6 +4,17 @@ import java.awt.Component;
 
 import javax.swing.SwingUtilities;
 
+import io.opensphere.controlpanels.iconpicker.ui.IconPickerButton;
+import io.opensphere.core.Toolbox;
+import io.opensphere.core.util.fx.FXUtilities;
+import io.opensphere.core.util.fx.NewAutoCompleteComboBoxListener;
+import io.opensphere.core.util.image.IconUtil.IconType;
+import io.opensphere.featureactions.editor.model.CriteriaOptions;
+import io.opensphere.featureactions.editor.model.SimpleFeatureAction;
+import io.opensphere.featureactions.editor.model.SimpleFeatureActionGroup;
+import io.opensphere.featureactions.editor.model.SimpleFeatureActions;
+import io.opensphere.mantle.data.DataTypeInfo;
+import io.opensphere.mantle.util.MantleToolboxUtils;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -16,18 +27,6 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.layout.GridPane;
 import javafx.scene.paint.Color;
 
-import io.opensphere.controlpanels.iconpicker.ui.IconPickerButton;
-import io.opensphere.core.Toolbox;
-import io.opensphere.core.util.fx.AutoCompleteComboBoxListener;
-import io.opensphere.core.util.fx.FXUtilities;
-import io.opensphere.core.util.image.IconUtil.IconType;
-import io.opensphere.featureactions.editor.model.CriteriaOptions;
-import io.opensphere.featureactions.editor.model.SimpleFeatureAction;
-import io.opensphere.featureactions.editor.model.SimpleFeatureActionGroup;
-import io.opensphere.featureactions.editor.model.SimpleFeatureActions;
-import io.opensphere.mantle.data.DataTypeInfo;
-import io.opensphere.mantle.util.MantleToolboxUtils;
-
 /**
  * A User Interface representing one feature action in the list of feature
  * actions.
@@ -39,10 +38,6 @@ public class SimpleFeatureActionRow extends ListCell<SimpleFeatureAction> implem
 
     /** Contains all actions for a given layer. */
     private final SimpleFeatureActions myActions;
-
-    /** Enables the combo box to be auto completed. */
-    @SuppressWarnings("unused")
-    private final AutoCompleteComboBoxListener<String> myAutoComplete;
 
     /** Binds this ui to the model. */
     private SimpleFeatureActionRowBinder myBinder;
@@ -126,8 +121,11 @@ public class SimpleFeatureActionRow extends ListCell<SimpleFeatureAction> implem
         myActions = actions;
         myGroup = group;
         layer = type;
-        myAutoComplete = new AutoCompleteComboBoxListener<>(myField);
+//        myAutoComplete = new AutoCompleteComboBoxListener<>(myField);
         parentDialog = dialog;
+
+        NewAutoCompleteComboBoxListener listener = new NewAutoCompleteComboBoxListener();
+        listener.setupComboBox(myField);
     }
 
     @Override

--- a/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/editor/ui/SimpleFeatureActionRow.java
+++ b/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/editor/ui/SimpleFeatureActionRow.java
@@ -121,7 +121,6 @@ public class SimpleFeatureActionRow extends ListCell<SimpleFeatureAction> implem
         myActions = actions;
         myGroup = group;
         layer = type;
-//        myAutoComplete = new AutoCompleteComboBoxListener<>(myField);
         parentDialog = dialog;
 
         NewAutoCompleteComboBoxListener listener = new NewAutoCompleteComboBoxListener();

--- a/open-sphere-plugins/filter-builder/src/main/java/io/opensphere/filterbuilder2/editor/model/GroupModel.java
+++ b/open-sphere-plugins/filter-builder/src/main/java/io/opensphere/filterbuilder2/editor/model/GroupModel.java
@@ -183,7 +183,7 @@ public class GroupModel extends WrappedModel<Group>
     }
 
     @Override
-    public String getErrorMessage()
+    public synchronized String getErrorMessage()
     {
         return myError != null ? myError : super.getErrorMessage();
     }

--- a/open-sphere-plugins/filter-builder/src/main/java/io/opensphere/filterbuilder2/layers/ColumnMappingPane.java
+++ b/open-sphere-plugins/filter-builder/src/main/java/io/opensphere/filterbuilder2/layers/ColumnMappingPane.java
@@ -278,7 +278,7 @@ public final class ColumnMappingPane extends GridPane implements Editor
     private ComboBox<String> buildComboBox(String sourceColumn, List<String> keyNames)
     {
         ComboBox<String> columnCombo = new ComboBox<>(FXCollections.observableArrayList(keyNames));
-//        new AutoCompleteComboBoxListener<>(columnCombo);
+
         NewAutoCompleteComboBoxListener listener = new NewAutoCompleteComboBoxListener();
         listener.setupComboBox(columnCombo);
 

--- a/open-sphere-plugins/filter-builder/src/main/java/io/opensphere/filterbuilder2/layers/ColumnMappingPane.java
+++ b/open-sphere-plugins/filter-builder/src/main/java/io/opensphere/filterbuilder2/layers/ColumnMappingPane.java
@@ -5,13 +5,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import javafx.collections.FXCollections;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.Label;
-import javafx.scene.layout.ColumnConstraints;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.Priority;
-
 import org.apache.log4j.Logger;
 
 import io.opensphere.core.datafilter.columns.MutableColumnMappingController;
@@ -19,11 +12,17 @@ import io.opensphere.core.util.DefaultValidatorSupport;
 import io.opensphere.core.util.Utilities;
 import io.opensphere.core.util.ValidationStatus;
 import io.opensphere.core.util.ValidatorSupport;
-import io.opensphere.core.util.fx.AutoCompleteComboBoxListener;
 import io.opensphere.core.util.fx.Editor;
+import io.opensphere.core.util.fx.NewAutoCompleteComboBoxListener;
 import io.opensphere.mantle.MantleToolbox;
 import io.opensphere.mantle.data.DataTypeInfo;
 import io.opensphere.mantle.data.MetaDataInfo;
+import javafx.collections.FXCollections;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
 
 /** Column mapping pane. */
 public final class ColumnMappingPane extends GridPane implements Editor
@@ -279,7 +278,10 @@ public final class ColumnMappingPane extends GridPane implements Editor
     private ComboBox<String> buildComboBox(String sourceColumn, List<String> keyNames)
     {
         ComboBox<String> columnCombo = new ComboBox<>(FXCollections.observableArrayList(keyNames));
-        new AutoCompleteComboBoxListener<>(columnCombo);
+//        new AutoCompleteComboBoxListener<>(columnCombo);
+        NewAutoCompleteComboBoxListener listener = new NewAutoCompleteComboBoxListener();
+        listener.setupComboBox(columnCombo);
+
         String selection = getInitialSelection(sourceColumn, keyNames);
         if (selection != null)
         {

--- a/open-sphere-plugins/geopackage/src/main/java/io/opensphere/geopackage/export/feature/FeatureRowExporter.java
+++ b/open-sphere-plugins/geopackage/src/main/java/io/opensphere/geopackage/export/feature/FeatureRowExporter.java
@@ -64,7 +64,7 @@ public class FeatureRowExporter
                 Object value = element.getMetaData().getValue(elementColumnName);
                 if (value instanceof DoubleRange)
                 {
-                    value = ((DoubleRange)value).doubleValue();
+                    value = Double.valueOf(((DoubleRange)value).doubleValue());
                 }
                 else if (value instanceof Date)
                 {

--- a/open-sphere-plugins/geopackage/src/main/java/io/opensphere/geopackage/export/feature/GeometryExporter.java
+++ b/open-sphere-plugins/geopackage/src/main/java/io/opensphere/geopackage/export/feature/GeometryExporter.java
@@ -215,7 +215,7 @@ public class GeometryExporter
     private mil.nga.wkb.geom.Point convertPoint(Point point)
     {
         mil.nga.wkb.geom.Point wkbPoint = new mil.nga.wkb.geom.Point(true, false, point.getX(), point.getY());
-        wkbPoint.setZ(point.getCoordinate().z);
+        wkbPoint.setZ(Double.valueOf(point.getCoordinate().z));
 
         return wkbPoint;
     }

--- a/open-sphere-plugins/geopackage/src/main/java/io/opensphere/geopackage/importer/feature/GeometryImporter.java
+++ b/open-sphere-plugins/geopackage/src/main/java/io/opensphere/geopackage/importer/feature/GeometryImporter.java
@@ -342,7 +342,7 @@ public class GeometryImporter
         double z = 0;
         if (point.hasZ())
         {
-            z = point.getZ();
+            z = point.getZ().doubleValue();
         }
 
         Point transformed = toGeodetic.transform(point);

--- a/open-sphere-plugins/geopackage/src/main/java/io/opensphere/geopackage/model/GeoPackageTileLayer.java
+++ b/open-sphere-plugins/geopackage/src/main/java/io/opensphere/geopackage/model/GeoPackageTileLayer.java
@@ -1,6 +1,5 @@
 package io.opensphere.geopackage.model;
 
-import java.io.Serializable;
 import java.util.Map;
 
 import io.opensphere.core.data.DataRegistry;
@@ -11,7 +10,7 @@ import io.opensphere.core.util.collections.New;
  * Contains tile specific information about a tile layer. This class is
  * serializable so it can be stored within the {@link DataRegistry}.
  */
-public class GeoPackageTileLayer extends GeoPackageLayer implements Serializable
+public class GeoPackageTileLayer extends GeoPackageLayer
 {
     /**
      * Serialization id.

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/GeoPackagePluginTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/GeoPackagePluginTest.java
@@ -47,6 +47,7 @@ import io.opensphere.mantle.data.impl.DefaultDataGroupInfo;
 /**
  * Tests the {@link GeoPackagePlugin}.
  */
+@SuppressWarnings("boxing")
 public class GeoPackagePluginTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/export/feature/FeatureExporterTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/export/feature/FeatureExporterTest.java
@@ -28,6 +28,7 @@ import mil.nga.geopackage.projection.ProjectionConstants;
 /**
  * Unit test for {@link FeatureExporter}.
  */
+@SuppressWarnings("boxing")
 public class FeatureExporterTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/export/feature/FeatureLayerExporterTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/export/feature/FeatureLayerExporterTest.java
@@ -56,6 +56,7 @@ import mil.nga.wkb.geom.Point;
 /**
  * Unit test for {@link FeatureLayerExporter}.
  */
+@SuppressWarnings("boxing")
 public class FeatureLayerExporterTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/export/feature/FeatureRowExporterTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/export/feature/FeatureRowExporterTest.java
@@ -43,6 +43,7 @@ import mil.nga.wkb.geom.Point;
 /**
  * Unit test for {@link FeatureRowExporter} class.
  */
+@SuppressWarnings("boxing")
 public class FeatureRowExporterTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/export/feature/GeometryExporterTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/export/feature/GeometryExporterTest.java
@@ -31,6 +31,7 @@ import mil.nga.wkb.geom.Polygon;
 /**
  * Unit test for {@link GeometryExporter}.
  */
+@SuppressWarnings("boxing")
 public class GeometryExporterTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/importer/GeoPackageImporterTestFunctional.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/importer/GeoPackageImporterTestFunctional.java
@@ -49,6 +49,7 @@ import mil.nga.geopackage.GeoPackageConstants;
 /**
  * Tests the {@link GeoPackageImporter} class.
  */
+@SuppressWarnings("boxing")
 public class GeoPackageImporterTestFunctional
 {
     /**
@@ -470,7 +471,8 @@ public class GeoPackageImporterTestFunctional
      * @throws IOException Bad IO.
      */
     private List<GeoPackageLayer> runTest(String filePath, Set<String> expectedFeatureLayers, Set<String> expectedTileLayers,
-            List<GeoPackageTile> tiles, List<InputStream> tileImages) throws InterruptedException, IOException
+            List<GeoPackageTile> tiles, List<InputStream> tileImages)
+        throws InterruptedException, IOException
     {
         File geoFile = getFile(filePath);
         File existingFile = File.createTempFile("existing", "." + GeoPackageConstants.GEOPACKAGE_EXTENSION);

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/importer/feature/FeatureImporterTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/importer/feature/FeatureImporterTest.java
@@ -34,6 +34,7 @@ import mil.nga.wkb.geom.GeometryType;
 /**
  * Unit test for the {@link FeatureImporter} class.
  */
+@SuppressWarnings("boxing")
 public class FeatureImporterTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/importer/feature/GeometryImporterTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/importer/feature/GeometryImporterTest.java
@@ -35,6 +35,7 @@ import mil.nga.wkb.geom.GeometryType;
 /**
  * Tests the {@link GeometryImporter} class.
  */
+@SuppressWarnings("boxing")
 public class GeometryImporterTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/importer/feature/RowImporterTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/importer/feature/RowImporterTest.java
@@ -23,6 +23,7 @@ import mil.nga.wkb.geom.GeometryType;
 /**
  * Unit test for {@link RowImporter}.
  */
+@SuppressWarnings("boxing")
 public class RowImporterTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/importer/feature/TableImporterTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/importer/feature/TableImporterTest.java
@@ -31,6 +31,7 @@ import mil.nga.wkb.geom.GeometryType;
 /**
  * Unit test for the {@link TableImporter} class.
  */
+@SuppressWarnings("boxing")
 public class TableImporterTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/DataElementPopulatorTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/DataElementPopulatorTest.java
@@ -31,6 +31,7 @@ import io.opensphere.mantle.data.impl.specialkey.TimeKey;
 /**
  * Tests the {@link DataElementPopulator} class.
  */
+@SuppressWarnings("boxing")
 public class DataElementPopulatorTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/FeatureDataTypeBuilderTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/FeatureDataTypeBuilderTest.java
@@ -46,6 +46,7 @@ import io.opensphere.mantle.data.impl.DefaultDataTypeInfo;
 /**
  * Tests the {@link FeatureDataTypeBuilder} class.
  */
+@SuppressWarnings("boxing")
 public class FeatureDataTypeBuilderTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/GeoPackageDataGroupControllerTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/GeoPackageDataGroupControllerTest.java
@@ -55,7 +55,7 @@ import io.opensphere.mantle.data.impl.DefaultDeletableDataGroupInfo;
 /**
  * Tests the {@link GeoPackageDataGroupController} class.
  */
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings({ "PMD.GodClass", "boxing" })
 public class GeoPackageDataGroupControllerTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/GeoPackageDataTypeInfoTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/GeoPackageDataTypeInfoTest.java
@@ -17,6 +17,7 @@ import io.opensphere.mantle.data.DataTypeInfoPreferenceAssistant;
 /**
  * Unit test for {@link GeoPackageDataTypeInfo}.
  */
+@SuppressWarnings("boxing")
 public class GeoPackageDataTypeInfoTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/GeoPackageDeleterTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/GeoPackageDeleterTest.java
@@ -16,6 +16,7 @@ import io.opensphere.mantle.data.DataGroupInfo;
 /**
  * Tests the {@link GeoPackageDeleter} class.
  */
+@SuppressWarnings("boxing")
 public class GeoPackageDeleterTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/MetaDataInfoBuilderTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/MetaDataInfoBuilderTest.java
@@ -24,6 +24,7 @@ import io.opensphere.mantle.data.impl.specialkey.TimeKey;
 /**
  * Tests the {@link MetaDataInfoBuilder} class.
  */
+@SuppressWarnings("boxing")
 public class MetaDataInfoBuilderTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/MetaDataProviderPopulatorTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/mantle/MetaDataProviderPopulatorTest.java
@@ -19,6 +19,7 @@ import io.opensphere.mantle.data.impl.DefaultMetaDataInfo;
 /**
  * Tests the {@link MetaDataProviderPopulator} class.
  */
+@SuppressWarnings("boxing")
 public class MetaDataProviderPopulatorTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/model/GeoPackageFeatureLayerTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/model/GeoPackageFeatureLayerTest.java
@@ -22,6 +22,7 @@ import io.opensphere.core.util.collections.New;
 /**
  * Unit tests the {@link GeoPackageFeatureLayer} class.
  */
+@SuppressWarnings("boxing")
 public class GeoPackageFeatureLayerTest
 {
     /**

--- a/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/model/GeoPackageTileLayerTest.java
+++ b/open-sphere-plugins/geopackage/src/test/java/io/opensphere/geopackage/model/GeoPackageTileLayerTest.java
@@ -18,6 +18,7 @@ import io.opensphere.core.util.collections.New;
 /**
  * Unit test for the {@link GeoPackageTileLayer} class.
  */
+@SuppressWarnings("boxing")
 public class GeoPackageTileLayerTest
 {
     /**

--- a/open-sphere-plugins/heatmap/src/main/java/io/opensphere/heatmap/HeatmapVisualizationStyle.java
+++ b/open-sphere-plugins/heatmap/src/main/java/io/opensphere/heatmap/HeatmapVisualizationStyle.java
@@ -49,12 +49,13 @@ public class HeatmapVisualizationStyle extends AbstractVisualizationStyle implem
 
     /** The default value of the intensity parameter. */
     public static final VisualizationStyleParameter DEFAULT_INTENSITY_PARAMETER = new VisualizationStyleParameter(
-            INTENSITY_PROPERTY_KEY, "Intensity", 6, Integer.class, new VisualizationStyleParameterFlags(false, false),
-            ParameterHint.hint(false, false));
+            INTENSITY_PROPERTY_KEY, "Intensity", Integer.valueOf(6), Integer.class,
+            new VisualizationStyleParameterFlags(false, false), ParameterHint.hint(false, false));
 
     /** The default value of the size parameter. */
     public static final VisualizationStyleParameter DEFAULT_SIZE_PARAMETER = new VisualizationStyleParameter(SIZE_PROPERTY_KEY,
-            "Size", 50, Integer.class, new VisualizationStyleParameterFlags(false, false), ParameterHint.hint(false, false));
+            "Size", Integer.valueOf(50), Integer.class, new VisualizationStyleParameterFlags(false, false),
+            ParameterHint.hint(false, false));
 
     /**
      * Creates a new instance of the {@link HeatmapVisualizationStyle} class.
@@ -236,18 +237,16 @@ public class HeatmapVisualizationStyle extends AbstractVisualizationStyle implem
         MutableVisualizationStyle style = panel.getChangedStyle();
 
         VisualizationStyleParameter colorPaletteParameter = style.getStyleParameter(COLOR_PALETTE_PROPERTY_KEY);
-        paramList.add(
-                new ComboBoxStyleParameterEditorPanel(PanelBuilder.get(colorPaletteParameter.getName()),
-                        style, COLOR_PALETTE_PROPERTY_KEY, false, false, false, Arrays.asList(HeatmapGradients.values())));
+        paramList.add(new ComboBoxStyleParameterEditorPanel(PanelBuilder.get(colorPaletteParameter.getName()), style,
+                COLOR_PALETTE_PROPERTY_KEY, false, false, false, Arrays.asList(HeatmapGradients.values())));
 
         VisualizationStyleParameter intensityParameter = style.getStyleParameter(INTENSITY_PROPERTY_KEY);
-        paramList.add(
-                new IntegerSliderStyleParameterEditorPanel(PanelBuilder.get(intensityParameter.getName()),
-                        style, INTENSITY_PROPERTY_KEY, true, false, 5, 50, null));
+        paramList.add(new IntegerSliderStyleParameterEditorPanel(PanelBuilder.get(intensityParameter.getName()), style,
+                INTENSITY_PROPERTY_KEY, true, false, 5, 50, null));
 
         VisualizationStyleParameter sizeParameter = style.getStyleParameter(SIZE_PROPERTY_KEY);
-        paramList.add(new IntegerSliderStyleParameterEditorPanel(PanelBuilder.get(sizeParameter.getName()),
-                style, SIZE_PROPERTY_KEY, true, false, 1, 150, null));
+        paramList.add(new IntegerSliderStyleParameterEditorPanel(PanelBuilder.get(sizeParameter.getName()), style,
+                SIZE_PROPERTY_KEY, true, false, 1, 150, null));
 
         StyleParameterEditorGroupPanel parameterGroup = new StyleParameterEditorGroupPanel("Heatmap", paramList, false, 1);
         panel.addGroup(parameterGroup);
@@ -276,7 +275,7 @@ public class HeatmapVisualizationStyle extends AbstractVisualizationStyle implem
      */
     public void setIntensity(int intensity)
     {
-        setParameter(getStyleParameter(INTENSITY_PROPERTY_KEY).deriveWithNewValue(intensity));
+        setParameter(getStyleParameter(INTENSITY_PROPERTY_KEY).deriveWithNewValue(Integer.valueOf(intensity)));
     }
 
     /**
@@ -288,7 +287,7 @@ public class HeatmapVisualizationStyle extends AbstractVisualizationStyle implem
      */
     public void setSize(int size)
     {
-        setParameter(getStyleParameter(SIZE_PROPERTY_KEY).deriveWithNewValue(size));
+        setParameter(getStyleParameter(SIZE_PROPERTY_KEY).deriveWithNewValue(Integer.valueOf(size)));
     }
 
     /**

--- a/open-sphere-plugins/hud/src/main/java/io/opensphere/hud/dashboard/JVMMonitor.java
+++ b/open-sphere-plugins/hud/src/main/java/io/opensphere/hud/dashboard/JVMMonitor.java
@@ -86,10 +86,10 @@ public class JVMMonitor implements ActionListener
         long inUseMem = totalMem - freeMem;
         double percent = (double)inUseMem / (double)maxMem;
 
-        myNumProcessorsProvider.setValue(Runtime.getRuntime().availableProcessors());
-        myMaxMemProvider.setValue(maxMem);
-        myInUseMemProvider.setValue(inUseMem);
-        myPercentUsedProvider.setValue(percent);
+        myNumProcessorsProvider.setValue(Integer.valueOf(Runtime.getRuntime().availableProcessors()));
+        myMaxMemProvider.setValue(Long.valueOf(maxMem));
+        myInUseMemProvider.setValue(Long.valueOf(inUseMem));
+        myPercentUsedProvider.setValue(Double.valueOf(percent));
 
         Color stateColor = Color.white;
         Status stat = myToolbox.getSystemToolbox().getMemoryManager().getMemoryStatus();

--- a/open-sphere-plugins/imagery/src/main/java/io/opensphere/imagery/ImageryFileImporter.java
+++ b/open-sphere-plugins/imagery/src/main/java/io/opensphere/imagery/ImageryFileImporter.java
@@ -135,8 +135,10 @@ public class ImageryFileImporter implements FileOrURLImporter
             wizardDialog.setSize(new Dimension(900, 700));
             wizardDialog.setLayout(new BorderLayout());
             wizardDialog.setResizable(false);
-            new ImagerySourceWizardPanel(wizardDialog.getContentPane(), myController.getToolbox(), fileList, sourcesInUse,
-                    new IDataSourceCreator()
+
+            @SuppressWarnings("unused")
+            ImagerySourceWizardPanel panel = new ImagerySourceWizardPanel(wizardDialog.getContentPane(),
+                    myController.getToolbox(), fileList, sourcesInUse, new IDataSourceCreator()
                     {
                         @Override
                         public void sourceCreated(boolean successful, final IDataSource source)
@@ -228,8 +230,10 @@ public class ImageryFileImporter implements FileOrURLImporter
         wiz.setLayout(new BorderLayout());
         wiz.setResizable(false);
         final ImagerySourceGroup backupGroup = new ImagerySourceGroup(group);
-        new ImagerySourceWizardPanel(wiz.getContentPane(), myController.getToolbox(), group, sourcesInUse,
-                new IDataSourceCreator()
+
+        @SuppressWarnings("unused")
+        ImagerySourceWizardPanel panel = new ImagerySourceWizardPanel(wiz.getContentPane(), myController.getToolbox(), group,
+                sourcesInUse, new IDataSourceCreator()
                 {
                     @Override
                     public void sourceCreated(boolean successful, final IDataSource source)

--- a/open-sphere-plugins/imagery/src/main/java/io/opensphere/imagery/ImagerySourceWizardPanel.java
+++ b/open-sphere-plugins/imagery/src/main/java/io/opensphere/imagery/ImagerySourceWizardPanel.java
@@ -187,9 +187,6 @@ public class ImagerySourceWizardPanel
     /** The Stage. */
     private final Stage myStage = Stage.SETTINGS_STAGE;
 
-    /** The Toolbox. */
-    private final Toolbox myToolbox;
-
     /**
      * Helper function in creating panels with various parameters.
      *
@@ -257,7 +254,6 @@ public class ImagerySourceWizardPanel
     public ImagerySourceWizardPanel(Container parent, Toolbox tb, ImagerySourceGroup group, Set<IDataSource> sourcesInUse,
             IDataSourceCreator caller)
     {
-        myToolbox = tb;
         myOwner = parent;
         myImportSources = new ArrayList<>(group.getImageSources());
         myImageInfoTilePanels = new ArrayList<>();
@@ -307,7 +303,6 @@ public class ImagerySourceWizardPanel
     public ImagerySourceWizardPanel(Container parent, Toolbox tb, List<File> chosenFiles, Set<IDataSource> sourcesInUse,
             IDataSourceCreator caller)
     {
-        myToolbox = tb;
         myOwner = parent;
         myImportSources = new ArrayList<>();
         myImageInfoTilePanels = new ArrayList<>();

--- a/open-sphere-plugins/import/src/test/java/io/opensphere/importer/config/ImportParseParametersTest.java
+++ b/open-sphere-plugins/import/src/test/java/io/opensphere/importer/config/ImportParseParametersTest.java
@@ -21,6 +21,7 @@ import io.opensphere.importer.config.ColumnType.Category;
  * Class designed to exercise the functionality of the
  * {@link ImportParseParameters} class.
  */
+@SuppressWarnings("boxing")
 public class ImportParseParametersTest
 {
     /**

--- a/open-sphere-plugins/kml/src/main/java/io/opensphere/kml/envoy/KMLProcessor.java
+++ b/open-sphere-plugins/kml/src/main/java/io/opensphere/kml/envoy/KMLProcessor.java
@@ -654,6 +654,7 @@ public class KMLProcessor
      * @param url The "URL".
      * @return {@code true} if the URL is probably local.
      */
+    @SuppressWarnings("unused")
     private static boolean isUrlLocal(KMLDataSource dataSource, String url)
     {
         if (dataSource.getContentType() == KMLContentType.KMZ)

--- a/open-sphere-plugins/kml/src/main/java/io/opensphere/kml/mantle/controller/KMLGeometryBuilder.java
+++ b/open-sphere-plugins/kml/src/main/java/io/opensphere/kml/mantle/controller/KMLGeometryBuilder.java
@@ -298,6 +298,7 @@ public class KMLGeometryBuilder
      * @param highlightStyle The highlight style
      * @return The MapGeometrySupport
      */
+    @SuppressWarnings("null")
     private MapGeometrySupport createIconMapGeometrySupport(Point point, Style style, Style highlightStyle)
     {
         DefaultMapIconGeometrySupport mapGeomSupport = null;

--- a/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/algorithm/JoinData.java
+++ b/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/algorithm/JoinData.java
@@ -136,7 +136,7 @@ public class JoinData extends DatasetOperation
     {
         src.stream().filter(x -> x.getType() == c.owner).findFirst().ifPresent(x ->
         {
-            if (c != null && c.definedName != null && !c.definedName.isEmpty())
+            if (c.definedName != null && !c.definedName.isEmpty())
             {
                 x.getKeepKeys().add(c.definedName);
             }

--- a/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/ui/DataUtil.java
+++ b/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/ui/DataUtil.java
@@ -377,7 +377,7 @@ public class DataUtil
             // include the new ones
             for (Long id : idList)
             {
-                newIds[j++] = id;
+                newIds[j++] = id.longValue();
             }
             mantleIds = newIds;
         }

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/BaseDataTypeInfoChangedListener.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/BaseDataTypeInfoChangedListener.java
@@ -40,10 +40,10 @@ public abstract class BaseDataTypeInfoChangedListener<T>
             MyPlacesDataTypeInfo dataType = (MyPlacesDataTypeInfo)info;
             Placemark placemark = dataType.getKmlPlacemark();
 
-            boolean isVisible = placemark.isVisibility();
+            boolean isVisible = placemark.isVisibility().booleanValue();
             if (isVisible)
             {
-                placemark.setVisibility(false);
+                placemark.setVisibility(Boolean.FALSE);
                 myModel.notifyObservers();
             }
 
@@ -51,7 +51,7 @@ public abstract class BaseDataTypeInfoChangedListener<T>
 
             if (isVisible)
             {
-                dataType.getKmlPlacemark().setVisibility(true);
+                dataType.getKmlPlacemark().setVisibility(Boolean.TRUE);
                 myModel.notifyObservers();
             }
         }

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/editor/model/AnnotationModel.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/editor/model/AnnotationModel.java
@@ -187,7 +187,7 @@ public class AnnotationModel extends WrappedModel<Placemark>
     }
 
     @Override
-    public String getErrorMessage()
+    public synchronized String getErrorMessage()
     {
         return myError != null ? myError : super.getErrorMessage();
     }
@@ -449,8 +449,8 @@ public class AnnotationModel extends WrappedModel<Placemark>
 
         ExtendedDataUtils.putBoolean(extendedData, Constants.IS_BUBBLE_FILLED_ID, myIsBubbleFilled.get().booleanValue());
         ExtendedDataUtils.putBoolean(extendedData, Constants.IS_POLYGON_FILLED_ID, myIsPolygonFilled.get().booleanValue());
-        ExtendedDataUtils.putBoolean(extendedData, Constants.IS_ANIMATE, myAnimate.get());
-        ExtendedDataUtils.putBoolean(extendedData, Constants.IS_SHOW_IN_TIMELINE, myShowInTimeline.get());
+        ExtendedDataUtils.putBoolean(extendedData, Constants.IS_ANIMATE, myAnimate.get().booleanValue());
+        ExtendedDataUtils.putBoolean(extendedData, Constants.IS_SHOW_IN_TIMELINE, myShowInTimeline.get().booleanValue());
     }
 
     @Override
@@ -501,8 +501,8 @@ public class AnnotationModel extends WrappedModel<Placemark>
         Font font = PlacemarkUtils.getPlacemarkFont(placemark);
 
         myTextStyleModel.getFont().set(new FontWrapper(font));
-        myTextStyleModel.getBold().set(font.isBold());
-        myTextStyleModel.getItalic().set(font.isItalic());
+        myTextStyleModel.getBold().set(Boolean.valueOf(font.isBold()));
+        myTextStyleModel.getItalic().set(Boolean.valueOf(font.isItalic()));
         myTextStyleModel.getFontSize().set(Integer.valueOf(font.getSize()));
 
         if (placemark != null && placemark.getExtendedData() != null)

--- a/open-sphere-plugins/ogc-server/src/main/java/io/opensphere/server/display/model/DefaultServerSourceModel.java
+++ b/open-sphere-plugins/ogc-server/src/main/java/io/opensphere/server/display/model/DefaultServerSourceModel.java
@@ -87,7 +87,7 @@ public abstract class DefaultServerSourceModel<T extends ServerSource> extends W
     }
 
     @Override
-    public String getErrorMessage()
+    public synchronized String getErrorMessage()
     {
         return myError != null ? myError : super.getErrorMessage();
     }

--- a/open-sphere-plugins/ogc-server/src/main/java/io/opensphere/server/source/ServerSource.java
+++ b/open-sphere-plugins/ogc-server/src/main/java/io/opensphere/server/source/ServerSource.java
@@ -1,10 +1,9 @@
 package io.opensphere.server.source;
 
-import io.opensphere.mantle.datasources.IDataSource;
 import io.opensphere.mantle.datasources.UrlSource;
 
 /** Interface for data sources that connect to external servers. */
-public interface ServerSource extends IDataSource, UrlSource
+public interface ServerSource extends UrlSource
 {
     /**
      * Creates a near copy of this data source suitable for export.

--- a/open-sphere-plugins/ogc-server/src/test/java/io/opensphere/server/permalink/loaders/UploadResponseTest.java
+++ b/open-sphere-plugins/ogc-server/src/test/java/io/opensphere/server/permalink/loaders/UploadResponseTest.java
@@ -1,6 +1,7 @@
 package io.opensphere.server.permalink.loaders;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
@@ -32,7 +33,7 @@ public class UploadResponseTest
         ObjectMapper mapper = JsonUtils.createMapper();
         UploadResponse response = mapper.readValue(jsonString, UploadResponse.class);
 
-        assertEquals(true, response.isSuccess());
+        assertTrue(response.isSuccess());
         assertEquals("theUrl", response.getUrl());
     }
 }

--- a/open-sphere-plugins/ogc-server/src/test/java/io/opensphere/server/serverprovider/http/factory/TimeoutsConfigurerTest.java
+++ b/open-sphere-plugins/ogc-server/src/test/java/io/opensphere/server/serverprovider/http/factory/TimeoutsConfigurerTest.java
@@ -24,6 +24,7 @@ import io.opensphere.server.util.ServerConstants;
  * Tests the TimeoutsConfigurer.
  *
  */
+@SuppressWarnings("boxing")
 public class TimeoutsConfigurerTest
 {
     /**

--- a/open-sphere-plugins/ogc-server/src/test/java/io/opensphere/server/serverprovider/http/requestors/FilePostRequestorTest.java
+++ b/open-sphere-plugins/ogc-server/src/test/java/io/opensphere/server/serverprovider/http/requestors/FilePostRequestorTest.java
@@ -37,6 +37,7 @@ import io.opensphere.core.util.lang.StringUtilities;
  * Tests the FilePostRequestor class.
  *
  */
+@SuppressWarnings("boxing")
 public class FilePostRequestorTest
 {
     /**

--- a/open-sphere-plugins/ogc-server/src/test/java/io/opensphere/server/serverprovider/http/requestors/PostRequestorImplTest.java
+++ b/open-sphere-plugins/ogc-server/src/test/java/io/opensphere/server/serverprovider/http/requestors/PostRequestorImplTest.java
@@ -37,6 +37,7 @@ import io.opensphere.core.util.lang.StringUtilities;
 /**
  * Tests the GetRequestor class.
  */
+@SuppressWarnings("boxing")
 public class PostRequestorImplTest
 {
     /**
@@ -308,7 +309,8 @@ public class PostRequestorImplTest
      */
     private HttpClient createClient(EasyMockSupport support, final HttpResponse response, final URI expectedUri,
             final InputStream expectedStream, final Map<String, String> formData, final ContentType expectedContentType,
-            boolean expectHeader) throws IOException
+            boolean expectHeader)
+        throws IOException
     {
         HttpClient client = support.createMock(HttpClient.class);
 

--- a/open-sphere-plugins/ogc-server/src/test/java/io/opensphere/server/state/ServerStateControllerImplTest.java
+++ b/open-sphere-plugins/ogc-server/src/test/java/io/opensphere/server/state/ServerStateControllerImplTest.java
@@ -30,6 +30,7 @@ import io.opensphere.server.util.ServerConstants;
 /**
  * Tests the ServerStateController.
  */
+@SuppressWarnings("boxing")
 public class ServerStateControllerImplTest
 {
     /**

--- a/open-sphere-plugins/search/src/test/java/io/opensphere/search/controller/SearchControllerTest.java
+++ b/open-sphere-plugins/search/src/test/java/io/opensphere/search/controller/SearchControllerTest.java
@@ -45,6 +45,7 @@ import javafx.collections.ListChangeListener;
 /**
  * Unit test for the SearchController.
  */
+@SuppressWarnings("boxing")
 public class SearchControllerTest
 {
     /**

--- a/open-sphere-plugins/search/src/test/java/io/opensphere/search/controller/SearchExecutorTest.java
+++ b/open-sphere-plugins/search/src/test/java/io/opensphere/search/controller/SearchExecutorTest.java
@@ -7,8 +7,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import javafx.collections.ListChangeListener;
-
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.Test;
@@ -26,10 +24,12 @@ import io.opensphere.core.search.SearchResult;
 import io.opensphere.core.util.ObservableList;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.search.model.SearchModel;
+import javafx.collections.ListChangeListener;
 
 /**
  * Unit test for {@link SearchExecutor}.
  */
+@SuppressWarnings("boxing")
 public class SearchExecutorTest
 {
     /**

--- a/open-sphere-plugins/shapefile/src/main/java/io/opensphere/shapefile/ShapeFileHandler.java
+++ b/open-sphere-plugins/shapefile/src/main/java/io/opensphere/shapefile/ShapeFileHandler.java
@@ -39,6 +39,7 @@ public class ShapeFileHandler extends AbstractDataSourceHandler
         super(controller);
     }
 
+    @SuppressWarnings("null")
     @Override
     public boolean addDataSource(IDataSource pSource)
     {

--- a/open-sphere-plugins/stk-terrain/src/main/java/io/opensphere/stkterrain/model/mesh/QuantizedMesh.java
+++ b/open-sphere-plugins/stk-terrain/src/main/java/io/opensphere/stkterrain/model/mesh/QuantizedMesh.java
@@ -2,7 +2,6 @@ package io.opensphere.stkterrain.model.mesh;
 
 import java.awt.Rectangle;
 import java.io.IOException;
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -16,7 +15,7 @@ import io.opensphere.core.util.lang.ToStringHelper;
  * Stores the QuantizeMesh data and any other information needed.
  */
 @Immutable
-public class QuantizedMesh extends Image implements Serializable
+public class QuantizedMesh extends Image
 {
     /** Serialization id. */
     private static final long serialVersionUID = 1L;

--- a/open-sphere-plugins/stk-terrain/src/test/java/io/opensphere/stkterrain/mantle/STKDataGroupBuilderTest.java
+++ b/open-sphere-plugins/stk-terrain/src/test/java/io/opensphere/stkterrain/mantle/STKDataGroupBuilderTest.java
@@ -28,6 +28,7 @@ import io.opensphere.stkterrain.model.TileSetDataSource;
 /**
  * Unit test for {@link STKDataGroupBuilder}.
  */
+@SuppressWarnings("boxing")
 public class STKDataGroupBuilderTest
 {
     /**

--- a/open-sphere-plugins/stk-terrain/src/test/java/io/opensphere/stkterrain/mantle/STKDataGroupControllerTest.java
+++ b/open-sphere-plugins/stk-terrain/src/test/java/io/opensphere/stkterrain/mantle/STKDataGroupControllerTest.java
@@ -30,6 +30,7 @@ import io.opensphere.stkterrain.util.Constants;
 /**
  * Unit test for {@link STKDataGroupController}.
  */
+@SuppressWarnings("boxing")
 public class STKDataGroupControllerTest
 {
     /**

--- a/open-sphere-plugins/stk-terrain/src/test/java/io/opensphere/stkterrain/server/STKServerSourceControllerTest.java
+++ b/open-sphere-plugins/stk-terrain/src/test/java/io/opensphere/stkterrain/server/STKServerSourceControllerTest.java
@@ -54,6 +54,7 @@ import io.opensphere.stkterrain.mantle.STKDataGroupController;
 /**
  * Unit test for {@link STKServerSourceController}.
  */
+@SuppressWarnings("boxing")
 public class STKServerSourceControllerTest extends GenericRegistry<Envoy>
 {
     /**

--- a/open-sphere-plugins/wfs/src/main/java/io/opensphere/wfs/gml311/GmlLinestringHandler.java
+++ b/open-sphere-plugins/wfs/src/main/java/io/opensphere/wfs/gml311/GmlLinestringHandler.java
@@ -75,11 +75,11 @@ public class GmlLinestringHandler extends AbstractGmlGeometryHandler
                     {
                         if (isLat)
                         {
-                            lat = Double.valueOf(entry);
+                            lat = Double.valueOf(entry).doubleValue();
                         }
                         else
                         {
-                            lon = Double.valueOf(entry);
+                            lon = Double.valueOf(entry).doubleValue();
                             if (lon > 180.0)
                             {
                                 lon = lon - 360.0;

--- a/open-sphere-plugins/wfs/src/main/java/io/opensphere/wfs/gml311/GmlPointHandler.java
+++ b/open-sphere-plugins/wfs/src/main/java/io/opensphere/wfs/gml311/GmlPointHandler.java
@@ -52,13 +52,13 @@ public class GmlPointHandler extends AbstractGmlGeometryHandler
 
                 if (isLatBeforeLong())
                 {
-                    myLat = Double.valueOf(arr[0]);
-                    myLon = Double.valueOf(arr[1]);
+                    myLat = Double.valueOf(arr[0]).doubleValue();
+                    myLon = Double.valueOf(arr[1]).doubleValue();
                 }
                 else
                 {
-                    myLon = Double.valueOf(arr[0]);
-                    myLat = Double.valueOf(arr[1]);
+                    myLon = Double.valueOf(arr[0]).doubleValue();
+                    myLat = Double.valueOf(arr[1]).doubleValue();
                 }
 
                 if (myLon > 180.0)

--- a/open-sphere-plugins/wfs/src/main/java/io/opensphere/wfs/state/WFSStateController.java
+++ b/open-sphere-plugins/wfs/src/main/java/io/opensphere/wfs/state/WFSStateController.java
@@ -35,6 +35,7 @@ public class WFSStateController extends BaseWFSStateController
     /** Listener for when servers are activated or deactivated. */
     private final EventListener<? super ServerConfigEvent> myServerEventListener = new EventListener<ServerConfigEvent>()
     {
+        @SuppressWarnings("null")
         @Override
         public void notify(ServerConfigEvent event)
         {
@@ -189,7 +190,7 @@ public class WFSStateController extends BaseWFSStateController
              * WFS currently does not deactivate groups when the server is
              * deactivated. */
             return group.hasMember(
-                t -> t instanceof WFSDataType && myDataTypeController.hasDataTypeInfoForTypeKey(t.getTypeKey()), false);
+                    t -> t instanceof WFSDataType && myDataTypeController.hasDataTypeInfoForTypeKey(t.getTypeKey()), false);
         }
         return false;
     }

--- a/open-sphere-plugins/wfs/src/main/java/io/opensphere/wfs/state/save/DynamicEllipseStyleStateSaver.java
+++ b/open-sphere-plugins/wfs/src/main/java/io/opensphere/wfs/state/save/DynamicEllipseStyleStateSaver.java
@@ -107,7 +107,7 @@ public class DynamicEllipseStyleStateSaver extends StyleStateSaver
             }
             else if (styleKey.equals(AbstractEllipseFeatureVisualizationStyle.ourRimFadePropertyKey))
             {
-                vsp = vsp.deriveWithNewValue(myEllipseStyle.getRimFade());
+                vsp = vsp.deriveWithNewValue(Integer.valueOf(myEllipseStyle.getRimFade()));
             }
             else if (styleKey.equals(DynamicEllipseFeatureVisualization.ourSemiMajorAxisColumnKey))
             {

--- a/open-sphere-plugins/wfs/src/test/java/io/opensphere/wfs/filter/BetterDefaultHandlerTest.java
+++ b/open-sphere-plugins/wfs/src/test/java/io/opensphere/wfs/filter/BetterDefaultHandlerTest.java
@@ -19,6 +19,7 @@ import org.xml.sax.Attributes;
  * Test used to exercise the functionality of the
  * {@link BetterDefaultHandlerTest} class.
  */
+@SuppressWarnings("boxing")
 public class BetterDefaultHandlerTest
 {
     /**

--- a/open-sphere-plugins/wfs/src/test/java/io/opensphere/wfs/filter/FilterHandlerTest.java
+++ b/open-sphere-plugins/wfs/src/test/java/io/opensphere/wfs/filter/FilterHandlerTest.java
@@ -25,14 +25,13 @@ import io.opensphere.core.model.Altitude.ReferenceLevel;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.mantle.data.geom.AbstractMapGeometrySupport;
 import io.opensphere.mantle.data.geom.impl.DefaultMapPolygonGeometrySupport;
-import io.opensphere.wfs.filter.FilterHandler;
-import io.opensphere.wfs.filter.SaxElement;
 import io.opensphere.wfs.gml311.AbstractGmlGeometryHandler;
 import io.opensphere.wfs.gml311.GeometryHandlerFactory;
 
 /**
  * Test used to exercise the functionality of the {@link FilterHandler} class.
  */
+@SuppressWarnings("boxing")
 public class FilterHandlerTest
 {
     /**

--- a/open-sphere-plugins/wfs/src/test/java/io/opensphere/wfs/filter/SaxElementTest.java
+++ b/open-sphere-plugins/wfs/src/test/java/io/opensphere/wfs/filter/SaxElementTest.java
@@ -12,11 +12,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.Attributes;
 
-import io.opensphere.wfs.filter.SaxElement;
-
 /**
  * Test used to exercise the functionality of the {@link SaxElement} class.
  */
+@SuppressWarnings("boxing")
 public class SaxElementTest
 {
     /**

--- a/open-sphere-plugins/wfs/src/test/java/io/opensphere/wfs/state/model/WFSLayerAndStateTest.java
+++ b/open-sphere-plugins/wfs/src/test/java/io/opensphere/wfs/state/model/WFSLayerAndStateTest.java
@@ -155,8 +155,8 @@ public class WFSLayerAndStateTest
         assertEquals("https://somehost/ogc/wfsServer", layerState.getUrl());
         assertEquals("1.1.0", layerState.getWFSParameters().getVersion());
         assertEquals("typename", layerState.getWFSParameters().getTypeName());
-        assertEquals(true, layerState.isVisible());
-        assertEquals(true, layerState.isAnimate());
+        assertTrue(layerState.isVisible());
+        assertTrue(layerState.isAnimate());
         assertEquals("default#id#features", layerState.getId());
         assertEquals("ffff00", layerState.getBasicFeatureStyle().getPointColor());
         assertEquals(255, layerState.getBasicFeatureStyle().getPointOpacity());

--- a/open-sphere-plugins/wms/src/test/java/io/opensphere/wms/state/activate/controllers/LayerBuilderTest.java
+++ b/open-sphere-plugins/wms/src/test/java/io/opensphere/wms/state/activate/controllers/LayerBuilderTest.java
@@ -41,6 +41,7 @@ import io.opensphere.wms.state.model.WMSLayerState;
  * Tests the layer builder class.
  *
  */
+@SuppressWarnings("boxing")
 public class LayerBuilderTest
 {
     /**

--- a/open-sphere-plugins/wms/src/test/java/io/opensphere/wms/state/model/ParametersTest.java
+++ b/open-sphere-plugins/wms/src/test/java/io/opensphere/wms/state/model/ParametersTest.java
@@ -17,6 +17,7 @@ import io.opensphere.core.util.XMLUtilities;
  * can serialize/deserialize and verifies that the xml format is as expected.
  *
  */
+@SuppressWarnings("boxing")
 public class ParametersTest
 {
     /**

--- a/open-sphere-plugins/wms/src/test/java/io/opensphere/wms/state/model/WMSLayerStateTest.java
+++ b/open-sphere-plugins/wms/src/test/java/io/opensphere/wms/state/model/WMSLayerStateTest.java
@@ -17,6 +17,7 @@ import io.opensphere.core.util.XMLUtilities;
  * it can serialize/deserialize and verifies that the xml format is as expected.
  *
  */
+@SuppressWarnings("boxing")
 public class WMSLayerStateTest
 {
     /**

--- a/open-sphere-plugins/wms/src/test/java/io/opensphere/wms/state/save/controllers/LayersToStateModelsTest.java
+++ b/open-sphere-plugins/wms/src/test/java/io/opensphere/wms/state/save/controllers/LayersToStateModelsTest.java
@@ -31,6 +31,7 @@ import io.opensphere.wms.state.model.WMSLayerState;
  * Tests the LayersToStateModels class.
  *
  */
+@SuppressWarnings("boxing")
 public class LayersToStateModelsTest
 {
     /**

--- a/open-sphere-plugins/wps/src/main/java/io/opensphere/wps/ui/detail/WpsDetailPanel.java
+++ b/open-sphere-plugins/wps/src/main/java/io/opensphere/wps/ui/detail/WpsDetailPanel.java
@@ -4,19 +4,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import javafx.geometry.Insets;
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonBar;
-import javafx.scene.control.Label;
-import javafx.scene.control.ScrollPane;
-import javafx.scene.control.ScrollPane.ScrollBarPolicy;
-import javafx.scene.image.ImageView;
-import javafx.scene.layout.ColumnConstraints;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.Priority;
-import javafx.scene.text.Font;
-import javafx.scene.text.FontPosture;
-
 import org.apache.commons.lang3.StringUtils;
 
 import io.opensphere.controlpanels.DetailPane;
@@ -29,6 +16,18 @@ import io.opensphere.core.util.lang.StringUtilities;
 import io.opensphere.mantle.data.DataGroupInfo;
 import io.opensphere.mantle.data.DataTypeInfo;
 import io.opensphere.mantle.data.impl.GroupCategorizationUtilities;
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.ScrollPane.ScrollBarPolicy;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontPosture;
 
 /**
  * An implementation of the {@link DetailPane} in which a WPS preview / editor
@@ -125,7 +124,7 @@ public class WpsDetailPanel extends DetailPane
         descriptionPane.setFitToWidth(true);
 
         grid.add(descriptionPane, 0, 2, 2, 1);
-        GridPane.setFillWidth(descriptionPane, true);
+        GridPane.setFillWidth(descriptionPane, Boolean.TRUE);
         GridPane.setHgrow(descriptionPane, Priority.ALWAYS);
         GridPane.setVgrow(descriptionPane, Priority.SOMETIMES);
 
@@ -142,7 +141,7 @@ public class WpsDetailPanel extends DetailPane
 
         myParameterFormArea = createProcessEditor();
         myParameterFormArea.setStyle("-fx-border-color: #676767; -fx-border-style: solid inside line-join miter;");
-        GridPane.setFillHeight(myParameterFormArea, true);
+        GridPane.setFillHeight(myParameterFormArea, Boolean.TRUE);
         GridPane.setHgrow(myParameterFormArea, Priority.ALWAYS);
         GridPane.setVgrow(myParameterFormArea, Priority.ALWAYS);
         grid.add(myParameterFormArea, 0, 6, 2, 1);
@@ -217,7 +216,7 @@ public class WpsDetailPanel extends DetailPane
 
         myModel.getProvider().set(pDataGroup.getTopParentDisplayName());
         myModel.getTypeList().addAll(StreamUtilities.map(GroupCategorizationUtilities.getGroupCategories(pDataGroup, false),
-            input -> StringUtilities.trim(input, 's')));
+                input -> StringUtilities.trim(input, 's')));
         myModel.getDescription().set(pDataGroup.getSummaryDescription());
 
         Collection<String> tags = New.set();

--- a/open-sphere-plugins/wps/src/main/java/io/opensphere/wps/ui/detail/provider/WpsDecimalInputProvider.java
+++ b/open-sphere-plugins/wps/src/main/java/io/opensphere/wps/ui/detail/provider/WpsDecimalInputProvider.java
@@ -45,11 +45,11 @@ public class WpsDecimalInputProvider implements WpsInputControlProvider
             {
                 valueFactory = new SpinnerValueFactory.DoubleSpinnerValueFactory(0, 1000);
             }
-            double doubleValue = Double.parseDouble(pDefaultValue);
+            Double doubleValue = Double.valueOf(pDefaultValue);
             valueFactory.setValue(doubleValue);
         }
 
-        Supplier<String> resultAccessorFunction = () -> Double.toString(spinner.valueProperty().get());
+        Supplier<String> resultAccessorFunction = () -> spinner.valueProperty().get().toString();
         returnValue = new ValidatedIdentifiedControl<>(pInputDescription.getIdentifier().getValue(), pTitle,
                 resultAccessorFunction, spinner);
         returnValue.setValidationGroup(pValidationGroup);

--- a/open-sphere-plugins/wps/src/main/java/io/opensphere/wps/ui/detail/provider/WpsIntegerInputProvider.java
+++ b/open-sphere-plugins/wps/src/main/java/io/opensphere/wps/ui/detail/provider/WpsIntegerInputProvider.java
@@ -40,7 +40,7 @@ public class WpsIntegerInputProvider implements WpsInputControlProvider
         Spinner<Integer> spinner = new Spinner<>();
         initializeSpinnerValueFactory(pDefaultValue, spinner);
 
-        Supplier<String> resultAccessorFunction = () -> Integer.toString(spinner.valueProperty().get());
+        Supplier<String> resultAccessorFunction = () -> spinner.valueProperty().get().toString();
         returnValue = new ValidatedIdentifiedControl<>(pInputDescription.getIdentifier().getValue(), pTitle,
                 resultAccessorFunction, spinner);
         returnValue.setValidationGroup(pValidationGroup);
@@ -74,12 +74,12 @@ public class WpsIntegerInputProvider implements WpsInputControlProvider
 
         if (StringUtils.isNotBlank(pDefaultValue))
         {
-            int integerValue = Integer.parseInt(pDefaultValue);
+            Integer integerValue = Integer.valueOf(pDefaultValue);
             valueFactory.setValue(integerValue);
         }
         else
         {
-            valueFactory.setValue(0);
+            valueFactory.setValue(Integer.valueOf(0));
         }
     }
 }

--- a/open-sphere-plugins/wps/src/main/java/io/opensphere/wps/ui/detail/provider/WpsStringInputProvider.java
+++ b/open-sphere-plugins/wps/src/main/java/io/opensphere/wps/ui/detail/provider/WpsStringInputProvider.java
@@ -13,7 +13,7 @@ import com.google.inject.Singleton;
 
 import io.opensphere.core.Toolbox;
 import io.opensphere.core.util.collections.CollectionUtilities;
-import io.opensphere.core.util.fx.AutoCompleteComboBoxListener;
+import io.opensphere.core.util.fx.NewAutoCompleteComboBoxListener;
 import io.opensphere.core.util.javafx.input.IdentifiedControl;
 import io.opensphere.core.util.javafx.input.ValidatedIdentifiedControl;
 import io.opensphere.mantle.MantleToolbox;
@@ -144,7 +144,9 @@ public class WpsStringInputProvider implements WpsInputControlProvider
         returnValue.setValidator(new BasicValidator(choiceBox.getItems()::contains));
         choiceBox.addEventHandler(ValidationEvent.ANY, event -> DecorationUtils.update(choiceBox, event.getEventType()));
 
-        new AutoCompleteComboBoxListener<>(choiceBox);
+//        new AutoCompleteComboBoxListener<>(choiceBox);
+        NewAutoCompleteComboBoxListener listener = new NewAutoCompleteComboBoxListener();
+        listener.setupComboBox(choiceBox);
 
         return returnValue;
     }

--- a/open-sphere-plugins/wps/src/main/java/io/opensphere/wps/ui/detail/provider/WpsStringInputProvider.java
+++ b/open-sphere-plugins/wps/src/main/java/io/opensphere/wps/ui/detail/provider/WpsStringInputProvider.java
@@ -144,7 +144,6 @@ public class WpsStringInputProvider implements WpsInputControlProvider
         returnValue.setValidator(new BasicValidator(choiceBox.getItems()::contains));
         choiceBox.addEventHandler(ValidationEvent.ANY, event -> DecorationUtils.update(choiceBox, event.getEventType()));
 
-//        new AutoCompleteComboBoxListener<>(choiceBox);
         NewAutoCompleteComboBoxListener listener = new NewAutoCompleteComboBoxListener();
         listener.setupComboBox(choiceBox);
 


### PR DESCRIPTION
- Auto-boxing replaced with proper primitive/object parsing. Warnings suppressed in tests.
  - Not generally a problem, but there are some situations where the item being boxed can be `null`.
  - Some unnecessary parsing has been removed, including error-induced autoboxing (ex `Integer.toString(int)` being used as `Integer.toString(Integer x)` instead of `x.toString()`)
- Raw Type issues fixed; replaced by explicit or generic typing where necessary.
- Many non-Observer deprecation warnings suppressed for now.
- Spacing fixed.
- Unnecessary casting removed. Cast warning suppression removed if unnecessary.
  - Some necessary casting was determined by Eclipse to be unnecessary, despite causing compile errors due to ambiguous method overloads. Warnings for these cases have been suppressed.
- Warnings for field hiding have been suppressed.
- Brace styling fixed.
- Various JavaDoc comments fixed & added.
- Unused classes deprecated.
  - Some classes have replacements; `AutoCompleteComboBoxListener` has been replaced by a refactored `NewAutoCompleteComboBoxListener` where in use.
- Various method calls utilizing mixed primitives/objects where their places were swapped have been fixed.
- Some methods that accepted primitive parameters have been given object overloads.
- Null warning suppression has been added to cases that cannot be null, despite Eclipse suggesting otherwise.
  - Null warning suppression has been removed from cases that cannot be null that Eclipse ignores.
- Resource leak warnings have been suppressed where they are impossible. `FilePreferencesPersistenceManager` could stand to be refactored or written so that the use of input/output streams is less confusing (to Eclipse).
  - Some resource leaks have been fixed by properly closing their streams after finishing all operations.
- Some superclass methods that were `synchronized` were overridden with ones that weren't. Made then synchronized.
- Other.