### PR TITLE
VORTEX-5803 Cacheing Error loading ArcGIS feature

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/cache/impl/LoadedElementData.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/cache/impl/LoadedElementData.java
@@ -436,6 +436,13 @@ public class LoadedElementData implements LoadedElementDataView, Serializable
                     }
                     else if (oldValue != null)
                     {
+                        if (keyClass == String.class)
+                        {
+                            // Some instances may have improper conversion. JSON
+                            // data in the form of String may auto-convert to a
+                            // Number
+                            resultList.set(i, String.valueOf(oldValue));
+                        }
                         if (keyClass == Long.class && oldValue.getClass() != Long.class)
                         {
                             resultList.set(i, convertValueToLongIfPossible(oldValue));


### PR DESCRIPTION
Fixes VORTEX-5803.


ESRI data-types may indicate that specific fields are strings, but present the actual data in another format when loaded. In this event, ensure the data is correctly mapped to a String when storing in the cache.