### PR TITLE
VORTEX-5614 Merged Layer has no time field

### DIFF
--- a/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/algorithm/MergeData.java
+++ b/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/algorithm/MergeData.java
@@ -1,11 +1,10 @@
 package io.opensphere.merge.algorithm;
 
 import java.io.Serializable;
-import java.util.LinkedHashMap; // added import
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import io.opensphere.mantle.data.DataTypeInfo;
 import io.opensphere.mantle.data.element.DataElement;
@@ -139,14 +138,10 @@ public class MergeData extends DatasetOperation
         for (DataElement elt : getSupp().getRecords(t))
         {
             MetaDataProvider meta = elt.getMetaData();
-            Map<String, Serializable> valMap = new LinkedHashMap<>(); //orig TreeMap
+            Map<String, Serializable> valMap = new LinkedHashMap<>();
             for (int i = 0; i < newKeys.size(); i++)
             {
-                Object value = getMetaVal(meta, oldKeys[i]);
-                if (value instanceof Serializable)
-                {
-                    Util.putNonNull(valMap, newKeys.get(i), (Serializable)value);
-                }
+                valMap.put(newKeys.get(i), (Serializable)getMetaVal(meta, oldKeys[i]));
             }
 
             MapGeometrySupport geometry = getMapGeometry(elt);

--- a/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/algorithm/MergeData.java
+++ b/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/algorithm/MergeData.java
@@ -1,6 +1,7 @@
 package io.opensphere.merge.algorithm;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap; // added import
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -138,7 +139,7 @@ public class MergeData extends DatasetOperation
         for (DataElement elt : getSupp().getRecords(t))
         {
             MetaDataProvider meta = elt.getMetaData();
-            Map<String, Serializable> valMap = new TreeMap<>();
+            Map<String, Serializable> valMap = new LinkedHashMap<>(); //orig TreeMap
             for (int i = 0; i < newKeys.size(); i++)
             {
                 Object value = getMetaVal(meta, oldKeys[i]);

--- a/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/controller/MetaDataInfoProvider.java
+++ b/open-sphere-plugins/merge/src/main/java/io/opensphere/merge/controller/MetaDataInfoProvider.java
@@ -1,6 +1,7 @@
 package io.opensphere.merge.controller;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -46,7 +47,7 @@ public class MetaDataInfoProvider
     {
         DefaultMetaDataInfo metadataInfo = new DefaultMetaDataInfo();
 
-        Map<String, Class<?>> columnsToTypes = New.map();
+        Map<String, Class<?>> columnsToTypes = new LinkedHashMap<>();
         for (MergedDataRow row : data)
         {
             for (Entry<String, Serializable> entry : row.getData().entrySet())


### PR DESCRIPTION
Fixes VORTEX-5614

## Proposed Changes

  - Fix: Columns and data are stored in-order
  - Fix: Entries that have no data for a particular column are not skipped