### PR TITLE
VORTEX-5780 'Styles for Tiles' Button for Reference Layers Not Opening HUD

### DIFF
--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/LayerControlPanel.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/LayerControlPanel.java
@@ -279,6 +279,10 @@ public abstract class LayerControlPanel extends AbstractHUDPanel
                     {
                         for (TileLevelController c : tlcControllers)
                         {
+                            if (c.getMaxGeneration() == -1)
+                            {
+                                continue;
+                            }
                             c.setDivisionOverride(myTileLevelHoldCheckBox.isSelected());
                             try
                             {

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/controller/impl/DataGroupControllerImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/controller/impl/DataGroupControllerImpl.java
@@ -432,7 +432,7 @@ public class DataGroupControllerImpl implements DataGroupController, EventListen
         boolean active = false;
         if (dti != null)
         {
-            active = dti.isInUseBy(this);
+            active = dti.isInUseBy(this) || myActivationController.getUserActivatedGroupIds().contains(dti.getParent().getId());
         }
         return active;
     }


### PR DESCRIPTION
- **Fix**: User-activated tile layers that depend on an external server will not work with the tile style window unless reloaded.
- **Fix**: Hold Level spinner will throw an exception if the tile level controller a layer is associated with does not have a max generation (-1).