### PR TITLE
VORTEX-5981: Fixing track menu items, menu item icon render size

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/geometry/util/PolylineGeometryUtils.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/geometry/util/PolylineGeometryUtils.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.log4j.Logger;
+
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.CoordinateSequence;
 import com.vividsolutions.jts.geom.GeometryFactory;
@@ -29,6 +31,9 @@ import io.opensphere.core.model.time.TimeSpan;
  */
 public final class PolylineGeometryUtils
 {
+    /** The logger used to capture output from instances of this class. */
+    private static final Logger LOG = Logger.getLogger(PolylineGeometryUtils.class);
+
     /**
      * The JTS factory used to create new geometries.
      */
@@ -100,6 +105,10 @@ public final class PolylineGeometryUtils
         Coordinate[] coordinateArray = new Coordinate[coordinates.size()];
         coordinateArray = coordinates.toArray(coordinateArray);
 
+        if (coordinateArray.length < 2)
+        {
+            return null;
+        }
         return new LineString(new CoordinateArraySequence(coordinateArray), GEOMETRY_FACTORY);
     }
 
@@ -218,7 +227,15 @@ public final class PolylineGeometryUtils
         Set<LineString> lineStrings = new HashSet<>();
         for (PolylineGeometry polylineGeometry : pPolylineGeometries)
         {
-            lineStrings.add(convertToLineString(polylineGeometry));
+            LineString lineString = convertToLineString(polylineGeometry);
+            if (lineString != null)
+            {
+                lineStrings.add(lineString);
+            }
+            else
+            {
+                LOG.info("Omitted polyline with single vertex.");
+            }
         }
 
         LineString[] lineStringArray = new LineString[lineStrings.size()];

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionCommandFactory.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionCommandFactory.java
@@ -166,6 +166,7 @@ public class SelectionCommandFactory
     {
         List<Component> menuItems = new ArrayList<>();
         menuItems.add(CREATE_BUFFER_REGION.createMenuItem(al));
+        menuItems.add(CREATE_BUFFER_REGION_FOR_SELECTED.createMenuItem(al));
         return menuItems;
     }
 

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/AddFeaturesCommand.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/AddFeaturesCommand.java
@@ -17,6 +17,6 @@ public class AddFeaturesCommand extends AbstractSelectionCommand
     public AddFeaturesCommand()
     {
         super("ADD_FEATURES", "Add", "Add features in region for active data types", SelectionCommandGroup.QUERY,
-                new GenericFontIcon(AwesomeIconSolid.PLUS_CIRCLE, Color.WHITE, 12));
+                new GenericFontIcon(AwesomeIconSolid.PLUS_CIRCLE, Color.WHITE));
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/AddFeaturesCurrentFrame.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/AddFeaturesCurrentFrame.java
@@ -18,6 +18,6 @@ public class AddFeaturesCurrentFrame extends AbstractSelectionCommand
     public AddFeaturesCurrentFrame()
     {
         super("ADD_FEATURES_CURRENT_FRAME", "Add in Current Frame", "Add features in region for active data types current time frame only",
-                SelectionCommandGroup.QUERY, new GenericFontIcon(AwesomeIconSolid.PLUS_CIRCLE, Color.WHITE, 12));
+                SelectionCommandGroup.QUERY, new GenericFontIcon(AwesomeIconSolid.PLUS_CIRCLE, Color.WHITE));
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/CreateBufferCommand.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/CreateBufferCommand.java
@@ -19,6 +19,6 @@ public class CreateBufferCommand extends AbstractSelectionCommand
     {
         super("CREATE_BUFFER_REGION", "Create Buffer Region",
                 "Create a polygon that buffers an item which can then be used for queries, selections, etc.",
-                SelectionCommandGroup.TOOLS, new GenericFontIcon(AwesomeIconSolid.BULLSEYE, Color.WHITE, 12));
+                SelectionCommandGroup.TOOLS, new GenericFontIcon(AwesomeIconSolid.BULLSEYE, Color.WHITE));
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/CreateBufferSelectedCommand.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/CreateBufferSelectedCommand.java
@@ -19,6 +19,6 @@ public class CreateBufferSelectedCommand extends AbstractSelectionCommand
     {
         super("CREATE_BUFFER_REGION_FOR_SELECTED_SEGMENT", "Create Buffer Region For Selected",
                 "Create a polygon that buffers the selected item, which can be used for queries, selections, etc.",
-                SelectionCommandGroup.TOOLS, new GenericFontIcon(AwesomeIconSolid.BULLSEYE, Color.WHITE, 12));
+                SelectionCommandGroup.TOOLS, new GenericFontIcon(AwesomeIconSolid.BULLSEYE, Color.WHITE));
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/DeselectCommand.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/DeselectCommand.java
@@ -17,6 +17,6 @@ public class DeselectCommand extends AbstractSelectionCommand
     public DeselectCommand()
     {
         super("DESELECT", "Deselect All", "Deselect all features in region", SelectionCommandGroup.FEATURES,
-                new GenericFontIcon(AwesomeIconSolid.TIMES_CIRCLE, Color.WHITE, 12));
+                new GenericFontIcon(AwesomeIconSolid.TIMES_CIRCLE, Color.WHITE));
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/LoadFeaturesCommand.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/LoadFeaturesCommand.java
@@ -18,6 +18,6 @@ public class LoadFeaturesCommand extends AbstractSelectionCommand
     public LoadFeaturesCommand()
     {
         super("LOAD_FEATURES", "Load", "Clear all loaded features and load new features in region for active data types",
-                SelectionCommandGroup.FEATURES, new GenericFontIcon(AwesomeIconRegular.CIRCLE, Color.WHITE, 12));
+                SelectionCommandGroup.FEATURES, new GenericFontIcon(AwesomeIconRegular.CIRCLE, Color.WHITE));
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/LoadFeaturesCurrentFrameCommand.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/LoadFeaturesCurrentFrameCommand.java
@@ -19,6 +19,6 @@ public class LoadFeaturesCurrentFrameCommand extends AbstractSelectionCommand
     {
         super("LOAD_FEATURES_CURRENT_FRAME", "Load in Current Frame",
                 "Clear all loaded features and load new features in region for active data types current time frame only",
-                SelectionCommandGroup.FEATURES, new GenericFontIcon(AwesomeIconRegular.CIRCLE, Color.WHITE, 12));
+                SelectionCommandGroup.FEATURES, new GenericFontIcon(AwesomeIconRegular.CIRCLE, Color.WHITE));
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/RemoveAllFeaturesCommand.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/RemoveAllFeaturesCommand.java
@@ -17,6 +17,6 @@ public class RemoveAllFeaturesCommand extends AbstractSelectionCommand
     public RemoveAllFeaturesCommand()
     {
         super("REMOVE_ALL", "Remove Features in Region", "Remove all features in region", SelectionCommandGroup.FEATURES,
-                new GenericFontIcon(AwesomeIconSolid.TIMES, Color.WHITE, 12));
+                new GenericFontIcon(AwesomeIconSolid.TIMES, Color.WHITE));
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/SelectCommand.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/SelectCommand.java
@@ -17,6 +17,6 @@ public class SelectCommand extends AbstractSelectionCommand
     public SelectCommand()
     {
         super("SELECT", "Select", "Select features in region", SelectionCommandGroup.FEATURES,
-                new GenericFontIcon(AwesomeIconSolid.CHECK_CIRCLE, Color.WHITE, 12));
+                new GenericFontIcon(AwesomeIconSolid.CHECK_CIRCLE, Color.WHITE));
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/SelectExclusiveCommand.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/impl/SelectExclusiveCommand.java
@@ -17,7 +17,7 @@ public class SelectExclusiveCommand extends AbstractSelectionCommand
     public SelectExclusiveCommand()
     {
         super("SELECT_EXCLUSIVE", "Select Exclusive", "Select features in region, deselect all other features",
-                SelectionCommandGroup.FEATURES, new GenericFontIcon(AwesomeIconSolid.CHECK_CIRCLE, Color.WHITE, 12));
+                SelectionCommandGroup.FEATURES, new GenericFontIcon(AwesomeIconSolid.CHECK_CIRCLE, Color.WHITE));
     }
 
 }


### PR DESCRIPTION
Fixes VORTEX-5981

## Proposed Changes
  - Update track buffer generation to account for segments with only 2 identical coordinates 
  - Update menu generation to work properly for selected items and selected segments for polylines
  - Update menu generation to remove 'set units' submenu when right clicking on a track
  - Update menu generation to add icons to all right click menu items when right clicking on a track.
