### PR TITLE
VORTEX-5832 Labels on mini style panel

### DIFF
--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/ActiveLayerControlPanel.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/ActiveLayerControlPanel.java
@@ -20,6 +20,7 @@ import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
+import javax.swing.JScrollPane;
 
 import io.opensphere.controlpanels.ControlPanelToolbox;
 import io.opensphere.controlpanels.event.AnimationChangeExtentRequestEvent;
@@ -816,7 +817,9 @@ public final class ActiveLayerControlPanel extends LayerControlPanel
                     && !MapVisualizationType.TERRAIN_TILE.equals(dti.getMapVisualizationInfo().getVisualizationType()))
             {
                 MiniStylePanel miniStylePanel = new MiniStylePanel(getToolbox(), dgi, dti);
-                myMiniStyleBox.add(miniStylePanel);
+                JScrollPane scroller = new JScrollPane(miniStylePanel);
+
+                myMiniStyleBox.add(scroller);
             }
             else
             {

--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/ActiveLayerControlPanel.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/ActiveLayerControlPanel.java
@@ -20,7 +20,6 @@ import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
-import javax.swing.JScrollPane;
 
 import io.opensphere.controlpanels.ControlPanelToolbox;
 import io.opensphere.controlpanels.event.AnimationChangeExtentRequestEvent;
@@ -817,9 +816,7 @@ public final class ActiveLayerControlPanel extends LayerControlPanel
                     && !MapVisualizationType.TERRAIN_TILE.equals(dti.getMapVisualizationInfo().getVisualizationType()))
             {
                 MiniStylePanel miniStylePanel = new MiniStylePanel(getToolbox(), dgi, dti);
-                JScrollPane scroller = new JScrollPane(miniStylePanel);
-
-                myMiniStyleBox.add(scroller);
+                myMiniStyleBox.add(miniStylePanel);
             }
             else
             {

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/dialog/MiniStylePanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/dialog/MiniStylePanel.java
@@ -234,22 +234,31 @@ public class MiniStylePanel extends JPanel
         /** you know what this is for */
         private static final long serialVersionUID = 1L;
 
+        /** Height of JScrollPane viewport. */
+        private static final int MAX_HEIGHT = 300;
+
+        /** Number of pixels per scrollable unit; scrollbar arrows. */
+        private static final int SCROLL_INCREMENT_PX = 25;
+
+        /** Number of pixels per block unit; scrollbar anchor & mouse wheel. */
+        private static final int BLOCK_INCREMENT_PX = 50;
+
         @Override
         public Dimension getPreferredScrollableViewportSize()
         {
-            return new Dimension(getPreferredSize().width, 300);
+            return new Dimension(getPreferredSize().width, MAX_HEIGHT);
         }
 
         @Override
         public int getScrollableUnitIncrement(Rectangle visibleRect, int orientation, int direction)
         {
-            return 25;
+            return SCROLL_INCREMENT_PX;
         }
 
         @Override
         public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction)
         {
-            return 50;
+            return BLOCK_INCREMENT_PX;
         }
 
         @Override

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/dialog/MiniStylePanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/dialog/MiniStylePanel.java
@@ -97,8 +97,12 @@ public class MiniStylePanel extends JPanel
     /** The Type panels. */
     private final List<MiniStyleTypePanel> myTypePanels;
 
+    /** Internal JPanel that holds MiniStyleTypePanels. */
     private final JPanel myInternalPanel;
 
+    /**
+     * Scroll pane allowing scroll on {@link #myInternalPanel} (can be null).
+     */
     private JScrollPane myScrollPane;
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/dialog/MiniStylePanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/dialog/MiniStylePanel.java
@@ -3,6 +3,7 @@ package io.opensphere.mantle.data.geom.style.dialog;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Insets;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.List;
@@ -19,6 +20,7 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JToggleButton;
+import javax.swing.Scrollable;
 
 import io.opensphere.core.Toolbox;
 import io.opensphere.core.util.Colors;
@@ -51,7 +53,7 @@ import io.opensphere.mantle.util.MantleToolboxUtils;
  * The Class MiniStylePanel.
  */
 @SuppressWarnings("PMD.GodClass")
-public class MiniStylePanel extends JPanel
+public class MiniStylePanel extends JPanel implements Scrollable
 {
     /** The Constant FEATURE_TYPE_COLLAPSED_PREFIX. */
     private static final String FEATURE_TYPE_COLLAPSED_PREFIX = "FeatureTypeCollapsed.";
@@ -111,16 +113,11 @@ public class MiniStylePanel extends JPanel
 
         myEnableCustomTypeCheckBox = new JCheckBox("Enable Custom Style", false);
         myEnableCustomTypeCheckBox.setBorder(null);
-        myEnableCustomTypeCheckBox.addActionListener(new ActionListener()
+        myEnableCustomTypeCheckBox.addActionListener(e ->
         {
-            @Override
-            public void actionPerformed(ActionEvent e)
-            {
-                VisualizationStyleController vsc = MantleToolboxUtils.getMantleToolbox(myToolbox)
-                        .getVisualizationStyleController();
-                vsc.setUseCustomStyleForDataType(myDGI, myDTI, myEnableCustomTypeCheckBox.isSelected(), MiniStylePanel.this);
-                rebuildUI();
-            }
+            VisualizationStyleController vsc = MantleToolboxUtils.getMantleToolbox(myToolbox).getVisualizationStyleController();
+            vsc.setUseCustomStyleForDataType(myDGI, myDTI, myEnableCustomTypeCheckBox.isSelected(), MiniStylePanel.this);
+            rebuildUI();
         });
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
@@ -754,5 +751,35 @@ public class MiniStylePanel extends JPanel
         public void styleChangesCancelled()
         {
         }
+    }
+
+    @Override
+    public Dimension getPreferredScrollableViewportSize()
+    {
+        return new Dimension(getPreferredSize().width, 300);
+    }
+
+    @Override
+    public int getScrollableUnitIncrement(Rectangle visibleRect, int orientation, int direction)
+    {
+        return visibleRect.height / 2;
+    }
+
+    @Override
+    public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction)
+    {
+        return visibleRect.height;
+    }
+
+    @Override
+    public boolean getScrollableTracksViewportWidth()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean getScrollableTracksViewportHeight()
+    {
+        return false;
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/ComboBoxAndColorChooserEditorPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/ComboBoxAndColorChooserEditorPanel.java
@@ -7,7 +7,6 @@ import java.util.Collection;
 
 import javax.swing.Box;
 import javax.swing.JButton;
-import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 
 import com.bric.swing.ColorPicker;
@@ -24,14 +23,14 @@ public class ComboBoxAndColorChooserEditorPanel extends ComboBoxStyleParameterEd
     /** serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
-    /** The Color. */
-    private Color myColor;
-
-    /** The Slider. */
-    private final JButton myColorChooserBT;
-
     /** The Second parameter. */
     private final String mySecondParameterKey;
+
+    /** The color chooser button. */
+    private final JButton myColorChooserButton;
+
+    /** The Color. */
+    private Color myColor;
 
     /**
      * Instantiates a new abstract style parameter editor panel.
@@ -55,23 +54,26 @@ public class ComboBoxAndColorChooserEditorPanel extends ComboBoxStyleParameterEd
         mySecondParameterKey = colorChooserParamKey;
 
         myColor = getColorParameterValue();
-        myColorChooserBT = new JButton(new ColorCircleIcon(myColor));
-        myColorChooserBT.setMaximumSize(new Dimension(25, 20));
-        myColorChooserBT.addActionListener(this);
+        myColorChooserButton = new JButton(new ColorCircleIcon(myColor));
+        myColorChooserButton.setMaximumSize(new Dimension(25, 20));
+        myColorChooserButton.addActionListener(this);
+
+        myComboBoxPanel.add(Box.createHorizontalStrut(5), 1);
+        myComboBoxPanel.add(myColorChooserButton, 2);
     }
 
     @Override
     public void actionPerformed(ActionEvent e)
     {
         super.actionPerformed(e);
-        if (e.getSource() == myColorChooserBT)
+        if (e.getSource() == myColorChooserButton)
         {
             Color c = ColorPicker.showDialog(SwingUtilities.getWindowAncestor(this), "Select Color",
-                    ((ColorCircleIcon)myColorChooserBT.getIcon()).getColor(), true);
+                    ((ColorCircleIcon)myColorChooserButton.getIcon()).getColor(), true);
             if (c != null)
             {
                 myColor = c;
-                myColorChooserBT.setIcon(new ColorCircleIcon(myColor));
+                myColorChooserButton.setIcon(new ColorCircleIcon(myColor));
                 myStyle.setParameter(mySecondParameterKey, myColor, this);
             }
         }
@@ -86,15 +88,8 @@ public class ComboBoxAndColorChooserEditorPanel extends ComboBoxStyleParameterEd
         if (!cValue.equals(myColor))
         {
             myColor = cValue;
-            EventQueueUtilities.runOnEDT(() -> myColorChooserBT.setIcon(new ColorCircleIcon(myColor)));
+            EventQueueUtilities.runOnEDT(() -> myColorChooserButton.setIcon(new ColorCircleIcon(myColor)));
         }
-    }
-
-    @Override
-    protected void addOtherComponents(JPanel cbPanel)
-    {
-        cbPanel.add(Box.createHorizontalStrut(5));
-        cbPanel.add(myColorChooserBT);
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/ComboBoxStyleParameterEditorPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/ComboBoxStyleParameterEditorPanel.java
@@ -2,7 +2,6 @@ package io.opensphere.mantle.data.geom.style.impl.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Collection;
@@ -13,9 +12,8 @@ import java.util.Map;
 import java.util.Objects;
 
 import javax.swing.Box;
-import javax.swing.BoxLayout;
 import javax.swing.JComboBox;
-import javax.swing.JPanel;
+import javax.swing.JComponent;
 
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.swing.EventQueueUtilities;
@@ -40,7 +38,7 @@ public class ComboBoxStyleParameterEditorPanel extends AbstractStyleParameterEdi
     private final JComboBox<OptionProxy<Object>> myComboBox;
 
     /** The Combo box panel. */
-    private JPanel myComboBoxPanel;
+    protected final JComponent myComboBoxPanel;
 
     /** The Options. */
     @SuppressWarnings("PMD.SingularField")
@@ -64,6 +62,7 @@ public class ComboBoxStyleParameterEditorPanel extends AbstractStyleParameterEdi
 
         myChoiceToProxyMap = New.map();
         myOptions = convertAndSortList(myChoiceToProxyMap, options, numericChoices, noneOption);
+
         myComboBox = new JComboBox<>(new ListComboBoxModel<>(myOptions));
         myComboBox.setSelectedItem(myChoiceToProxyMap.get(getParamValue()));
         Color cbBackground = getComboboxBackgroundFromBuilder(label);
@@ -71,6 +70,17 @@ public class ComboBoxStyleParameterEditorPanel extends AbstractStyleParameterEdi
         {
             myComboBox.setBackground(cbBackground);
         }
+
+        myComboBoxPanel = Box.createHorizontalBox();
+        myComboBoxPanel.add(myComboBox);
+        myComboBoxPanel.add(Box.createHorizontalGlue());
+
+        myControlPanel.setLayout(new BorderLayout());
+        myControlPanel.add(myComboBoxPanel, BorderLayout.CENTER);
+
+        myComboBox.addActionListener(this);
+
+        showMessage(getParamValue());
     }
 
     @SuppressWarnings("unchecked")
@@ -83,30 +93,6 @@ public class ComboBoxStyleParameterEditorPanel extends AbstractStyleParameterEdi
             setParamValue(option);
             showMessage(option);
         }
-    }
-
-    @Override
-    public void addNotify()
-    {
-        super.addNotify();
-
-        myComboBoxPanel = new JPanel();
-        myComboBoxPanel.setLayout(new BoxLayout(myComboBoxPanel, BoxLayout.X_AXIS));
-        myComboBoxPanel.add(myComboBox);
-        addOtherComponents(myComboBoxPanel);
-        myComboBoxPanel.add(Box.createHorizontalGlue());
-
-        myControlPanel.setLayout(new BorderLayout());
-        myControlPanel.add(myComboBoxPanel, BorderLayout.CENTER);
-
-        myComboBox.addActionListener(this);
-
-        int panelHeight = getPanelHeightFromBuilder();
-        setSize(new Dimension(80, panelHeight));
-        setMinimumSize(new Dimension(80, panelHeight));
-        setPreferredSize(new Dimension(80, panelHeight));
-        setMaximumSize(new Dimension(1200, panelHeight));
-        showMessage(getParamValue());
     }
 
     /**
@@ -134,15 +120,6 @@ public class ComboBoxStyleParameterEditorPanel extends AbstractStyleParameterEdi
                 showMessage(pVal);
             });
         }
-    }
-
-    /**
-     * Adds the other components.
-     *
-     * @param cbPanel the cb panel
-     */
-    protected void addOtherComponents(JPanel cbPanel)
-    {
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/FloatSliderStyleParameterEditorPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/FloatSliderStyleParameterEditorPanel.java
@@ -10,7 +10,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 
 import javax.swing.Box;
-import javax.swing.BoxLayout;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSlider;
@@ -46,8 +46,8 @@ public class FloatSliderStyleParameterEditorPanel extends AbstractStyleParameter
     /** The Slider. */
     private final JSlider mySlider;
 
-    /** The Slider panel. */
-    private final JPanel mySliderPanel;
+    /** The Slider container. */
+    private final JComponent mySliderContainer;
 
     /** The Text entry. */
     private final boolean myTextEntry;
@@ -116,40 +116,40 @@ public class FloatSliderStyleParameterEditorPanel extends AbstractStyleParameter
         myTextField.addActionListener(this);
         myTextField.setMinimumSize(new Dimension(80, 20));
 
-        Box aBox = Box.createHorizontalBox();
+        // Construct the container for the slider & siblings.
+        mySliderContainer = Box.createHorizontalBox();
         Component c = getPrefixComponent(myPanelBuilder);
         if (c != null)
         {
-            aBox.add(c);
+            mySliderContainer.add(c);
         }
-        mySliderPanel = new JPanel();
-        mySliderPanel.setLayout(new BoxLayout(mySliderPanel, BoxLayout.X_AXIS));
-        mySliderPanel.add(Box.createHorizontalStrut(5));
 
+        mySliderContainer.add(Box.createHorizontalStrut(5));
+
+        Component subPanel;
         if (myTextEntry)
         {
-            JPanel subPanel = new JPanel(new GridLayout(1, 2, 5, 0));
-            subPanel.add(mySlider);
-            subPanel.add(myTextField);
-            mySliderPanel.add(subPanel);
-            mySliderPanel.add(Box.createHorizontalStrut(5));
-
-            if (myConvertor.getUnit() != null)
-            {
-                mySliderPanel.add(myValueLabel);
-            }
+            subPanel = new JPanel(new GridLayout(1, 2, 5, 0));
+            ((JPanel)subPanel).add(mySlider);
+            ((JPanel)subPanel).add(myTextField);
         }
         else
         {
-            mySliderPanel.add(mySlider);
-            mySliderPanel.add(Box.createHorizontalStrut(5));
-            mySliderPanel.add(myValueLabel);
+            subPanel = mySlider;
         }
-        mySliderPanel.add(Box.createHorizontalGlue());
-        aBox.add(mySliderPanel);
+
+        mySliderContainer.add(subPanel);
+        mySliderContainer.add(Box.createHorizontalStrut(5));
+
+        if (!myTextEntry || myConvertor.getUnit() != null)
+        {
+            mySliderContainer.add(myValueLabel);
+        }
+
+        mySliderContainer.add(Box.createHorizontalGlue());
 
         myControlPanel.setLayout(new BorderLayout());
-        myControlPanel.add(aBox, BorderLayout.CENTER);
+        myControlPanel.add(mySliderContainer, BorderLayout.CENTER);
         mySlider.addChangeListener(this);
         myTimer = new Timer(300, this);
         myTimer.setRepeats(false);
@@ -249,9 +249,9 @@ public class FloatSliderStyleParameterEditorPanel extends AbstractStyleParameter
      *
      * @return the slider panel
      */
-    protected JPanel getSliderPanel()
+    protected JComponent getSliderPanel()
     {
-        return mySliderPanel;
+        return mySliderContainer;
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/MultiComboBoxStyleTwoParameterEditorPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/MultiComboBoxStyleTwoParameterEditorPanel.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import javax.swing.Box;
 import javax.swing.JComboBox;
-import javax.swing.JPanel;
 
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.lang.EqualsHelper;
@@ -73,18 +72,11 @@ public class MultiComboBoxStyleTwoParameterEditorPanel extends ComboBoxStylePara
         {
             mySecondComboBox.setBackground(cbBackground);
         }
-//        Dimension d = mySecondComboBox.getPreferredSize();
-//        mySecondComboBox.setPreferredSize(new Dimension(d.width - 50, d.height));
-//        mySecondComboBox.setMaximumSize(new Dimension(d.width - 50, 30));
-//        getComboBoxPanel().add(Box.createHorizontalStrut(5));
-//        getComboBoxPanel().add(mySecondComboBox);
-//        if (labelOpt2 != null)
-//        {
-//            getComboBoxPanel().add(Box.createHorizontalStrut(5));
-//            getComboBoxPanel().add(new JLabel(labelOpt2));
-//        }
 
         mySecondComboBox.addActionListener(this);
+
+        myComboBoxPanel.add(Box.createHorizontalStrut(5), 1);
+        myComboBoxPanel.add(mySecondComboBox, 2);
     }
 
     @Override
@@ -102,9 +94,6 @@ public class MultiComboBoxStyleTwoParameterEditorPanel extends ComboBoxStylePara
         }
     }
 
-    /**
-     * Update.
-     */
     @Override
     public final void update()
     {
@@ -116,18 +105,6 @@ public class MultiComboBoxStyleTwoParameterEditorPanel extends ComboBoxStylePara
             final Object fVal = val;
             EventQueueUtilities.runOnEDT(() -> mySecondComboBox.setSelectedItem(fVal));
         }
-    }
-
-    /**
-     * Adds the other components.
-     *
-     * @param cbPanel the cb panel
-     */
-    @Override
-    protected void addOtherComponents(JPanel cbPanel)
-    {
-        cbPanel.add(Box.createHorizontalStrut(5));
-        cbPanel.add(mySecondComboBox);
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/MultiComboEditor.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/ui/MultiComboEditor.java
@@ -18,8 +18,8 @@ import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
-import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTextArea;
 
 import org.apache.log4j.Logger;
 
@@ -202,8 +202,12 @@ public class MultiComboEditor extends AbstractStyleParameterEditorPanel
         // maximum
         if (rowList.size() < maxBoxes)
         {
-            JLabel label = new JLabel("Click the plus button to add labels.");
+            JTextArea label = new JTextArea();
+            label.setEditable(false);
+            label.setLineWrap(true);
+            label.setWrapStyleWord(true);
             label.setFont(label.getFont().deriveFont(Font.ITALIC));
+            label.setText(String.format("Click the plus button to add labels to a maximum of %d.", Integer.valueOf(maxBoxes)));
 
             JPanel p = new JPanel();
             p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));


### PR DESCRIPTION
Fixes VORTEX-5832

## Proposed Changes
- **Add**: Internal scrollable frame inside `MiniStylePanel`, fixed height of 300 pixels when visible
- **Update**: Various style editor classes updated in an attempt to fix resize problem
  - When active layer panel reaches specific minimum width (varies for each editor type) the style editors will expand vertically without reporting new size. This pushes sibling panels outside of the `MiniStylePanel` dimensions
  - This issue was not fixed; may only be resolvable through complete rewrite. Is fully mitigated through allowing horizontal scroll in mini style panel, however
