### PR TITLE
VORTEX-5896 Overlay - Show map overlay and controls by default

### DIFF
--- a/open-sphere-base/core/src/main/resources/system.properties
+++ b/open-sphere-base/core/src/main/resources/system.properties
@@ -33,9 +33,6 @@ opensphere.whatsnew.contactinfo=
 # Customer support contact info
 contact.info=
 
-# The url for doing geoquery searches
-geoquery.url=http://home.gvs.nga.ic.gov/GeoQuery/geClientQueryAction.do?query=replace_me
-
 # User Agent Name
 opensphere.useragent=OpenSphere Desktop
 

--- a/open-sphere-base/overlay/src/main/resources/prefs/MenuItem.HUDOverlayControls.xml
+++ b/open-sphere-base/overlay/src/main/resources/prefs/MenuItem.HUDOverlayControls.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?><preferences topic="MenuItem.HUD Overlay Controls">
+   <preference class="java.lang.Boolean" key="visible">
+      <value>true</value>
+   </preference>
+</preferences>

--- a/open-sphere-base/overlay/src/main/resources/prefs/MenuItem.WorldMap.xml
+++ b/open-sphere-base/overlay/src/main/resources/prefs/MenuItem.WorldMap.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?><preferences topic="MenuItem.World Map">
+   <preference class="java.lang.Boolean" key="visible">
+      <value>true</value>
+   </preference>
+</preferences>


### PR DESCRIPTION
Moves the prefs files controlling overlay/overlay controls visibility from a config location to the overlay project so that for all configurations, the map overlay and controls are visible by default.
