### PR TITLE
VORTEX-5735 Matching for similar keys.

### DIFF
--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/export/model/ExtraColumnsMetaDataProvider.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/export/model/ExtraColumnsMetaDataProvider.java
@@ -5,6 +5,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import io.opensphere.core.util.collections.New;
 import io.opensphere.mantle.data.element.MetaDataProvider;
@@ -90,6 +93,20 @@ public class ExtraColumnsMetaDataProvider implements MetaDataProvider
     public boolean hasKey(String key)
     {
         return myExtraColumns.containsKey(key) || myOriginal.hasKey(key);
+    }
+
+    @Override
+    public Stream<String> matchKey(Pattern key)
+    {
+        LongAdder adder = new LongAdder();
+        Stream<String> value = myExtraColumns.keySet().stream().filter(k -> key.matcher(k).matches())
+                .peek(v -> adder.increment());
+        if (adder.intValue() == 0)
+        {
+            value.close();
+            value = myOriginal.matchKey(key);
+        }
+        return value;
     }
 
     @Override

--- a/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/listtool/model/DirectAccessMetaDataProvider.java
+++ b/open-sphere-base/analysis/src/main/java/io/opensphere/analysis/listtool/model/DirectAccessMetaDataProvider.java
@@ -66,6 +66,12 @@ class DirectAccessMetaDataProvider implements MetaDataProvider
     }
 
     @Override
+    public java.util.stream.Stream<String> matchKey(java.util.regex.Pattern key)
+    {
+        throw new UnsupportedOperationException("matchKey() is not supported for DirectAccessMetaDataProvider");
+    }
+
+    @Override
     public boolean keysMutable()
     {
         throw new UnsupportedOperationException("keysMutable() is not supported for DirectAccessMetaDataProvider");

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/crust/MetaDataProviderAdapter.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/crust/MetaDataProviderAdapter.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import io.opensphere.mantle.data.element.MetaDataProvider;
 
@@ -47,6 +49,12 @@ public abstract class MetaDataProviderAdapter implements MetaDataProvider
     public boolean hasKey(String key)
     {
         return myFieldNames.contains(key);
+    }
+
+    @Override
+    public Stream<String> matchKey(Pattern key)
+    {
+        return myFieldNames.stream().filter(k -> key.matcher(k).matches());
     }
 
     @Override

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/element/MetaDataProvider.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/element/MetaDataProvider.java
@@ -2,6 +2,8 @@ package io.opensphere.mantle.data.element;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * Interface for DataElements that provide Meta Data for tooling.
@@ -84,4 +86,14 @@ public interface MetaDataProvider
      * @return true if keys are mutable on the fly, false if not.
      */
     boolean valuesMutable();
+
+    /**
+     * Returns a stream containing similar keys to the provided parameter.
+     * <p>
+     * When using this function, ensure that the resulting stream is terminated.
+     *
+     * @param key - the key to check
+     * @return the matching keystream
+     */
+    Stream<String> matchKey(Pattern key);
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/element/impl/AbstractMDILinkedMetaDataProvider.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/element/impl/AbstractMDILinkedMetaDataProvider.java
@@ -2,6 +2,8 @@ package io.opensphere.mantle.data.element.impl;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import io.opensphere.mantle.data.MetaDataInfo;
 import io.opensphere.mantle.data.element.MetaDataProvider;
@@ -45,6 +47,12 @@ public abstract class AbstractMDILinkedMetaDataProvider implements MetaDataProvi
     public final boolean hasKey(String key)
     {
         return myMetaDataInfo.hasKey(key);
+    }
+
+    @Override
+    public Stream<String> matchKey(Pattern key)
+    {
+        return myMetaDataInfo.getKeyNames().stream().filter(k -> key.matcher(k).matches());
     }
 
     @Override

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/element/impl/SimpleMetaDataProvider.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/element/impl/SimpleMetaDataProvider.java
@@ -6,6 +6,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import io.opensphere.mantle.data.element.MetaDataProvider;
 
@@ -81,6 +83,12 @@ public class SimpleMetaDataProvider implements MetaDataProvider, Serializable
     public boolean hasKey(String key)
     {
         return myKeyToValueMap.containsKey(key);
+    }
+
+    @Override
+    public Stream<String> matchKey(Pattern key)
+    {
+        return myKeyToValueMap.keySet().stream().filter(k -> key.matcher(k).matches());
     }
 
     @Override

--- a/open-sphere-plugins/wfs/src/main/java/io/opensphere/wfs/envoy/DataObjectMetaDataProvider.java
+++ b/open-sphere-plugins/wfs/src/main/java/io/opensphere/wfs/envoy/DataObjectMetaDataProvider.java
@@ -3,6 +3,8 @@ package io.opensphere.wfs.envoy;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import io.opensphere.core.common.geospatial.model.DataObject;
 import io.opensphere.mantle.data.element.MetaDataProvider;
@@ -92,5 +94,11 @@ public class DataObjectMetaDataProvider implements MetaDataProvider
     public boolean valuesMutable()
     {
         return false;
+    }
+
+    @Override
+    public Stream<String> matchKey(Pattern key)
+    {
+        return myKeys.stream().filter(k -> key.matcher(k).matches());
     }
 }


### PR DESCRIPTION
Fixes VORTEX-5735

## Proposed Changes
- **Add**: `MetaDataProvider.matchKey`, which returns a stream of keys that match a given pattern.