### PR TITLE
VORTEX-5816 Remove source during load failure (sphere)

### DIFF
--- a/open-sphere-plugins/csv/src/main/java/io/opensphere/csv/CSVFileHandler.java
+++ b/open-sphere-plugins/csv/src/main/java/io/opensphere/csv/CSVFileHandler.java
@@ -236,6 +236,10 @@ public class CSVFileHandler extends AbstractDataSourceHandler
         }
         if (dep.hadError())
         {
+            //Imported File is not usable.  Remove source from CSVFileDataSourceController so
+            //source name can be used again.
+            controller.removeSource(csvFileSource, false, null);
+
             StringBuilder sb = new StringBuilder();
             sb.append("Errors encountered loading CSV File ").append(csvFileSource.getSourceUri());
             if (dep.getErrorMessages() != null && !dep.getErrorMessages().isEmpty())


### PR DESCRIPTION
Fixes #
- Remove source from controller if it fails to load.  This will allows another source with the same name to be loaded later
## Proposed Changes

  -
  -
  -
