### PR TITLE
VORTEX-5898 Look and Feel Alignment: State button

### DIFF
--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/ActiveLayerControlPanel.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/activedata/ActiveLayerControlPanel.java
@@ -526,11 +526,9 @@ public final class ActiveLayerControlPanel extends LayerControlPanel
      */
     private JButton buildExportButton()
     {
-        myExportButton = new SplitButton(null, null);
+        myExportButton = new SplitButton(null, null, false);
         IconUtil.setIcons(myExportButton, IconType.EXPORT);
         myExportButton.setToolTipText("Export the selected layers");
-        myExportButton.setAlwaysPopup(true);
-
         return myExportButton;
     }
 

--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/state/DisableStatesMenuProvider.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/state/DisableStatesMenuProvider.java
@@ -13,7 +13,7 @@ import io.opensphere.core.util.Utilities;
 /**
  * A menu provider for the clear states button.
  */
-public class ClearStatesMenuProvider implements ContextMenuProvider<Void>
+public class DisableStatesMenuProvider implements ContextMenuProvider<Void>
 {
     /** The module state manager. */
     private final ModuleStateManager myModuleStateManager;
@@ -23,7 +23,7 @@ public class ClearStatesMenuProvider implements ContextMenuProvider<Void>
      *
      * @param moduleStateManager The module state manager.
      */
-    public ClearStatesMenuProvider(ModuleStateManager moduleStateManager)
+    public DisableStatesMenuProvider(ModuleStateManager moduleStateManager)
     {
         myModuleStateManager = Utilities.checkNull(moduleStateManager, "moduleStateManager");
     }
@@ -31,14 +31,14 @@ public class ClearStatesMenuProvider implements ContextMenuProvider<Void>
     @Override
     public List<JMenuItem> getMenuItems(String contextId, Void key)
     {
-        JMenuItem clearStatesMenuItem = new JMenuItem("Clear States");
-        clearStatesMenuItem.addActionListener(e ->
+        JMenuItem disableStatesMenuItem = new JMenuItem("Disable States");
+        disableStatesMenuItem.addActionListener(e ->
         {
-            Quantify.collectMetric("mist3d.control-panels.selection.clear-states");
+            Quantify.collectMetric("mist3d.control-panels.selection.disable-states");
             myModuleStateManager.deactivateAllStates();
         });
-        clearStatesMenuItem.setToolTipText("Deactivate all states");
-        return Collections.singletonList(clearStatesMenuItem);
+        disableStatesMenuItem.setToolTipText("Deactivate all states");
+        return Collections.singletonList(disableStatesMenuItem);
     }
 
     @Override

--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/state/StatePlugin.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/state/StatePlugin.java
@@ -9,6 +9,7 @@ import io.opensphere.core.control.ui.ToolbarManager.ToolbarLocation;
 import io.opensphere.core.event.ApplicationLifecycleEvent;
 import io.opensphere.core.event.EventListener;
 import io.opensphere.core.util.swing.EventQueueUtilities;
+import io.opensphere.core.util.swing.SplitButton;
 
 /**
  * Plugin that provides the controls for saving and restoring state.
@@ -18,8 +19,8 @@ public class StatePlugin extends PluginAdapter
     /** The toolbox. */
     private Toolbox myToolbox;
 
-    /** The menu provider for the clear button. */
-    private ClearStatesMenuProvider myClearStatesMenuProvider;
+    /** The menu provider for the disable button. */
+    private DisableStatesMenuProvider myDisableStatesMenuProvider;
 
     /** The import controller. */
     private StateImportController myImportController;
@@ -48,9 +49,9 @@ public class StatePlugin extends PluginAdapter
     {
         myToolbox = toolbox;
 
-        myClearStatesMenuProvider = new ClearStatesMenuProvider(toolbox.getModuleStateManager());
+        myDisableStatesMenuProvider = new DisableStatesMenuProvider(toolbox.getModuleStateManager());
         toolbox.getUIRegistry().getContextActionManager().registerContextMenuItemProvider(ContextIdentifiers.DELETE_CONTEXT,
-                Void.class, myClearStatesMenuProvider);
+                Void.class, myDisableStatesMenuProvider);
 
         myImportController = new StateImportController(toolbox.getUIRegistry().getMainFrameProvider(),
                 toolbox.getModuleStateManager(), toolbox);
@@ -64,7 +65,7 @@ public class StatePlugin extends PluginAdapter
     {
         myToolbox.getUIRegistry().getToolbarComponentRegistry().deregisterToolbarComponent(ToolbarLocation.NORTH, "State");
         myToolbox.getUIRegistry().getContextActionManager().deregisterContextMenuItemProvider(ContextIdentifiers.DELETE_CONTEXT,
-                Void.class, myClearStatesMenuProvider);
+                Void.class, myDisableStatesMenuProvider);
         myToolbox.getImporterRegistry().removeImporter(myImportController);
     }
 
@@ -75,14 +76,16 @@ public class StatePlugin extends PluginAdapter
     void initializeAfterPlugins()
     {
         StateController controller = new StateControllerImpl(myToolbox);
-        myStateView = new StateView(controller, myToolbox);
+        myStateView = new StateView(controller, myImportController, myToolbox);
         myImportController.setStateController(controller);
-        myToolbox.getUIRegistry().getToolbarComponentRegistry().registerToolbarComponent(ToolbarLocation.NORTH, "State",
-                myStateView.getStateControlButton(), 470, SeparatorLocation.LEFT);
-        myToolbox.getUIRegistry().getIconLegendRegistry().addIconToLegend(myStateView.getStateControlButton().getIcon(), "State",
-                "Launches the Save State dialog which allows the current state of the tool to be saved. Different "
-                        + "parts of the current state can be saved including Filters, Time, Current View, Animation, Map Layers"
-                        + " and Layers, Query Regions, and Styles. There is also a dropdown button that allows states to be"
-                        + " cleared, deleted, activated, or saved.");
+
+        SplitButton stateControlButton = myStateView.getStateControlButton();
+        myToolbox.getUIRegistry().getToolbarComponentRegistry().registerToolbarComponent(ToolbarLocation.NORTH,
+                stateControlButton.getText(), stateControlButton, 470, SeparatorLocation.LEFT);
+        myToolbox.getUIRegistry().getIconLegendRegistry().addIconToLegend(stateControlButton.getIcon(),
+                stateControlButton.getText(),
+                "Shows state controls for activating/deactivating a state, importing a state (via file or url), saving a state, "
+                        + "disabling states, and deleting states. Different parts of the current state can be saved including "
+                        + "Filters, Time, Current View, Animation, Map Layers and Layers, Query Regions, and Styles. ");
     }
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/SplitButton.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/swing/SplitButton.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.swing.Icon;
+import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.event.PopupMenuEvent;
@@ -31,8 +32,11 @@ public class SplitButton extends IconButton
     /** The serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
-    /** The Draws split. */
-    private final boolean myDrawsSplit;
+    /**
+     * If the main part and drop-down part of the button have different
+     * functionality.
+     */
+    private final boolean myHasMultipleFunctions;
 
     /** The width of the region which activates the drop menu. */
     private int myDropRegionWidth = 14;
@@ -40,8 +44,8 @@ public class SplitButton extends IconButton
     /** The dynamic menu items. */
     private final List<Component> myDynamicMenuItems = New.list();
 
-    /** Whether to show the popup for a normal click (when not on the arrow). */
-    private boolean myIsAlwaysPopup;
+    /** The static menu items. */
+    private final List<Component> myStaticMenuItems = New.list();
 
     /** True if the button press was over the menu, false otherwise. */
     private boolean myIsMenuPress;
@@ -56,7 +60,9 @@ public class SplitButton extends IconButton
     private boolean mySkipNextMenu;
 
     /**
-     * Constructor.
+     * Instantiates a new split button. In this case, pressing the main part
+     * button will have a different effect than pressing the drop-down part of
+     * the button.
      *
      * @param text the text
      * @param icon the icon
@@ -67,26 +73,20 @@ public class SplitButton extends IconButton
     }
 
     /**
-     * Instantiates a new split button. In this case, the split part of the
-     * button will not be drawn and pressing the button anywhere on the button
-     * will show the popup menu.
+     * Instantiates a new split button with the option to have the main part of
+     * the button do something different than the drop-down part of the button.
      *
      * @param text the text
      * @param icon the icon
-     * @param drawSplit the draw split
+     * @param hasMultipleFunctions if the main part and drop-down part of the
+     *            button have different functionality
      */
-    public SplitButton(String text, Icon icon, boolean drawSplit)
+    public SplitButton(String text, Icon icon, boolean hasMultipleFunctions)
     {
         super(text, icon);
-        myDrawsSplit = drawSplit;
-        if (myDrawsSplit)
-        {
-            addExtraSpace();
-        }
-        else
-        {
-            myIsAlwaysPopup = true;
-        }
+        myHasMultipleFunctions = hasMultipleFunctions;
+
+        addExtraSpace();
 
         // Listen to mouse events to determine where the user clicked
         addMouseListener(new MouseAdapter()
@@ -106,7 +106,7 @@ public class SplitButton extends IconButton
             @Override
             public void mousePressed(MouseEvent e)
             {
-                myIsMenuPress = myDrawsSplit && e.getX() >= getWidth() - myDropRegionWidth;
+                myIsMenuPress = myHasMultipleFunctions && e.getX() >= getWidth() - myDropRegionWidth || !myHasMultipleFunctions;
             }
         });
 
@@ -162,6 +162,7 @@ public class SplitButton extends IconButton
     {
         pMenuItem.setFocusable(false);
         myMenu.add(pMenuItem);
+        myStaticMenuItems.add(pMenuItem);
     }
 
     /**
@@ -200,17 +201,6 @@ public class SplitButton extends IconButton
     }
 
     /**
-     * Sets whether to show the popup for a normal click (when not on the
-     * arrow).
-     *
-     * @param isAlwaysPopup whether to always show the popup
-     */
-    public void setAlwaysPopup(boolean isAlwaysPopup)
-    {
-        myIsAlwaysPopup = isAlwaysPopup;
-    }
-
-    /**
      * Set the dropRegionWidth.
      *
      * @param dropRegionWidth the dropRegionWidth to set
@@ -225,25 +215,27 @@ public class SplitButton extends IconButton
      */
     public void toggleDropComponentVisibility()
     {
-        // Remove the old dynamic menu items
-        if (!myDynamicMenuItems.isEmpty())
-        {
-            for (Component c : myDynamicMenuItems)
-            {
-                myMenu.remove(c);
-            }
-            myDynamicMenuItems.clear();
-        }
+        List<Component> newDynamicMenuItems = getDynamicMenuItems();
 
-        // Add the new dynamic menu items
-        List<Component> newDynamicItems = getDynamicMenuItems();
-        if (!newDynamicItems.isEmpty())
+        // determine if there are/were dynamic menu items
+        if (!myDynamicMenuItems.isEmpty() || !newDynamicMenuItems.isEmpty())
         {
-            myDynamicMenuItems.addAll(newDynamicItems);
-            for (Component c : newDynamicItems)
+            // clear the menu completely
+            myMenu.removeAll();
+            myDynamicMenuItems.clear();
+
+            // determine if there are dynamic items to add to the menu
+            if (!newDynamicMenuItems.isEmpty())
             {
-                myMenu.add(c);
+                myDynamicMenuItems.addAll(newDynamicMenuItems);
+                myMenu.add(new JLabel(getDynamicMenuItemsLabel()));
+                myDynamicMenuItems.forEach(item -> myMenu.add(item));
+                myMenu.addSeparator();
             }
+
+            // add static menu items back either below the dynamic menu items or
+            // alone if there were no dynamic menu items to add
+            myStaticMenuItems.forEach(item -> myMenu.add(item));
         }
 
         boolean empty = myMenu.getComponentCount() == 0;
@@ -274,7 +266,7 @@ public class SplitButton extends IconButton
             mySkipNextMenu = false;
             return;
         }
-        if (myIsMenuPress || myIsAlwaysPopup)
+        if (myIsMenuPress)
         {
             toggleDropComponentVisibility();
         }
@@ -285,7 +277,8 @@ public class SplitButton extends IconButton
     }
 
     /**
-     * Gets the dynamic menu items.
+     * Gets the dynamic menu items. Exists to be overwritten if dynamic menu
+     * items are needed
      *
      * @return the dynamic menu items
      */
@@ -294,44 +287,49 @@ public class SplitButton extends IconButton
         return Collections.emptyList();
     }
 
+    /**
+     * Gets the dynamic menu items' label. Exists to be overwritten if dynamic
+     * menu items are needed
+     *
+     * @return the dynamic menu items' label
+     */
+    protected String getDynamicMenuItemsLabel()
+    {
+        return null;
+    }
+
     @Override
     protected void paintComponent(Graphics g)
     {
         super.paintComponent(g);
 
-        if (myDrawsSplit)
-        {
-            int margin = 3;
-            int triWidth = myDropRegionWidth / 2;
-            int triHeight = (triWidth + 1) / 2;
+        int margin = 3;
+        int triWidth = myDropRegionWidth / 2;
+        int triHeight = (triWidth + 1) / 2;
 
-            Graphics2D g2d = (Graphics2D)g;
-            int lineX = getWidth() - myDropRegionWidth - 1;
+        Graphics2D g2d = (Graphics2D)g;
+        int lineX = getWidth() - myDropRegionWidth - 1;
 
-            // Draw vertical line
-            g2d.setColor(Colors.LF_SECONDARY1);
-            g2d.drawLine(lineX, 1, lineX, getHeight() - 1);
+        // Draw vertical line
+        g2d.setColor(Colors.LF_SECONDARY1);
+        g2d.drawLine(lineX, 1, lineX, getHeight() - 1);
 
-            // Draw triangle
-            int x1 = lineX + margin + 1;
-            int x2 = x1 + triWidth;
-            int x3 = x1 + (triWidth - 1) / 2;
-            int y1 = getHeight() / 2;
-            int y2 = y1;
-            int y3 = y1 + triHeight;
-            g2d.setColor(isEnabled() ? Color.WHITE : Color.GRAY);
-            g2d.fillPolygon(new int[] { x1, x2, x3 }, new int[] { y1, y2, y3 }, 3);
-        }
+        // Draw triangle
+        int x1 = lineX + margin + 1;
+        int x2 = x1 + triWidth;
+        int x3 = x1 + (triWidth - 1) / 2;
+        int y1 = getHeight() / 2;
+        int y2 = y1;
+        int y3 = y1 + triHeight;
+        g2d.setColor(isEnabled() ? Color.WHITE : Color.GRAY);
+        g2d.fillPolygon(new int[] { x1, x2, x3 }, new int[] { y1, y2, y3 }, 3);
     }
 
     @Override
     protected void sizeToFit()
     {
         super.sizeToFit();
-        if (myDrawsSplit)
-        {
-            addExtraSpace();
-        }
+        addExtraSpace();
     }
 
     /**


### PR DESCRIPTION
Made the "States" button more similar in look and functionality to web's "States" button.

Reordered state controls drop down to put the saved states on top and added a label to them.
Added in options to import state from file/url in drop down.
Took away state button's save state action and made it only open up the state controls drop down menu.
Renamed some options / added icons  / rewrote the tooltips to match web.
Rewrote the icon legend entry for the states button.