### PR TITLE
VORTEX-5957: Updating purge to not remove areas

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/transformer/impl/PurgeByRegionCommandWorker.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/transformer/impl/PurgeByRegionCommandWorker.java
@@ -31,8 +31,9 @@ public class PurgeByRegionCommandWorker extends PolygonRegionCommandWorker
     @Override
     public void process()
     {
-        // Don't purge anything from base.
-        if (getProvider() != null && getProvider().getDataType() != null
+        // Don't purge anything from base, or any areas
+        if (getProvider() != null && getProvider().getDataType() != null 
+                && !getProvider().getDataType().getClass().getSimpleName().startsWith("Area")
                 && getProvider().getDataType().getBasicVisualizationInfo() != null
                 && getProvider().getDataType().getBasicVisualizationInfo().getLoadsTo().isAnalysisEnabled())
         {


### PR DESCRIPTION
Fixes #5957

## Proposed Changes
  - Checks the datatype name to determine if it purges. If it starts with "Area", then it won't purge (avoids introducing weird dependencies)
  -
  -
