### PR TITLE
VORTEX-5805: Fixing fly-to issues for groups of points.

### DIFF
--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/controller/ActiveDataMouseListener.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/controller/ActiveDataMouseListener.java
@@ -55,7 +55,7 @@ public class ActiveDataMouseListener implements MouseListener
                 boolean wentToView = gotoBookmarkView(dataType);
                 if (!wentToView)
                 {
-                    DataTypeActionUtils.gotoDataType(dataType, myToolbox.getMapManager().getStandardViewer());
+                    DataTypeActionUtils.gotoDataType(dataType, myToolbox);
                 }
             }
         }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/model/GeographicBoundingBox.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/model/GeographicBoundingBox.java
@@ -172,6 +172,23 @@ public class GeographicBoundingBox implements BoundingBox<GeographicPosition>, C
         return merge(box1, box2, box1.getAltitudeReference());
     }
 
+    public static GeographicBoundingBox merge(Collection<GeographicBoundingBox> boxes)
+    {
+        GeographicBoundingBox mergedBox = null;
+        for (GeographicBoundingBox box : boxes)
+        {
+            if (mergedBox == null)
+            {
+                mergedBox = box;
+            }
+            else
+            {
+                mergedBox = merge(mergedBox, box);
+            }
+        }
+        return mergedBox;
+    }
+
     /**
      * Create a new geographic bounding box that merges two other boxes. The
      * result will have an altitude of 0 using the provided reference level.

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/model/GeographicBoundingBox.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/model/GeographicBoundingBox.java
@@ -172,6 +172,14 @@ public class GeographicBoundingBox implements BoundingBox<GeographicPosition>, C
         return merge(box1, box2, box1.getAltitudeReference());
     }
 
+    /**
+     * Create a new geographic bounding box that merges the supplied boxes. The
+     * result will have an altitude of 0 using the reference level of the input
+     * boxes. If the reference levels do not match, an exception is thrown.
+     *
+     * @param boxes the collection of bounding boxes to merge.
+     * @return The union of the supplied bounding boxes.
+     */
     public static GeographicBoundingBox merge(Collection<GeographicBoundingBox> boxes)
     {
         GeographicBoundingBox mergedBox = null;
@@ -542,10 +550,7 @@ public class GeographicBoundingBox implements BoundingBox<GeographicPosition>, C
         {
             return average;
         }
-        else
-        {
-            return average - Constants.HALF_CIRCLE_DEGREES;
-        }
+        return average - Constants.HALF_CIRCLE_DEGREES;
     }
 
     /**

--- a/open-sphere-plugins/kml/src/main/java/io/opensphere/kml/mantle/controller/KMLMantleController.java
+++ b/open-sphere-plugins/kml/src/main/java/io/opensphere/kml/mantle/controller/KMLMantleController.java
@@ -136,7 +136,7 @@ public class KMLMantleController extends EventListenerService implements KMLMapC
         boolean zoomTo = myBundlePreferences.getBoolean("zoomTo", false);
         if (zoomTo)
         {
-            DataTypeActionUtils.gotoDataType(dataType, myToolbox.getMapManager().getStandardViewer());
+            DataTypeActionUtils.gotoDataType(dataType, myToolbox.getMapManager().getStandardViewer(), myToolbox);
         }
     }
 

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesController.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/controllers/MyPlacesController.java
@@ -19,10 +19,10 @@ import io.opensphere.core.viewbookmark.ViewBookmark;
 import io.opensphere.core.viewbookmark.util.ViewBookmarkUtil;
 import io.opensphere.mantle.data.CategoryContextKey;
 import io.opensphere.mantle.data.DataGroupInfo;
+import io.opensphere.mantle.data.DataGroupInfo.MultiDataGroupContextKey;
 import io.opensphere.mantle.data.DataTypeInfo;
 import io.opensphere.mantle.data.MapVisualizationInfo;
 import io.opensphere.mantle.data.MapVisualizationType;
-import io.opensphere.mantle.data.DataGroupInfo.MultiDataGroupContextKey;
 import io.opensphere.mantle.data.util.impl.DataTypeActionUtils;
 import io.opensphere.myplaces.constants.Constants;
 import io.opensphere.myplaces.dataaccess.MyPlacesDataAccessor;
@@ -184,7 +184,7 @@ public class MyPlacesController implements Observer, Runnable, PointGoer, Servic
 
             if (!wentToView)
             {
-                DataTypeActionUtils.gotoDataType(dataType, myToolbox.getMapManager().getStandardViewer());
+                DataTypeActionUtils.gotoDataType(dataType, myToolbox);
             }
         }
     }

--- a/open-sphere-plugins/open-sensor-hub/src/main/java/io/opensphere/osh/model/OSHDataGroupInfoAssistant.java
+++ b/open-sphere-plugins/open-sensor-hub/src/main/java/io/opensphere/osh/model/OSHDataGroupInfoAssistant.java
@@ -80,6 +80,6 @@ public class OSHDataGroupInfoAssistant extends DefaultDataGroupInfoAssistant
     public void gotoLocation(DataGroupInfo dataGroup)
     {
         DataTypeInfo dataType = dataGroup.getMembers(false).iterator().next();
-        DataTypeActionUtils.gotoDataType(dataType, myToolbox.getMapManager().getStandardViewer());
+        DataTypeActionUtils.gotoDataType(dataType, myToolbox);
     }
 }


### PR DESCRIPTION
Fixes #142 Unable to fly to on different data sources

## Proposed Changes
  - This was never implemented for some data sources (CSVs, specifically), implemented ability to calculate a minimum bounding box if none has previously been calculated, and fly to the box. This does not take time into account. 
