### PR TITLE
Enable Custom Style affects feature action styles when enabled, but not when disabled

### DIFF
--- a/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/controller/FeatureActionsController.java
+++ b/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/controller/FeatureActionsController.java
@@ -113,10 +113,7 @@ public class FeatureActionsController extends EventListenerService
             @Override
             public void visualizationStyleDatatypeChanged(VisualizationStyleDatatypeChangeEvent evt)
             {
-                if (!evt.isNewIsDefaultStyle())
-                {
-                    myProcrastinatingExecutor.execute(() -> handleModelChange(evt.getDTIKey()));
-                }
+                myProcrastinatingExecutor.execute(() -> handleModelChange(evt.getDTIKey()));
             }
 
             @Override

--- a/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/controller/StyleFactory.java
+++ b/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/controller/StyleFactory.java
@@ -181,7 +181,7 @@ public class StyleFactory
                 switch (styleOptions.getStyle())
                 {
                     case POINT:
-                        style = newPointStyle(dataType, styleOptions);
+                        style = newPointStyle(dataType, styleOptions, defaultStyle);
                         break;
                     case ICON:
                         style = newIconStyle(dataType, styleOptions, defaultStyle);
@@ -258,14 +258,20 @@ public class StyleFactory
      *
      * @param dataType the data type
      * @param styleOptions style options
+     * @param defaultStyle the default style
      * @return the style
      */
-    private PointFeatureVisualizationStyle newPointStyle(DataTypeInfo dataType, StyleOptions styleOptions)
+    private PointFeatureVisualizationStyle newPointStyle(DataTypeInfo dataType, StyleOptions styleOptions,
+            FeatureVisualizationStyle defaultStyle)
     {
         PointFeatureVisualizationStyle style = getStyleFromConfig(PointFeatureVisualizationStyle.class, dataType);
         if (styleOptions.hasSizeBeenSet())
         {
             style.setPointSize(styleOptions.getSize(), this);
+        }
+        else
+        {
+            style.setPointSize(((PointFeatureVisualizationStyle)defaultStyle).getPointSize(), this);
         }
         return style;
     }


### PR DESCRIPTION
Fixes VORTEX-5886

## Proposed Changes

  - listener responds to default style updates
  - point size in the new style will default to the default style size