### PR TITLE
VORTEX-5779: Fixing search view menu popup.

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/control/ui/ToolbarManager.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/control/ui/ToolbarManager.java
@@ -467,7 +467,7 @@ public class ToolbarManager
         JPanel panel = centerPanel;
         for (ToolbarComponent tbc : myNorthToolbarComponents)
         {
-            if (tbc.getName().equals("SearchGoto"))
+            if (tbc.getName().equals("Search"))
             {
                 panel = eastPanel;
             }

--- a/open-sphere-plugins/search/src/main/java/io/opensphere/search/SearchPlugin.java
+++ b/open-sphere-plugins/search/src/main/java/io/opensphere/search/SearchPlugin.java
@@ -5,10 +5,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.function.Supplier;
 import java.util.Set;
-
-import javafx.application.Platform;
+import java.util.function.Supplier;
 
 import javax.swing.SwingUtilities;
 
@@ -27,6 +25,7 @@ import io.opensphere.core.search.SearchProvider;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.swing.EventQueueUtilities;
 import io.opensphere.search.model.SearchModel;
+import javafx.application.Platform;
 
 /** Class for the "Goto" hud frame. */
 public class SearchPlugin extends AbstractHUDFrameMenuItemPlugin
@@ -96,7 +95,7 @@ public class SearchPlugin extends AbstractHUDFrameMenuItemPlugin
                 SearchPanel mainPanel = new SearchPanel(controller, myResultsDialog, instance.getHUDFrameSupplier(), myModel);
 
                 myToolbox.getUIRegistry().getToolbarComponentRegistry().registerToolbarComponent(ToolbarLocation.NORTH,
-                        "SearchGoto", mainPanel, 10000, SeparatorLocation.RIGHT);
+                        "Search", mainPanel, 10000, SeparatorLocation.RIGHT);
             }
         });
     }

--- a/open-sphere-plugins/search/src/main/java/io/opensphere/search/SearchResultHudDialog.java
+++ b/open-sphere-plugins/search/src/main/java/io/opensphere/search/SearchResultHudDialog.java
@@ -53,6 +53,20 @@ public class SearchResultHudDialog extends AbstractInternalFrame
         setResizable(true);
         setDefaultCloseOperation(HIDE_ON_CLOSE);
 
+        // set up default height and width:
+        int width = 550;
+        int height = 850;
+        int xposition = 0;
+        int yposition = 0;
+        if (getParent() != null)
+        {
+            height = getParent().getHeight() - 187;
+            xposition = getParent().getWidth() - getWidth();
+        }
+        setSize(width, height);
+        setLocation(xposition, yposition);
+
+
         myResultPanel = new SearchDialogPanel(toolbox, searchModel);
         myResultPanelContainer = new JFXPanel();
         Scene scene = new Scene(myResultPanel, 600, 800);

--- a/open-sphere-plugins/search/src/main/java/io/opensphere/search/SearchResultHudDialog.java
+++ b/open-sphere-plugins/search/src/main/java/io/opensphere/search/SearchResultHudDialog.java
@@ -17,6 +17,15 @@ import javafx.scene.Scene;
 /** A HUD-dialog in which search results are rendered. */
 public class SearchResultHudDialog extends AbstractInternalFrame
 {
+    /** The height offset used to avoid the timeline. */
+    private static final int HEIGHT_OFFSET = 187;
+
+    /** The default height of the HUD window. */
+    private static final int DEFAULT_HEIGHT = 850;
+
+    /** The default width of the HUD window. */
+    private static final int DEFAULT_WIDTH = 550;
+
     /** The title of the frame in which the search results are presented. */
     public static final String TITLE = "Search Results";
 
@@ -54,13 +63,13 @@ public class SearchResultHudDialog extends AbstractInternalFrame
         setDefaultCloseOperation(HIDE_ON_CLOSE);
 
         // set up default height and width:
-        int width = 550;
-        int height = 850;
+        int width = DEFAULT_WIDTH;
+        int height = DEFAULT_HEIGHT;
         int xposition = 0;
         int yposition = 0;
         if (getParent() != null)
         {
-            height = getParent().getHeight() - 187;
+            height = getParent().getHeight() - HEIGHT_OFFSET;
             xposition = getParent().getWidth() - getWidth();
         }
         setSize(width, height);
@@ -69,7 +78,7 @@ public class SearchResultHudDialog extends AbstractInternalFrame
 
         myResultPanel = new SearchDialogPanel(toolbox, searchModel);
         myResultPanelContainer = new JFXPanel();
-        Scene scene = new Scene(myResultPanel, 600, 800);
+        Scene scene = new Scene(myResultPanel, DEFAULT_WIDTH, DEFAULT_HEIGHT);
         myResultPanelContainer.setScene(FXUtilities.addDesktopStyle(scene));
         setDefaultCloseOperation(HIDE_ON_CLOSE);
 
@@ -122,8 +131,8 @@ public class SearchResultHudDialog extends AbstractInternalFrame
         {
             myResultPanel.performSearch();
         }
-        int width = 150;
-        int height = 850;
+        int width = DEFAULT_WIDTH;
+        int height = DEFAULT_HEIGHT;
         int xposition = 0;
         int yposition = 0;
         if (myResultPanelContainer.getPreferredSize() != null)
@@ -132,7 +141,7 @@ public class SearchResultHudDialog extends AbstractInternalFrame
         }
         if (getParent() != null)
         {
-            height = getParent().getHeight() - 187;
+            height = getParent().getHeight() - HEIGHT_OFFSET;
             xposition = getParent().getWidth() - getWidth();
         }
         setSize(width, height);

--- a/open-sphere-plugins/search/src/main/resources/pluginLoader.xml
+++ b/open-sphere-plugins/search/src/main/resources/pluginLoader.xml
@@ -12,7 +12,7 @@
         </pluginProperty>
         <pluginProperty>
             <key>menuButtonLabel</key>
-            <value>SearchGoto</value>
+            <value>Search</value>
         </pluginProperty>
     </pluginLoaderData>
 </pluginLoaderCollection>


### PR DESCRIPTION
Fixes #149 View menu's "Search" option doesn't do anything.

## Proposed Changes
  - The search pane was being initialized with a width of zero, causing it to error out. Fixed to initialize with a default width. 
  - Renamed references from "SearchGoto" to just "Search"

