### PR TITLE
VORTEX-5983 Icon Manager close instead of cancel

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/gui/IconChooserDialog.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/gui/IconChooserDialog.java
@@ -104,7 +104,7 @@ public class IconChooserDialog extends JDialog
 
         JPanel closePanel = new JPanel();
         closePanel.setLayout(new BoxLayout(closePanel, BoxLayout.X_AXIS));
-        JButton closeButton = new JButton("Cancel");
+        JButton closeButton = new JButton("Close");
         closeButton.setMaximumSize(new Dimension(100, 30));
         closeButton.addActionListener(e -> close(CANCELLED));
         closePanel.add(Box.createHorizontalGlue());


### PR DESCRIPTION
Fixes VORTEX-5983

## Proposed Changes

  - Icon chooser says close instead of cancel on main dialog