### PR TITLE
VORTEX-5961: Creating buffers for multipolygons from the map.

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/BufferRegionCreator.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/BufferRegionCreator.java
@@ -56,7 +56,7 @@ public class BufferRegionCreator
     {
         myToolbox = toolbox;
     }
-    
+
     /**
      * Gets the value of the {@link #myToolbox} field.
      *
@@ -247,18 +247,17 @@ public class BufferRegionCreator
             }
         }
     }
-    
+
     /**
      * Sets the value of the {@link #myGeometry} field.
      *
-     * @param geometry 
-     *            the value to store in the {@link #myGeometry} field.
+     * @param geometry the value to store in the {@link #myGeometry} field.
      */
     protected void setGeometry(Geometry geometry)
     {
         myGeometry = geometry;
     }
-    
+
     /**
      * Gets the value of the {@link #myGeometry} field.
      *
@@ -268,18 +267,18 @@ public class BufferRegionCreator
     {
         return myGeometry;
     }
-    
+
     /**
      * Sets the value of the {@link #myPreviewGeometry} field.
      *
-     * @param previewGeometry 
-     *            the value to store in the {@link #myPreviewGeometry} field.
+     * @param previewGeometry the value to store in the
+     *            {@link #myPreviewGeometry} field.
      */
     protected void setPreviewGeometry(Geometry previewGeometry)
     {
         myPreviewGeometry = previewGeometry;
     }
-    
+
     /**
      * Gets the value of the {@link #myPreviewGeometry} field.
      *

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionCommandFactory.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionCommandFactory.java
@@ -18,7 +18,7 @@ import io.opensphere.mantle.plugin.selection.impl.AddFeaturesCommand;
 import io.opensphere.mantle.plugin.selection.impl.AddFeaturesCurrentFrame;
 import io.opensphere.mantle.plugin.selection.impl.CancelQueryCommand;
 import io.opensphere.mantle.plugin.selection.impl.CreateBufferCommand;
-import io.opensphere.mantle.plugin.selection.impl.CreateBufferSelectedSegmentCommand;
+import io.opensphere.mantle.plugin.selection.impl.CreateBufferSelectedCommand;
 import io.opensphere.mantle.plugin.selection.impl.DeselectCommand;
 import io.opensphere.mantle.plugin.selection.impl.LoadFeaturesCommand;
 import io.opensphere.mantle.plugin.selection.impl.LoadFeaturesCurrentFrameCommand;
@@ -50,7 +50,7 @@ public class SelectionCommandFactory
     public static final SelectionCommand CREATE_BUFFER_REGION = new CreateBufferCommand();
 
     /** Buffer Line. */
-    public static final SelectionCommand CREATE_BUFFER_REGION_FOR_SELECTED_SEGMENT = new CreateBufferSelectedSegmentCommand();
+    public static final SelectionCommand CREATE_BUFFER_REGION_FOR_SELECTED = new CreateBufferSelectedCommand();
 
     /** DESELECT. */
     public static final SelectionCommand DESELECT = new DeselectCommand();
@@ -75,7 +75,7 @@ public class SelectionCommandFactory
      */
     private static final List<SelectionCommand> DEFAULT_COMMANDS = List.of(ADD_FEATURES, ADD_FEATURES_CURRENT_FRAME,
             LOAD_FEATURES, LOAD_FEATURES_CURRENT_FRAME, CANCEL_QUERY, CREATE_BUFFER_REGION,
-            CREATE_BUFFER_REGION_FOR_SELECTED_SEGMENT, DESELECT, REMOVE_ALL, SELECT, SELECT_EXCLUSIVE);
+            CREATE_BUFFER_REGION_FOR_SELECTED, DESELECT, REMOVE_ALL, SELECT, SELECT_EXCLUSIVE);
 
     /**
      * Default set of commands.
@@ -151,6 +151,7 @@ public class SelectionCommandFactory
         {
             menuItems.add(createHeader("TOOLS"));
             menuItems.add(CREATE_BUFFER_REGION.createMenuItem(listener));
+            menuItems.add(CREATE_BUFFER_REGION_FOR_SELECTED.createMenuItem(listener));
         }
         return menuItems;
     }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
@@ -490,10 +490,13 @@ public class SelectionHandler
             }
             else
             {
-                myBufferRegionCreator.createBuffer(myLastGeometry);
+                // check to see if the geometry is a member of a group of
+                // multiple geometries. if so, create the buffer for the group
+                // instead of the individual geometry:
+                myBufferRegionCreator.createBuffer(getCompleteGeometryGroup(myLastGeometry));
             }
         }
-        else if (cmd.equals(SelectionCommandFactory.CREATE_BUFFER_REGION_FOR_SELECTED_SEGMENT))
+        else if (cmd.equals(SelectionCommandFactory.CREATE_BUFFER_REGION_FOR_SELECTED))
         {
             Quantify.collectMetric("mist3d.tracks.create-buffer-for-selected-segment");
             myBufferRegionCreator.createBuffer(myLastGeometry);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/CreateBufferSelectedCommand.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/CreateBufferSelectedCommand.java
@@ -10,15 +10,15 @@ import io.opensphere.mantle.plugin.selection.SelectionCommandGroup;
  * Command to create a polygon that buffers the selected line segment, which can
  * be used for queries, selections, etc.
  */
-public class CreateBufferSelectedSegmentCommand extends AbstractSelectionCommand
+public class CreateBufferSelectedCommand extends AbstractSelectionCommand
 {
     /**
      * Creates a new command.
      */
-    public CreateBufferSelectedSegmentCommand()
+    public CreateBufferSelectedCommand()
     {
-        super("CREATE_BUFFER_REGION_FOR_SELECTED_SEGMENT", "Create Buffer Region For Selected Segment",
-                "Create a polygon that buffers the selected line segment, which can be used for queries, selections, etc.",
+        super("CREATE_BUFFER_REGION_FOR_SELECTED_SEGMENT", "Create Buffer Region For Selected",
+                "Create a polygon that buffers the selected item, which can be used for queries, selections, etc.",
                 SelectionCommandGroup.TOOLS, new GenericFontIcon(AwesomeIconSolid.BULLSEYE, Color.WHITE, 12));
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/toolbox/MantleToolboxImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/toolbox/MantleToolboxImpl.java
@@ -154,7 +154,7 @@ public class MantleToolboxImpl implements MantleToolbox
 
         myQueryLineManager = new QueryLineManagerImpl(aToolbox);
         mySelectionHandler.registerLineSelectionCommandProcessor(SelectionCommandFactory.CREATE_BUFFER_REGION, myQueryLineManager);
-        mySelectionHandler.registerLineSelectionCommandProcessor(SelectionCommandFactory.CREATE_BUFFER_REGION_FOR_SELECTED_SEGMENT,
+        mySelectionHandler.registerLineSelectionCommandProcessor(SelectionCommandFactory.CREATE_BUFFER_REGION_FOR_SELECTED,
                 myQueryLineManager);
 
         myDataTypeInfoPreferenceAssistant = new DataTypeInfoPreferenceAssistantImpl(myParentToolbox);


### PR DESCRIPTION
Fixes #5961

## Proposed Changes
  - Allows a user to right click on a polygon on the map, and if that sub-polygon is a member of a multipolygon, can create a buffer for the whole multipolygon.
  - Adds an option to create the buffer for only the selected sub-polygon.
  -
