### PR TITLE
Icon Manager Grid and List Style

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/PanelModel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/PanelModel.java
@@ -19,7 +19,7 @@ import io.opensphere.mantle.iconproject.impl.DefaultIconRecordTreeItemObject;
 public class PanelModel
 {
     /** View set to default of Grid. */
-    private final ObjectProperty<ViewStyle> myViewType = new SimpleObjectProperty<>(this, "viewtype", ViewStyle.GRID);
+    private final ObjectProperty<ViewStyle> myViewStyle = new SimpleObjectProperty<>(this, "viewtype", ViewStyle.GRID);
 
     /** The selected icon to be used for customization dialogs. */
     private ObjectProperty<IconRecord> mySelectedRecord = new SimpleObjectProperty<IconRecord>();
@@ -79,13 +79,13 @@ public class PanelModel
     }
 
     /**
-     * Gets the icon display view type.
+     * Gets the icon display view style.
      *
      * @return the chosen view.
      */
-    public ObjectProperty<ViewStyle> getViewType()
+    public ObjectProperty<ViewStyle> getViewStyle()
     {
-        return myViewType;
+        return myViewStyle;
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
@@ -97,6 +97,12 @@ public class GridBuilder extends TilePane
         return iconButton;
     }
 
+    /**
+     * Creates the buttons to be placed in a non-image list.
+     *
+     * @param record the icon
+     * @return the new button of the icon
+     */
     private Button buttonBuilderListStyle(IconRecord record)
     {
         Button iconButton = new Button();

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
@@ -15,6 +15,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.TilePane;
 import io.opensphere.mantle.icon.IconRecord;
 import io.opensphere.mantle.iconproject.model.PanelModel;
+import io.opensphere.mantle.iconproject.model.ViewStyle;
 import io.opensphere.mantle.iconproject.view.IconCustomizerDialog;
 import io.opensphere.mantle.iconproject.view.IconPopupMenu;
 
@@ -96,6 +97,37 @@ public class GridBuilder extends TilePane
         return iconButton;
     }
 
+    private Button buttonBuilderListStyle(IconRecord record)
+    {
+        Button iconButton = new Button();
+        iconButton.setMinHeight(30);
+        iconButton.setMaxHeight(30);
+        iconButton.setPadding(new Insets(5, 5, 5, 5));
+        iconButton.setText(record.getName());
+        iconButton.setAlignment(Pos.CENTER);
+        iconButton.setTooltip(new Tooltip(record.getId() + record.getImageURL().toString()));
+        iconButton.addEventHandler(MouseEvent.MOUSE_CLICKED, new EventHandler<MouseEvent>()
+        {
+            @Override
+            public void handle(MouseEvent e)
+            {
+                if (e.getButton() == MouseButton.SECONDARY)
+                {
+                    iconButton.setContextMenu(new IconPopupMenu(myPanelModel));
+                }
+                if (myPanelModel.getViewModel().getMultiSelectEnabled())
+                {
+                    iconButton.setStyle("-fx-effect: dropshadow(three-pass-box, purple, 20, 0, 0, 0);");
+                    myPanelModel.getSelectedIcons().put(record, iconButton);
+                }
+                myPanelModel.getSelectedRecord().set(record);
+                myPanelModel.getSelectedIconMap().clear();
+                myPanelModel.getSelectedIconMap().put(record, iconButton);
+            }
+        });
+        return iconButton;
+    }
+
     /**
      * Shows the icon customizer.
      *
@@ -119,7 +151,15 @@ public class GridBuilder extends TilePane
     {
         for (IconRecord recordindex : iconRecordList)
         {
-            Button iconButton = buttonBuilder(recordindex);
+            Button iconButton;
+            if (myPanelModel.getViewStyle().get() == ViewStyle.GRID)
+            {
+                iconButton = buttonBuilder(recordindex);
+            }
+            else
+            {
+                iconButton = buttonBuilderListStyle(recordindex);
+            }
             setMargin(iconButton, new Insets(5, 5, 5, 5));
             getChildren().add(iconButton);
         }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang.StringUtils;
 import io.opensphere.mantle.iconproject.impl.ButtonBuilder;
 import io.opensphere.mantle.iconproject.impl.LabelMaker;
 import io.opensphere.mantle.iconproject.model.PanelModel;
+import io.opensphere.mantle.iconproject.model.ViewStyle;
 
 /** An HBox containing display size controls, view style, and filter options. */
 public class TopMenuBar extends HBox
@@ -169,8 +170,18 @@ public class TopMenuBar extends HBox
         myGridView.setText("Grid");
         myGridView.setToggleGroup(myToggleGroup);
         myGridView.setSelected(true);
+        myListView.setOnAction(event ->
+        {
+            myPanelModel.getViewStyle().set(ViewStyle.LIST);
+            myPanelModel.getViewModel().getMainPanel().refresh();
+        });
+        myGridView.setOnAction(event ->
+        {
+            myPanelModel.getViewStyle().set(ViewStyle.GRID);
+            myPanelModel.getViewModel().getMainPanel().refresh();
+        });
 
-        theViewToggle.getButtons().addAll(myViewLabel, myListView, myGridView);
+        theViewToggle.getButtons().addAll(myViewLabel, myGridView, myListView);
 
         return theViewToggle;
     }


### PR DESCRIPTION
Fixes

## Proposed Changes

  - Can swap between original grid layout of icons and text-only list layout