### PR TITLE
Unique ID Column combo-box size increase

### DIFF
--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/ActiveLayerControlPanel.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/ActiveLayerControlPanel.java
@@ -2,6 +2,7 @@ package io.opensphere.controlpanels.layers.activedata;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
@@ -842,10 +843,12 @@ public final class ActiveLayerControlPanel extends LayerControlPanel
         getProviderPanel().removeAll();
         GridBagPanel providerPanel = new GridBagPanel();
         JLabel textField = new JLabel("Unique ID Column: ");
-        uniqueProvider.setSize(35, 24);
         providerPanel.add(textField);
         providerPanel.fillHorizontal();
+
+        uniqueProvider.setMinimumSize(new Dimension(100, 24));
         providerPanel.add(uniqueProvider);
+
         getProviderPanel().setVisible(true);
         getProviderPanel().add(providerPanel);
         getProviderPanel().revalidate();


### PR DESCRIPTION
## Proposed Changes
- Updates minimum size of UID box from 34 to 100 px.
  - New minimum size falls within acceptable visibility bounds; is not cut off on Active Layer panel shrinking until after buttons + other text
