### PR TITLE
Icon Manager Small Adjustments/Cleanup

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/IconRegistry.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/IconRegistry.java
@@ -62,18 +62,18 @@ public interface IconRegistry
     /**
      * Clear icon for element.
      *
-     * @param deId the de id
+     * @param elementId the element id
      * @param source the source initiating the change
      */
-    void clearIconForElement(long deId, Object source);
+    void clearIconForElement(long elementId, Object source);
 
     /**
-     * Clear icons for all the elements int he list.
+     * Clear icons for all the elements in the list.
      *
-     * @param deIds the de ids to clear icons.
+     * @param elementIds the element ids to clear icons.
      * @param source the source initiating the change
      */
-    void clearIconsForElements(Collection<Long> deIds, Object source);
+    void clearIconsForElements(Collection<Long> elementIds, Object source);
 
     /**
      * Gets the all assigned element ids.
@@ -115,10 +115,10 @@ public interface IconRegistry
     /**
      * Gets the icon id for element id.
      *
-     * @param deId the de id
+     * @param elementId the element id
      * @return the icon id for element or -1 if not found.
      */
-    int getIconIdForElement(long deId);
+    int getIconIdForElement(long elementId);
 
     /**
      * Gets the icon ids for all the icons in the registry.
@@ -157,10 +157,10 @@ public interface IconRegistry
     /**
      * Gets the icon record for element.
      *
-     * @param deId the de id
+     * @param elementId the element id
      * @return the {@link IconRecord} for element
      */
-    IconRecord getIconRecordForElement(long deId);
+    IconRecord getIconRecordForElement(long elementId);
 
     /**
      * Gets the {@link IconRecord}s for the specified ids.
@@ -201,11 +201,11 @@ public interface IconRegistry
     /**
      * Removes the icon.
      *
-     * @param rec the {@link IconRecord}
+     * @param record the {@link IconRecord}
      * @param source the source of the remove
      * @return true, if removed
      */
-    boolean removeIcon(IconRecord rec, Object source);
+    boolean removeIcon(IconRecord record, Object source);
 
     /**
      * Removes the icon.
@@ -229,9 +229,9 @@ public interface IconRegistry
      * Deletes the icon file from the machine.
      *
      * @param iconToDelete the IconRecord to delete.
-     * @param thePanelModel used for registry.
+     * @param panelModel used for registry.
      */
-    void deleteIcon(IconRecord iconToDelete, PanelModel thePanelModel);
+    void deleteIcon(IconRecord iconToDelete, PanelModel panelModel);
 
     /**
      * Removes the listener.
@@ -248,43 +248,43 @@ public interface IconRegistry
      * Note: Does not check to see if the {@link IconRecord} is part of the
      * registry.
      *
-     * @param deId the de id
-     * @param rec the {@link IconRecord} to link with the data element id, or de
-     *            assign if null.
+     * @param elementId the element id
+     * @param record the {@link IconRecord} to link with the data element id, or
+     *            data element assign if null.
      * @param source the source initiating the change
      */
-    void setIconForElement(long deId, IconRecord rec, Object source);
+    void setIconForElement(long elementId, IconRecord record, Object source);
 
     /**
      * Sets the icon for element.
      *
      * Note: Does not check to see if the iconId is valid for the registry.
      *
-     * @param deId the de id
+     * @param elementId the element id
      * @param iconId the icon id
      * @param source the source initiating the change
      */
-    void setIconForElement(long deId, int iconId, Object source);
+    void setIconForElement(long elementId, int iconId, Object source);
 
     /**
      * Sets the icon for elements by id.
      *
-     * @param deIds the de ids
-     * @param rec the {@link IconRecord}
+     * @param elementIds the element ids
+     * @param record the {@link IconRecord}
      * @param source the source
      */
-    void setIconForElements(List<Long> deIds, IconRecord rec, Object source);
+    void setIconForElements(List<Long> elementIds, IconRecord record, Object source);
 
     /**
      * Sets the icon for elements.
      *
      * Note: Does not check to see if the iconId is valid for the registry.
      *
-     * @param deIds the de ids
+     * @param elementIds the element ids
      * @param iconId the icon id
      * @param source the source initiating the change
      */
-    void setIconForElements(List<Long> deIds, int iconId, Object source);
+    void setIconForElements(List<Long> elementIds, int iconId, Object source);
 
     /**
      * Sets up the preferences to be used when using the program. Are reset on

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/gui/IconTreeBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/gui/IconTreeBuilder.java
@@ -46,36 +46,36 @@ public class IconTreeBuilder
         List<IconRecord> records = myIconRegistry.getIconRecords(filter);
         Collections.sort(records, (r1, r2) -> AlphanumComparator.compareNatural(r1.getImageURL().toString(), r2.getImageURL().toString()));
         Set<String> collectionSet = New.set();
-        Map<String, Map<String, List<IconRecord>>> collectionToSubCatIconRecMap = New.map();
-        String defaultSubCat = "DEFAULT";
-        for (IconRecord rec : records)
+        Map<String, Map<String, List<IconRecord>>> iconRecordMapCollection = New.map();
+        String defaultSubCategory = "DEFAULT";
+        for (IconRecord record : records)
         {
-            String collection = rec.getCollectionName() == null ? IconRecord.DEFAULT_COLLECTION : rec.getCollectionName();
-            if (collection == null)
+            String collectionName = record.getCollectionName() == null ? IconRecord.DEFAULT_COLLECTION : record.getCollectionName();
+            if (collectionName == null)
             {
-                collection = IconRecord.DEFAULT_COLLECTION;
+                collectionName = IconRecord.DEFAULT_COLLECTION;
             }
 
-            collectionSet.add(collection);
-            String subCat = rec.getSubCategory() == null ? defaultSubCat : rec.getSubCategory();
+            collectionSet.add(collectionName);
+            String subCategory = record.getSubCategory() == null ? defaultSubCategory : record.getSubCategory();
 
-            Map<String, List<IconRecord>> subCatToRecListMap = collectionToSubCatIconRecMap.get(collection);
-            if (subCatToRecListMap == null)
+            Map<String, List<IconRecord>> iconRecordMap = iconRecordMapCollection.get(collectionName);
+            if (iconRecordMap == null)
             {
-                subCatToRecListMap = New.map();
-                collectionToSubCatIconRecMap.put(collection, subCatToRecListMap);
+                iconRecordMap = New.map();
+                iconRecordMapCollection.put(collectionName, iconRecordMap);
             }
 
-            List<IconRecord> recList = subCatToRecListMap.get(subCat);
-            if (recList == null)
+            List<IconRecord> recordList = iconRecordMap.get(subCategory);
+            if (recordList == null)
             {
-                recList = New.linkedList();
-                subCatToRecListMap.put(subCat, recList);
+                recordList = New.linkedList();
+                iconRecordMap.put(subCategory, recordList);
             }
-            recList.add(rec);
+            recordList.add(record);
         }
 
-        buildTreeFromMaps(rootNode, collectionSet, collectionToSubCatIconRecMap, defaultSubCat);
+        buildTreeFromMaps(rootNode, collectionSet, iconRecordMapCollection, defaultSubCategory);
 
         return rootNode;
     }
@@ -85,12 +85,12 @@ public class IconTreeBuilder
      *
      * @param rootNode the root node
      * @param collectionSet the collection set
-     * @param collectionToSubCatIconRecMap the collection to sub cat icon rec
+     * @param iconRecordMapCollection the collection to sub cat icon rec
      *            map
-     * @param defaultSubCat the default sub cat
+     * @param defaultSubCategory the default sub cat
      */
     private void buildTreeFromMaps(DefaultMutableTreeNode rootNode, Set<String> collectionSet,
-            Map<String, Map<String, List<IconRecord>>> collectionToSubCatIconRecMap, String defaultSubCat)
+            Map<String, Map<String, List<IconRecord>>> iconRecordMapCollection, String defaultSubCategory)
     {
         List<String> collectionList = New.list(collectionSet);
         Collections.sort(collectionList);
@@ -107,31 +107,31 @@ public class IconTreeBuilder
 
         for (String collection : collectionList)
         {
-            DefaultMutableTreeNode colNode = new DefaultMutableTreeNode();
-            Map<String, List<IconRecord>> subToRecListMap = collectionToSubCatIconRecMap.get(collection);
-            if (subToRecListMap != null)
+            DefaultMutableTreeNode collectionNode = new DefaultMutableTreeNode();
+            Map<String, List<IconRecord>> iconRecordMap = iconRecordMapCollection.get(collection);
+            if (iconRecordMap != null)
             {
-                rootNode.add(colNode);
-                List<String> subCatList = New.list(subToRecListMap.keySet());
-                Collections.sort(subCatList);
-                if (subCatList.remove(defaultSubCat))
+                rootNode.add(collectionNode);
+                List<String> subCategoryList = New.list(iconRecordMap.keySet());
+                Collections.sort(subCategoryList);
+                if (subCategoryList.remove(defaultSubCategory))
                 {
-                    List<IconRecord> defaultRecList = subToRecListMap.get(defaultSubCat);
-                    colNode.setUserObject(DefaultIconRecordTreeNodeUserObject.createLeafNode(colNode, collection, defaultRecList,
+                    List<IconRecord> defaultRecList = iconRecordMap.get(defaultSubCategory);
+                    collectionNode.setUserObject(DefaultIconRecordTreeNodeUserObject.createLeafNode(collectionNode, collection, defaultRecList,
                             IconRecordTreeNodeUserObject.NameType.COLLECTION));
                 }
                 else
                 {
-                    colNode.setUserObject(DefaultIconRecordTreeNodeUserObject.createFolderNode(colNode, collection,
+                    collectionNode.setUserObject(DefaultIconRecordTreeNodeUserObject.createFolderNode(collectionNode, collection,
                             IconRecordTreeNodeUserObject.NameType.COLLECTION));
                 }
 
-                for (String subCat : subCatList)
+                for (String subCategory : subCategoryList)
                 {
                     DefaultMutableTreeNode subNode = new DefaultMutableTreeNode();
-                    subNode.setUserObject(DefaultIconRecordTreeNodeUserObject.createLeafNode(subNode, subCat,
-                            subToRecListMap.get(subCat), IconRecordTreeNodeUserObject.NameType.SUBCATEGORY));
-                    colNode.add(subNode);
+                    subNode.setUserObject(DefaultIconRecordTreeNodeUserObject.createLeafNode(subNode, subCategory,
+                            iconRecordMap.get(subCategory), IconRecordTreeNodeUserObject.NameType.SUBCATEGORY));
+                    collectionNode.add(subNode);
                 }
             }
         }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/gui/IconTreeBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/gui/IconTreeBuilder.java
@@ -51,27 +51,10 @@ public class IconTreeBuilder
         for (IconRecord record : records)
         {
             String collectionName = record.getCollectionName() == null ? IconRecord.DEFAULT_COLLECTION : record.getCollectionName();
-            if (collectionName == null)
-            {
-                collectionName = IconRecord.DEFAULT_COLLECTION;
-            }
-
             collectionSet.add(collectionName);
             String subCategory = record.getSubCategory() == null ? defaultSubCategory : record.getSubCategory();
-
-            Map<String, List<IconRecord>> iconRecordMap = iconRecordMapCollection.get(collectionName);
-            if (iconRecordMap == null)
-            {
-                iconRecordMap = New.map();
-                iconRecordMapCollection.put(collectionName, iconRecordMap);
-            }
-
-            List<IconRecord> recordList = iconRecordMap.get(subCategory);
-            if (recordList == null)
-            {
-                recordList = New.linkedList();
-                iconRecordMap.put(subCategory, recordList);
-            }
+            Map<String, List<IconRecord>> iconRecordMap = iconRecordMapCollection.computeIfAbsent(collectionName, k -> New.map());
+            List<IconRecord> recordList = iconRecordMap.computeIfAbsent(subCategory, k -> New.linkedList());
             recordList.add(record);
         }
 

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/ButtonBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/ButtonBuilder.java
@@ -8,9 +8,6 @@ import javafx.scene.layout.AnchorPane;
 /** Creates customized buttons for the icon manager. */
 public class ButtonBuilder extends Button
 {
-    /** The button label. */
-    private final String myLabel;
-
     /**
      * Creates a new button with the supplied parameters.
      *
@@ -20,8 +17,7 @@ public class ButtonBuilder extends Button
     public ButtonBuilder(String label, boolean useIcon)
     {
         super();
-        myLabel = label;
-        setText(myLabel);
+        setText(label);
         setTextOverrun(javafx.scene.control.OverrunStyle.CLIP);
 
         if (useIcon)

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/IconPopupMenuImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/IconPopupMenuImpl.java
@@ -93,12 +93,12 @@ public class IconPopupMenuImpl
         }
         else if (recordSet.size() > 1)
         {
-            for (IconRecord rec : recordSet)
+            for (IconRecord record : recordSet)
             {
-                myPanelModel.getIconRegistry().removeIcon(rec, this);
+                myPanelModel.getIconRegistry().removeIcon(record, this);
                 if (doDelete)
                 {
-                    myPanelModel.getIconRegistry().deleteIcon(rec, myPanelModel);
+                    myPanelModel.getIconRegistry().deleteIcon(record, myPanelModel);
                 }
             }
         }
@@ -116,10 +116,10 @@ public class IconPopupMenuImpl
     /** Un-Selects the Icons visually and in the registry. */
     public void unSelectIcons()
     {
-        for (Button recordindex : myPanelModel.getSelectedIcons().values())
+        for (Button recordButton : myPanelModel.getSelectedIcons().values())
         {
-            int idx = myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().indexOf(recordindex);
-            myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().get(idx).setStyle("");
+            int recordIndex = myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().indexOf(recordButton);
+            myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().get(recordIndex).setStyle("");
         }
         myPanelModel.getSelectedIcons().clear();
     }
@@ -127,10 +127,10 @@ public class IconPopupMenuImpl
     /** Un-Selects the Icons visually and in the registry. */
     public void unSelectIcon()
     {
-        for (Button recordindex : myPanelModel.getSelectedIconMap().values())
+        for (Button recordButton : myPanelModel.getSelectedIconMap().values())
         {
-            int idx = myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().indexOf(recordindex);
-            myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().get(idx).setStyle("");
+            int recordIndex = myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().indexOf(recordButton);
+            myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().get(recordIndex).setStyle("");
         }
         myPanelModel.getSelectedIconMap().clear();
     }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/IconPopupMenuImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/IconPopupMenuImpl.java
@@ -118,6 +118,7 @@ public class IconPopupMenuImpl
         myPanelModel.getAllSelectedIcons().values().stream().filter(b -> myPanelModel.getViewModel().getMainPanel().getIconGrid()
                 .getChildren().contains(b)).forEach(b -> b.setStyle(""));
         myPanelModel.getAllSelectedIcons().clear();
+        myPanelModel.getSingleSelectedIcon().clear();
     }
 
     /** Un-Selects the single, primary Icon visually and in the registry. */

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/IconPopupMenuImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/IconPopupMenuImpl.java
@@ -124,7 +124,8 @@ public class IconPopupMenuImpl
     /** Un-Selects the single, primary Icon visually and in the registry. */
     public void unSelectSingleIcon()
     {
-        myPanelModel.getSingleSelectedIcon().forEach((i, b) -> {
+        myPanelModel.getSingleSelectedIcon().forEach((i, b) ->
+        {
             myPanelModel.getAllSelectedIcons().remove(i);            
             b.setStyle("");
         });

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/IconPopupMenuImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/IconPopupMenuImpl.java
@@ -10,7 +10,6 @@ import io.opensphere.mantle.icon.IconRecord;
 import io.opensphere.mantle.icon.impl.DefaultIconProvider;
 import io.opensphere.mantle.iconproject.model.PanelModel;
 import io.opensphere.mantle.iconproject.view.IconCustomizerDialog;
-import javafx.scene.control.Button;
 
 /**
  * The Class IconPopupMenuImpl.
@@ -39,7 +38,7 @@ public class IconPopupMenuImpl
      */
     public void addToFav()
     {
-        Set<IconRecord> recordSet = myPanelModel.getSelectedIcons().keySet();
+        Set<IconRecord> recordSet = myPanelModel.getAllSelectedIcons().keySet();
         if (recordSet.isEmpty() && mySelectedIcon == null)
         {
             JOptionPane.showMessageDialog(myPanelModel.getOwner(),
@@ -83,7 +82,7 @@ public class IconPopupMenuImpl
      */
     public void delete(boolean doDelete)
     {
-        Set<IconRecord> recordSet = myPanelModel.getSelectedIcons().keySet();
+        Set<IconRecord> recordSet = myPanelModel.getAllSelectedIcons().keySet();
 
         if (recordSet.isEmpty() && myPanelModel.getSelectedRecord().get() == null)
         {
@@ -113,25 +112,21 @@ public class IconPopupMenuImpl
         myPanelModel.getViewModel().getMainPanel().refresh();
     }
 
-    /** Un-Selects the Icons visually and in the registry. */
-    public void unSelectIcons()
+    /** Un-Selects all selected Icons visually and in the registry. */
+    public void unSelectAllIcons()
     {
-        for (Button recordButton : myPanelModel.getSelectedIcons().values())
-        {
-            int recordIndex = myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().indexOf(recordButton);
-            myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().get(recordIndex).setStyle("");
-        }
-        myPanelModel.getSelectedIcons().clear();
+        myPanelModel.getAllSelectedIcons().values().stream().filter(b -> myPanelModel.getViewModel().getMainPanel().getIconGrid()
+                .getChildren().contains(b)).forEach(b -> b.setStyle(""));
+        myPanelModel.getAllSelectedIcons().clear();
     }
 
-    /** Un-Selects the Icons visually and in the registry. */
-    public void unSelectIcon()
+    /** Un-Selects the single, primary Icon visually and in the registry. */
+    public void unSelectSingleIcon()
     {
-        for (Button recordButton : myPanelModel.getSelectedIconMap().values())
-        {
-            int recordIndex = myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().indexOf(recordButton);
-            myPanelModel.getViewModel().getMainPanel().getIconGrid().getChildren().get(recordIndex).setStyle("");
-        }
-        myPanelModel.getSelectedIconMap().clear();
+        myPanelModel.getSingleSelectedIcon().forEach((i, b) -> {
+            myPanelModel.getAllSelectedIcons().remove(i);            
+            b.setStyle("");
+        });
+        myPanelModel.getSingleSelectedIcon().clear();
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/LabelMaker.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/LabelMaker.java
@@ -9,11 +9,11 @@ public class LabelMaker extends Text
     /**
      * Creates a custom label with white text.
      *
-     * @param theText the Text to edit.
+     * @param text the Text to edit.
      */
-    public LabelMaker(String theText)
+    public LabelMaker(String text)
     {
-        setText(theText);
+        setText(text);
         setFill(Color.WHITE);
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/TreePopupMenuImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/impl/TreePopupMenuImpl.java
@@ -15,11 +15,11 @@ public class TreePopupMenuImpl
     /**
      * The constructor for IconPopupMenuImpl.
      *
-     * @param thePanelModel the model used to get registry items.
+     * @param panelModel the model used to get registry items.
      */
-    public TreePopupMenuImpl(PanelModel thePanelModel)
+    public TreePopupMenuImpl(PanelModel panelModel)
     {
-        myPanelModel = thePanelModel;
+        myPanelModel = panelModel;
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/IconManagerPrefs.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/IconManagerPrefs.java
@@ -27,10 +27,10 @@ import javafx.scene.control.TreeItem;
 public class IconManagerPrefs
 {
     /** The value used for the tilewidth. */
-    private final IntegerProperty myInitTileWidth = new SimpleIntegerProperty();
+    private final IntegerProperty myInitialTileWidth = new SimpleIntegerProperty();
 
     /** The tree which will be selected on start up. */
-    private final ObjectProperty<TreeItem<String>> myInitTreeSelection = new SimpleObjectProperty<>(
+    private final ObjectProperty<TreeItem<String>> myInitialTreeSelection = new SimpleObjectProperty<>(
             new TreeItem<>("temp"));
 
     /**
@@ -40,15 +40,15 @@ public class IconManagerPrefs
      */
     public IntegerProperty getIconWidth()
     {
-        return myInitTileWidth;
+        return myInitialTileWidth;
     }
     /**
-     * Gets the value of the {@link #myInitTreeSelection} field.
+     * Gets the value of the {@link #myInitialTreeSelection} field.
      *
-     * @return the value stored in the {@link #myInitTreeSelection} field.
+     * @return the value stored in the {@link #myInitialTreeSelection} field.
      */
-    public ObjectProperty<TreeItem<String>> getInitTreeSelection()
+    public ObjectProperty<TreeItem<String>> getTreeSelection()
     {
-        return myInitTreeSelection;
+        return myInitialTreeSelection;
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/IconManagerPrefs.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/IconManagerPrefs.java
@@ -15,9 +15,7 @@
 package io.opensphere.mantle.iconproject.model;
 
 import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleIntegerProperty;
-import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.TreeItem;
 
 /**
@@ -26,29 +24,29 @@ import javafx.scene.control.TreeItem;
  */
 public class IconManagerPrefs
 {
-    /** The value used for the tilewidth. */
-    private final IntegerProperty myInitialTileWidth = new SimpleIntegerProperty();
+    /** The value used for the icon width. */
+    private final IntegerProperty myIconWidth = new SimpleIntegerProperty();
 
     /** The tree which will be selected on start up. */
-    private final ObjectProperty<TreeItem<String>> myInitialTreeSelection = new SimpleObjectProperty<>(
-            new TreeItem<>("temp"));
+    private TreeItem<String> myTreeSelection = new TreeItem<>("temp");
 
     /**
-     * Gets the tilewidth for display icons in the Icon Manager.
+     * Gets the icon width for display icons in the Icon Manager.
      *
-     * @return the set value.
+     * @return the icon width.
      */
     public IntegerProperty getIconWidth()
     {
-        return myInitialTileWidth;
+        return myIconWidth;
     }
-    /**
-     * Gets the value of the {@link #myInitialTreeSelection} field.
-     *
-     * @return the value stored in the {@link #myInitialTreeSelection} field.
-     */
-    public ObjectProperty<TreeItem<String>> getTreeSelection()
+
+    public TreeItem<String> getTreeSelection()
     {
-        return myInitialTreeSelection;
+        return myTreeSelection;
+    }
+
+    public void setTreeSelection(TreeItem<String> selection)
+    {
+        myTreeSelection = selection;
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/ImportProp.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/ImportProp.java
@@ -47,9 +47,9 @@ public class ImportProp
      *
      * @param the List containing the sub collection names
      */
-    public void setSubCollectionList(Set<String> theSubCollectionList)
+    public void setSubCollectionList(Set<String> subCollectionList)
     {
-        mySubCollectionList = theSubCollectionList;
+        mySubCollectionList = subCollectionList;
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/PanelModel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/PanelModel.java
@@ -52,7 +52,7 @@ public class PanelModel
     private ViewModel myViewModel;
 
     /** The icons currently selected. */
-    private HashMap<IconRecord, Button> mySelectedIcons = new HashMap<>();
+    private HashMap<IconRecord, Button> myAllSelectedIcons = new HashMap<>();
 
     /** The Tree model. */
     private DefaultIconRecordTreeItemObject myTreeObject;
@@ -229,24 +229,24 @@ public class PanelModel
     }
 
     /**
-     * Gets the value of the {@link #mySelectedIcons} field.
+     * Gets the value of the {@link #myAllSelectedIcons} field.
      *
-     * @return the value stored in the {@link #mySelectedIcons} field.
+     * @return the value stored in the {@link #myAllSelectedIcons} field.
      */
-    public HashMap<IconRecord, Button> getSelectedIcons()
+    public HashMap<IconRecord, Button> getAllSelectedIcons()
     {
-        return mySelectedIcons;
+        return myAllSelectedIcons;
     }
 
     /**
-     * Sets the value of the {@link #mySelectedIcons} field.
+     * Sets the value of the {@link #myAllSelectedIcons} field.
      *
      * @param selectedIcons the value to store in the
-     *            {@link #mySelectedIcons} field.
+     *            {@link #myAllSelectedIcons} field.
      */
     public void setSelectedIcons(HashMap<IconRecord, Button> selectedIcons)
     {
-        mySelectedIcons = selectedIcons;
+        myAllSelectedIcons = selectedIcons;
     }
 
     /**
@@ -280,12 +280,11 @@ public class PanelModel
     }
 
     /**
-     * Gets the selected icon map.
+     * Gets the single, primary selected button.
      *
-     * @return a map containing an icon record and it's corresponding
-     *         button in the display.
+     * @return the selected button
      */
-    public HashMap<IconRecord, Button> getSelectedIconMap()
+    public HashMap<IconRecord, Button> getSingleSelectedIcon()
     {
         return mySingleSelectedIcon;
     }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/PanelModel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/model/PanelModel.java
@@ -22,13 +22,13 @@ public class PanelModel
     private final ObjectProperty<ViewStyle> myViewStyle = new SimpleObjectProperty<>(this, "viewtype", ViewStyle.GRID);
 
     /** The selected icon to be used for customization dialogs. */
-    private ObjectProperty<IconRecord> mySelectedRecord = new SimpleObjectProperty<>();
+    private final ObjectProperty<IconRecord> mySelectedRecord = new SimpleObjectProperty<>();
 
     /** The registry of icons. */
     private IconRegistry myIconRegistry;
 
     /** The toolbox. */
-    private Toolbox myToolbox;
+    private final Toolbox myToolbox;
 
     /** The owner of this window. */
     private Window myOwner;
@@ -46,13 +46,13 @@ public class PanelModel
     private List<IconRecord> myIconRecordList;
 
     /** The filtered icon record list. */
-    private List<IconRecord> myFilteredIconRecordList;
+    private final List<IconRecord> myFilteredIconRecordList;
 
     /** The model for the panels contained in the UI. */
     private ViewModel myViewModel;
 
     /** The icons currently selected. */
-    private HashMap<IconRecord, Button> myAllSelectedIcons = new HashMap<>();
+    private final HashMap<IconRecord, Button> myAllSelectedIcons = new HashMap<>();
 
     /** The Tree model. */
     private DefaultIconRecordTreeItemObject myTreeObject;
@@ -61,7 +61,7 @@ public class PanelModel
      * Used to keep track of which icon and button are selected on the grid for
      * single selection purposes.
      */
-    private HashMap<IconRecord, Button> mySingleSelectedIcon = new HashMap<>();
+    private final HashMap<IconRecord, Button> mySingleSelectedIcon = new HashMap<>();
 
     /** Whether to use the filtered icon record list or the regular one. */ 
     private boolean myUseFilteredList;
@@ -199,16 +199,6 @@ public class PanelModel
     }
 
     /**
-     * Sets the filtered icon record list.
-     *
-     * @param list the filtered icon record list
-     */
-    public void setFilteredRecordList(List<IconRecord> list)
-    {
-        myFilteredIconRecordList = list;
-    }
-
-    /**
      * Gets the value of the {@link #myViewModel} field.
      *
      * @return the value stored in the {@link #myViewModel} field.
@@ -236,17 +226,6 @@ public class PanelModel
     public HashMap<IconRecord, Button> getAllSelectedIcons()
     {
         return myAllSelectedIcons;
-    }
-
-    /**
-     * Sets the value of the {@link #myAllSelectedIcons} field.
-     *
-     * @param selectedIcons the value to store in the
-     *            {@link #myAllSelectedIcons} field.
-     */
-    public void setSelectedIcons(HashMap<IconRecord, Button> selectedIcons)
-    {
-        myAllSelectedIcons = selectedIcons;
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/AddIconPane.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/AddIconPane.java
@@ -10,10 +10,10 @@ import javafx.scene.layout.BorderPane;
 public class AddIconPane extends BorderPane
 {
     /** The pane containing controls for the collection name choice. */
-    private CollectNamesPane myCollectionNamePane;
+    private final CollectNamesPane myCollectionNamePane;
 
     /** The pane containing controls for the sub collection name choice. */
-    private SubCollectPane mySubCollectPane;
+    private final SubCollectPane mySubCollectPane;
 
     /**
      * Instantiates the panel for getting the category and sub category from the

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/AddIconPane.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/AddIconPane.java
@@ -9,9 +9,6 @@ import javafx.scene.layout.BorderPane;
  */
 public class AddIconPane extends BorderPane
 {
-    /** The current model for UI elements. */
-    private PanelModel myPanelModel;
-
     /** The pane containing controls for the collection name choice. */
     private CollectNamesPane myCollectionNamePane;
 
@@ -26,23 +23,11 @@ public class AddIconPane extends BorderPane
      */
     public AddIconPane(PanelModel panelModel)
     {
-        myPanelModel = panelModel;
+        myCollectionNamePane = new CollectNamesPane(panelModel);
+        mySubCollectPane = new SubCollectPane(panelModel);
 
-        setCollectionNamePane(new CollectNamesPane(myPanelModel));
-        setSubCollectPane(new SubCollectPane(myPanelModel));
-
-        setTop(getCollectionNamePane());
-        setCenter(getSubCollectPane());
-    }
-
-    /**
-     * Sets the current collection name pane.
-     *
-     * @param collectionNamePane the collection name input pane.
-     */
-    public void setCollectionNamePane(CollectNamesPane collectionNamePane)
-    {
-        myCollectionNamePane = collectionNamePane;
+        setTop(myCollectionNamePane);
+        setCenter(mySubCollectPane);
     }
 
     /**
@@ -53,16 +38,6 @@ public class AddIconPane extends BorderPane
     public CollectNamesPane getCollectionNamePane()
     {
         return myCollectionNamePane;
-    }
-
-    /**
-     * Sets the current sub collection pane.
-     *
-     * @param subCollectPane the sub collection name input pane.
-     */
-    private void setSubCollectPane(SubCollectPane subCollectPane)
-    {
-        mySubCollectPane = subCollectPane;
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/CollectNamesPane.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/CollectNamesPane.java
@@ -6,7 +6,6 @@ import java.util.Set;
 
 import io.opensphere.core.util.collections.New;
 import io.opensphere.mantle.icon.IconRecord;
-import io.opensphere.mantle.iconproject.model.ImportProp;
 import io.opensphere.mantle.iconproject.model.PanelModel;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -32,7 +31,7 @@ public class CollectNamesPane extends VBox
      * The Radio Button to indicate only existing collection names will appear
      * in the combobox.
      */
-    private RadioButton myExistingRB;
+    private RadioButton myExistingRadioButton;
 
     /**
      * The ComboBox to show the current collections names and take in user input
@@ -55,9 +54,6 @@ public class CollectNamesPane extends VBox
     /** The toggle group for the New and Existing radio buttons. */
     private ToggleGroup myToggleGroup = new ToggleGroup();
 
-    /** The model for the importation properties. */
-    private ImportProp myIconProps;
-
     /**
      * Creates the Collection Name selection controls and packages into a VBox.
      *
@@ -66,19 +62,18 @@ public class CollectNamesPane extends VBox
     public CollectNamesPane(PanelModel panelModel)
     {
         myPanelModel = panelModel;
-        myIconProps = myPanelModel.getImportProps();
         Set<String> collectionNameSet = myPanelModel.getIconRegistry().getCollectionNames();
 
         collectionNameSet.remove(IconRecord.DEFAULT_COLLECTION);
         collectionNameSet.remove(IconRecord.USER_ADDED_COLLECTION);
         collectionNameSet.remove(IconRecord.FAVORITES_COLLECTION);
-        List<String> colNames = New.list(collectionNameSet);
-        Collections.sort(colNames);
-        colNames.add(0, IconRecord.FAVORITES_COLLECTION);
-        colNames.add(0, IconRecord.USER_ADDED_COLLECTION);
-        colNames.add(0, IconRecord.DEFAULT_COLLECTION);
+        List<String> collectionNames = New.list(collectionNameSet);
+        Collections.sort(collectionNames);
+        collectionNames.add(0, IconRecord.FAVORITES_COLLECTION);
+        collectionNames.add(0, IconRecord.USER_ADDED_COLLECTION);
+        collectionNames.add(0, IconRecord.DEFAULT_COLLECTION);
 
-        myOptions = FXCollections.observableArrayList(colNames);
+        myOptions = FXCollections.observableArrayList(collectionNames);
 
         HBox bottomPane = new HBox();
 
@@ -86,15 +81,15 @@ public class CollectNamesPane extends VBox
         collectionMessage.setFont(Font.font(collectionMessage.getFont().getFamily(), FontPosture.ITALIC, 11));
         collectionMessage.setContentDisplay(ContentDisplay.BOTTOM);
 
-        myExistingRB = new RadioButton("Existing");
-        myExistingRB.setSelected(true);
-        myExistingRB.setOnMouseClicked(event -> lockfeature(false));
+        myExistingRadioButton = new RadioButton("Existing");
+        myExistingRadioButton.setSelected(true);
+        myExistingRadioButton.setOnMouseClicked(event -> lockfeature(false));
 
         myExistingComboBox = new ComboBox<>(myOptions);
         myExistingComboBox.getSelectionModel().selectFirst();
         myExistingComboBox.setOnAction((event) ->
         {
-            myIconProps.getCollectionName().set(myExistingComboBox.getValue());
+        	myPanelModel.getImportProps().getCollectionName().set(myExistingComboBox.getValue());
             if (!myOptions.contains(myExistingComboBox.getValue()))
             {
                 myOptions.add(myExistingComboBox.getValue());
@@ -109,9 +104,9 @@ public class CollectNamesPane extends VBox
         bottomPane.setSpacing(5);
         bottomPane.setAlignment(Pos.BASELINE_LEFT);
 
-        myExistingRB.setToggleGroup(myToggleGroup);
+        myExistingRadioButton.setToggleGroup(myToggleGroup);
         myNewCollectionButton.setToggleGroup(myToggleGroup);
-        bottomPane.getChildren().addAll(myExistingRB, myNewCollectionButton, myExistingComboBox);
+        bottomPane.getChildren().addAll(myExistingRadioButton, myNewCollectionButton, myExistingComboBox);
         bottomPane.setSpacing(5);
 
         getChildren().addAll(collectionMessage, bottomPane);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/CollectNamesPane.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/CollectNamesPane.java
@@ -37,22 +37,22 @@ public class CollectNamesPane extends VBox
      * The ComboBox to show the current collections names and take in user input
      * for new collection names.
      */
-    private ComboBox<String> myExistingComboBox;
+    private final ComboBox<String> myExistingComboBox;
 
     /** The existing collection name choices. */
-    private ObservableList<String> myOptions;
+    private final ObservableList<String> myOptions;
 
     /** The Radio Button to enable the user to enter a new collection name. */
-    private RadioButton myNewCollectionButton;
+    private final RadioButton myNewCollectionButton;
 
     /** The text for the new Radio Button. */
-    private TextField myNewCollectionTextField;
+    private final TextField myNewCollectionTextField;
 
     /** The model for the UI. */
-    private PanelModel myPanelModel;
+    private final PanelModel myPanelModel;
 
     /** The toggle group for the New and Existing radio buttons. */
-    private ToggleGroup myToggleGroup = new ToggleGroup();
+    private final ToggleGroup myToggleGroup = new ToggleGroup();
 
     /**
      * Creates the Collection Name selection controls and packages into a VBox.

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/CollectNamesPane.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/CollectNamesPane.java
@@ -31,7 +31,7 @@ public class CollectNamesPane extends VBox
      * The Radio Button to indicate only existing collection names will appear
      * in the combobox.
      */
-    private RadioButton myExistingRadioButton;
+    private final RadioButton myExistingRadioButton;
 
     /**
      * The ComboBox to show the current collections names and take in user input

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/CollectNamesPane.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/CollectNamesPane.java
@@ -89,7 +89,7 @@ public class CollectNamesPane extends VBox
         myExistingComboBox.getSelectionModel().selectFirst();
         myExistingComboBox.setOnAction((event) ->
         {
-        	myPanelModel.getImportProps().getCollectionName().set(myExistingComboBox.getValue());
+            myPanelModel.getImportProps().getCollectionName().set(myExistingComboBox.getValue());
             if (!myOptions.contains(myExistingComboBox.getValue()))
             {
                 myOptions.add(myExistingComboBox.getValue());

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
@@ -85,11 +85,11 @@ public class GridBuilder extends TilePane
             if (myPanelModel.getViewModel().getMultiSelectEnabled())
             {
                 iconButton.setStyle("-fx-effect: dropshadow(three-pass-box, purple, 20, 0, 0, 0);");
-                myPanelModel.getSelectedIcons().put(record, iconButton);
+                myPanelModel.getAllSelectedIcons().put(record, iconButton);
             }
             myPanelModel.getSelectedRecord().set(record);
-            myPanelModel.getSelectedIconMap().clear();
-            myPanelModel.getSelectedIconMap().put(record, iconButton);
+            myPanelModel.getSingleSelectedIcon().clear();
+            myPanelModel.getSingleSelectedIcon().put(record, iconButton);
         });
         return iconButton;
     }
@@ -120,11 +120,11 @@ public class GridBuilder extends TilePane
             if (myPanelModel.getViewModel().getMultiSelectEnabled())
             {
                 iconButton.setStyle("-fx-effect: dropshadow(three-pass-box, purple, 20, 0, 0, 0);");
-                myPanelModel.getSelectedIcons().put(record, iconButton);
+                myPanelModel.getAllSelectedIcons().put(record, iconButton);
             }
             myPanelModel.getSelectedRecord().set(record);
-            myPanelModel.getSelectedIconMap().clear();
-            myPanelModel.getSelectedIconMap().put(record, iconButton);
+            myPanelModel.getSingleSelectedIcon().clear();
+            myPanelModel.getSingleSelectedIcon().put(record, iconButton);
         });
         return iconButton;
     }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
@@ -54,7 +54,7 @@ public class GridBuilder extends TilePane
      * @param record the IconRecord
      * @return the button of the icon
      */
-    private Button buttonBuilder(IconRecord record)
+    private Button buttonBuilderGridStyle(IconRecord record)
     {
         Button iconButton = new Button();
         iconButton.setMinSize(myTileWidth, myTileWidth);
@@ -155,7 +155,7 @@ public class GridBuilder extends TilePane
             Button iconButton;
             if (myPanelModel.getViewStyle().get() == ViewStyle.GRID)
             {
-                iconButton = buttonBuilder(recordindex);
+                iconButton = buttonBuilderGridStyle(recordindex);
             }
             else
             {

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
@@ -61,11 +61,12 @@ public class GridBuilder extends TilePane
         iconButton.setMaxSize(myTileWidth, myTileWidth);
         String text = record.getName();
         iconButton.setPadding(new Insets(5, 5, 5, 5));
-        iconButton.setTooltip(new Tooltip(record.getId() + record.getImageURL().toString()));
+        iconButton.setTooltip(new Tooltip("Icon #" + record.getId() + ": " + record.getImageURL().toString()));
 
         iconButton.setText(text);
         iconButton.setContentDisplay(ContentDisplay.TOP);
         iconButton.setAlignment(Pos.BOTTOM_CENTER);
+        iconButton.setMnemonicParsing(false);
 
         ImageView iconView = new ImageView(record.getImageURL().toString());
         if (iconView.getImage().getWidth() + 20 > myTileWidth)
@@ -74,6 +75,7 @@ public class GridBuilder extends TilePane
             iconView.setFitWidth(myTileWidth - 40);
         }
         iconButton.setGraphic(iconView);
+        iconButton.setContextMenu(new IconPopupMenu(myPanelModel));
         iconButton.addEventHandler(MouseEvent.MOUSE_CLICKED, e ->
         {
             if (e.getButton() == MouseButton.SECONDARY)
@@ -106,7 +108,9 @@ public class GridBuilder extends TilePane
         iconButton.setPadding(new Insets(5, 5, 5, 5));
         iconButton.setText(record.getName());
         iconButton.setAlignment(Pos.CENTER);
-        iconButton.setTooltip(new Tooltip(record.getId() + record.getImageURL().toString()));
+        iconButton.setMnemonicParsing(false);
+        iconButton.setTooltip(new Tooltip("Icon #" + record.getId() + ": " + record.getImageURL().toString()));
+        iconButton.setContextMenu(new IconPopupMenu(myPanelModel));
         iconButton.addEventHandler(MouseEvent.MOUSE_CLICKED, e ->
         {
             if (e.getButton() == MouseButton.SECONDARY)

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
@@ -136,7 +136,7 @@ public class GridBuilder extends TilePane
      */
     public void showIconCustomizer(Window owner)
     {
-        if (myPanelModel.getSelectedRecord().get() != null)
+        if (!myPanelModel.getSingleSelectedIcon().isEmpty())
         {
             IconCustomizerDialog builderPane = new IconCustomizerDialog(owner, myPanelModel);
             builderPane.setVisible(true);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/GridBuilder.java
@@ -107,24 +107,20 @@ public class GridBuilder extends TilePane
         iconButton.setText(record.getName());
         iconButton.setAlignment(Pos.CENTER);
         iconButton.setTooltip(new Tooltip(record.getId() + record.getImageURL().toString()));
-        iconButton.addEventHandler(MouseEvent.MOUSE_CLICKED, new EventHandler<MouseEvent>()
+        iconButton.addEventHandler(MouseEvent.MOUSE_CLICKED, e ->
         {
-            @Override
-            public void handle(MouseEvent e)
+            if (e.getButton() == MouseButton.SECONDARY)
             {
-                if (e.getButton() == MouseButton.SECONDARY)
-                {
-                    iconButton.setContextMenu(new IconPopupMenu(myPanelModel));
-                }
-                if (myPanelModel.getViewModel().getMultiSelectEnabled())
-                {
-                    iconButton.setStyle("-fx-effect: dropshadow(three-pass-box, purple, 20, 0, 0, 0);");
-                    myPanelModel.getSelectedIcons().put(record, iconButton);
-                }
-                myPanelModel.getSelectedRecord().set(record);
-                myPanelModel.getSelectedIconMap().clear();
-                myPanelModel.getSelectedIconMap().put(record, iconButton);
+                iconButton.setContextMenu(new IconPopupMenu(myPanelModel));
             }
+            if (myPanelModel.getViewModel().getMultiSelectEnabled())
+            {
+                iconButton.setStyle("-fx-effect: dropshadow(three-pass-box, purple, 20, 0, 0, 0);");
+                myPanelModel.getSelectedIcons().put(record, iconButton);
+            }
+            myPanelModel.getSelectedRecord().set(record);
+            myPanelModel.getSelectedIconMap().clear();
+            myPanelModel.getSelectedIconMap().put(record, iconButton);
         });
         return iconButton;
     }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/IconCustomizerPane.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/IconCustomizerPane.java
@@ -158,7 +158,7 @@ public class IconCustomizerPane extends BorderPane
         rotationSlider.valueProperty().bindBidirectional(myRotation);
 
         Spinner<Number> rotationSpinner = new Spinner<>(-180., 180., 0.);
-        rotationSpinner.setPrefWidth(40.);
+        rotationSpinner.setPrefWidth(68.);
         rotationSpinner.getValueFactory().valueProperty().bindBidirectional(myRotation);
         rotationSpinner.setEditable(true);
         rotationSpinner.getStyleClass().clear();

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/MainPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/MainPanel.java
@@ -78,7 +78,7 @@ public class MainPanel extends SplitPane
         myOwner = myPanelModel.getOwner();
 
         myPanelModel.getCurrentTileWidth().addListener((o, v, m) -> refresh());
-        createTreeView(myPanelModel.getIconRegistry().getManagerPrefs().getTreeSelection().get());
+        createTreeView(myPanelModel.getIconRegistry().getManagerPrefs().getTreeSelection());
         myRecordMap = new HashMap<>(myTreeBuilder.getRecordMap());
         myPanelModel.setRecordList(myRecordMap.get("Default"));
         myIconGrid = new GridBuilder(myPanelModel);
@@ -184,7 +184,7 @@ public class MainPanel extends SplitPane
                     myTreeView.getSelectionModel().getSelectedItem().getValue();
             myPanelModel.setRecordList(myRecordMap.get(item));
             myScrollPane.setContent(myIconGrid = new GridBuilder(myPanelModel));
-            myPanelModel.getSelectedIcons().clear();
+            myPanelModel.getAllSelectedIcons().clear();
         });
     }
 
@@ -206,7 +206,7 @@ public class MainPanel extends SplitPane
         String collectionName = newValue.getValue();
         if (!myPanelModel.getRecordList().equals(myRecordMap.get(collectionName)))
         {
-            myPanelModel.getSelectedIcons().clear();
+            myPanelModel.getAllSelectedIcons().clear();
         }
         myPanelModel.setRecordList(myRecordMap.get(collectionName));
         myPanelModel.setUseFilteredList(false);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/MainPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/MainPanel.java
@@ -78,7 +78,7 @@ public class MainPanel extends SplitPane
         myOwner = myPanelModel.getOwner();
 
         myPanelModel.getCurrentTileWidth().addListener((o, v, m) -> refresh());
-        createTreeView(myPanelModel.getIconRegistry().getManagerPrefs().getInitTreeSelection().get());
+        createTreeView(myPanelModel.getIconRegistry().getManagerPrefs().getTreeSelection().get());
         myRecordMap = new HashMap<>(myTreeBuilder.getRecordMap());
         myPanelModel.setRecordList(myRecordMap.get("Default"));
         myIconGrid = new GridBuilder(myPanelModel);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/MainPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/MainPanel.java
@@ -185,6 +185,7 @@ public class MainPanel extends SplitPane
             myPanelModel.setRecordList(myRecordMap.get(item));
             myScrollPane.setContent(myIconGrid = new GridBuilder(myPanelModel));
             myPanelModel.getAllSelectedIcons().clear();
+            myPanelModel.getSingleSelectedIcon().clear();
         });
     }
 

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/MainPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/MainPanel.java
@@ -41,13 +41,13 @@ public class MainPanel extends SplitPane
     private GridBuilder myIconGrid;
 
     /** The Customize Icon button. */
-    private final ButtonBuilder myCustIconButton = new ButtonBuilder("Customize Icon", false);
+    private final ButtonBuilder myCustomizeIconButton = new ButtonBuilder("Customize Icon", false);
 
     /** The button to add the icon. */
     private final MenuButton myAddIconButton = new MenuButton("Add Icon From");
 
     /** The button to generate a new icon. */
-    private final ButtonBuilder myGenIconButton = new ButtonBuilder("Generate New Icon", false);
+    private final ButtonBuilder myGenerateIconButton = new ButtonBuilder("Generate New Icon", false);
 
     /** The tree view. */
     private TreeView<String> myTreeView;
@@ -96,13 +96,13 @@ public class MainPanel extends SplitPane
 
         folderOption.setOnAction(event -> EventQueue.invokeLater(() -> addIconsFromFolder()));
 
-        AnchorPane.setBottomAnchor(myCustIconButton, 26.0);
-        myCustIconButton.lockButton(myCustIconButton);
-        myCustIconButton.setOnAction(event -> EventQueue.invokeLater(() -> myIconGrid.showIconCustomizer(myOwner)));
+        AnchorPane.setBottomAnchor(myCustomizeIconButton, 26.0);
+        myCustomizeIconButton.lockButton(myCustomizeIconButton);
+        myCustomizeIconButton.setOnAction(event -> EventQueue.invokeLater(() -> myIconGrid.showIconCustomizer(myOwner)));
 
-        AnchorPane.setBottomAnchor(myGenIconButton, 0.0);
-        myGenIconButton.lockButton(myGenIconButton);
-        myGenIconButton.setOnAction(event -> EventQueue.invokeLater(() ->
+        AnchorPane.setBottomAnchor(myGenerateIconButton, 0.0);
+        myGenerateIconButton.lockButton(myGenerateIconButton);
+        myGenerateIconButton.setOnAction(event -> EventQueue.invokeLater(() ->
             {
                 IconProjGenDialog dialog = new IconProjGenDialog(myOwner, myPanelModel.getIconRegistry(), this);
                 dialog.setVisible(true);
@@ -117,7 +117,7 @@ public class MainPanel extends SplitPane
         myScrollPane.setFitToHeight(true);
         myScrollPane.setFitToWidth(true);
 
-        myLeftView.getChildren().addAll(myAddIconButton, myCustIconButton, myGenIconButton, myTreeView);
+        myLeftView.getChildren().addAll(myAddIconButton, myCustomizeIconButton, myGenerateIconButton, myTreeView);
         setResizableWithParent(myLeftView, false);
         getItems().addAll(myLeftView, myScrollPane);
     }
@@ -203,22 +203,22 @@ public class MainPanel extends SplitPane
      */
     private void treeHandle(TreeItem<String> newValue)
     {
-        String colName = newValue.getValue();
-        if (!myPanelModel.getRecordList().equals(myRecordMap.get(colName)))
+        String collectionName = newValue.getValue();
+        if (!myPanelModel.getRecordList().equals(myRecordMap.get(collectionName)))
         {
             myPanelModel.getSelectedIcons().clear();
         }
-        myPanelModel.setRecordList(myRecordMap.get(colName));
+        myPanelModel.setRecordList(myRecordMap.get(collectionName));
         myPanelModel.setUseFilteredList(false);
         myScrollPane.setContent(myIconGrid = new GridBuilder(myPanelModel));
-        if (myPanelModel.getIconRegistry().getCollectionNames().contains(colName))
+        if (myPanelModel.getIconRegistry().getCollectionNames().contains(collectionName))
         {
-            myPanelModel.getImportProps().getCollectionName().set(colName);
+            myPanelModel.getImportProps().getCollectionName().set(collectionName);
         }
         else
         {
-            myPanelModel.getImportProps().getCollectionName().set(myRecordMap.get(colName).get(0).getCollectionName());
-            myPanelModel.getImportProps().getSubCollectionName().set(colName);
+            myPanelModel.getImportProps().getCollectionName().set(myRecordMap.get(collectionName).get(0).getCollectionName());
+            myPanelModel.getImportProps().getSubCollectionName().set(collectionName);
         }
     }
 
@@ -226,9 +226,9 @@ public class MainPanel extends SplitPane
      * Loads a single icon from a file.
      *
      * @param collectionName the collection name
-     * @param subCatName the sub cat name
+     * @param subCategoryName the sub category name
      */
-    public void loadFromFile(String collectionName, String subCatName)
+    public void loadFromFile(String collectionName, String subCategoryName)
     {
         File result = ImageUtil.showImageFileChooser("Choose Icon File", myOwner,
                 myPanelModel.getToolbox().getPreferencesRegistry());
@@ -236,7 +236,7 @@ public class MainPanel extends SplitPane
         {
             try
             {
-                IconProvider provider = new DefaultIconProvider(result.toURI().toURL(), collectionName, subCatName, "User");
+                IconProvider provider = new DefaultIconProvider(result.toURI().toURL(), collectionName, subCategoryName, "User");
                 myPanelModel.getIconRegistry().addIcon(provider, this);
             }
             catch (MalformedURLException e)

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/SubCollectPane.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/SubCollectPane.java
@@ -128,8 +128,8 @@ public class SubCollectPane extends VBox
         });
 
         myComboBox = new ComboBox<>(myComboBoxItems);
-        HBox existingPnl = new HBox();
-        existingPnl.getChildren().addAll(myExistingButton, myComboBox);
+        HBox existingPanel = new HBox();
+        existingPanel.getChildren().addAll(myExistingButton, myComboBox);
 
         myNewCategoryButton = new RadioButton("New");
         myNewCategoryButton.setOnAction(event ->

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/SubCollectPane.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/SubCollectPane.java
@@ -128,8 +128,6 @@ public class SubCollectPane extends VBox
         });
 
         myComboBox = new ComboBox<>(myComboBoxItems);
-        HBox existingPanel = new HBox();
-        existingPanel.getChildren().addAll(myExistingButton, myComboBox);
 
         myNewCategoryButton = new RadioButton("New");
         myNewCategoryButton.setOnAction(event ->

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
@@ -32,10 +32,10 @@ public class TopMenuBar extends HBox
     private final ButtonBuilder myEnlargeButton = new ButtonBuilder("+", false);
 
     /** The bar containing the sizing options. */
-    private ButtonBar mySizeMenu = new ButtonBar();
+    private final ButtonBar mySizeMenu;
 
     /** The bar containing the icon display toggles. */
-    private ButtonBar myViewToggle = new ButtonBar();
+    private final ButtonBar myViewToggle;
 
     /** The label for the icon display view. */
     private final Text myViewLabel = new LabelMaker("View Style");
@@ -50,7 +50,7 @@ public class TopMenuBar extends HBox
     private final ToggleGroup myToggleGroup = new ToggleGroup();
 
     /** The bar containing the filter functionality. */
-    private ButtonBar mySearchBar = new ButtonBar();
+    private final ButtonBar mySearchBar;
 
     /** The label for the filter text input. */
     private final Text mySearchLabel = new LabelMaker("Filter");

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
@@ -84,7 +84,7 @@ public class TopMenuBar extends HBox
     }
 
     /**
-     * Creates the search bar containing the label and ext entry field for
+     * Creates the search bar containing the label and text entry field for
      * filtering icons.
      *
      * @return a JavaFX ButtonBar containing filter control elements.
@@ -141,16 +141,13 @@ public class TopMenuBar extends HBox
         ButtonBar sizeMenu = new ButtonBar();
         myEnlargeButton.setOnAction(event ->
         {
-            int origTile = myPanelModel.getCurrentTileWidth().get();
-            myPanelModel.getCurrentTileWidth().set(origTile + 10);
-            myPanelModel.getViewModel().getMainPanel().getScrollPane().setContent(new GridBuilder(myPanelModel));
+            myPanelModel.getCurrentTileWidth().set(myPanelModel.getCurrentTileWidth().get() + 10);
         });
         myEnlargeButton.setTooltip(new Tooltip("Increase Icon Size"));
 
         myShrinkButton.setOnAction(event ->
         {
-            int origTile = myPanelModel.getCurrentTileWidth().get();
-            myPanelModel.getCurrentTileWidth().set(origTile - 10);
+            myPanelModel.getCurrentTileWidth().set(myPanelModel.getCurrentTileWidth().get() - 10);
         });
         myShrinkButton.setTooltip(new Tooltip("Decrease Icon Size"));
         sizeMenu.getButtons().addAll(mySizeLabel, myShrinkButton, myEnlargeButton);
@@ -164,7 +161,7 @@ public class TopMenuBar extends HBox
      */
     public ButtonBar createViewToggle()
     {
-        ButtonBar theViewToggle = new ButtonBar();
+        ButtonBar viewToggle = new ButtonBar();
         myListView.setText("List");
         myListView.setToggleGroup(myToggleGroup);
         myGridView.setText("Grid");
@@ -185,9 +182,9 @@ public class TopMenuBar extends HBox
             myPanelModel.getViewModel().getMainPanel().refresh();
         });
 
-        theViewToggle.getButtons().addAll(myViewLabel, myGridView, myListView);
+        viewToggle.getButtons().addAll(myViewLabel, myGridView, myListView);
 
-        return theViewToggle;
+        return viewToggle;
     }
 
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
@@ -139,16 +139,10 @@ public class TopMenuBar extends HBox
     public ButtonBar createSizeMenu()
     {
         ButtonBar sizeMenu = new ButtonBar();
-        myEnlargeButton.setOnAction(event ->
-        {
-            myPanelModel.getCurrentTileWidth().set(myPanelModel.getCurrentTileWidth().get() + 10);
-        });
+        myEnlargeButton.setOnAction(event -> myPanelModel.getCurrentTileWidth().set(myPanelModel.getCurrentTileWidth().get() + 10));
         myEnlargeButton.setTooltip(new Tooltip("Increase Icon Size"));
 
-        myShrinkButton.setOnAction(event ->
-        {
-            myPanelModel.getCurrentTileWidth().set(myPanelModel.getCurrentTileWidth().get() - 10);
-        });
+        myShrinkButton.setOnAction(event -> myPanelModel.getCurrentTileWidth().set(myPanelModel.getCurrentTileWidth().get() - 10));
         myShrinkButton.setTooltip(new Tooltip("Decrease Icon Size"));
         sizeMenu.getButtons().addAll(mySizeLabel, myShrinkButton, myEnlargeButton);
         return sizeMenu;

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
@@ -173,11 +173,15 @@ public class TopMenuBar extends HBox
         myListView.setOnAction(event ->
         {
             myPanelModel.getViewStyle().set(ViewStyle.LIST);
+            myShrinkButton.setDisable(true);
+            myEnlargeButton.setDisable(true);
             myPanelModel.getViewModel().getMainPanel().refresh();
         });
         myGridView.setOnAction(event ->
         {
             myPanelModel.getViewStyle().set(ViewStyle.GRID);
+            myShrinkButton.setDisable(false);
+            myEnlargeButton.setDisable(false);
             myPanelModel.getViewModel().getMainPanel().refresh();
         });
 

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TopMenuBar.java
@@ -64,14 +64,14 @@ public class TopMenuBar extends HBox
     /**
      * Creates the top menu bar of the icon manager UI.
      *
-     * @param thePanelModel the current UI model.
+     * @param panelModel the current UI model.
      */
-    public TopMenuBar(PanelModel thePanelModel)
+    public TopMenuBar(PanelModel panelModel)
     {
         mySearchBar = createFilterBar();
         myViewToggle = createViewToggle();
         mySizeMenu = createSizeMenu();
-        myPanelModel = thePanelModel;
+        myPanelModel = panelModel;
 
         Region region1 = new Region();
         HBox.setHgrow(region1, Priority.ALWAYS);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TreeBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TreeBuilder.java
@@ -54,36 +54,36 @@ public class TreeBuilder extends TreeItem<String>
         List<IconRecord> records = myIconRegistry.getIconRecords(filter);
         Collections.sort(records, (r1, r2) -> AlphanumComparator.compareNatural(r1.getImageURL().toString(), r2.getImageURL().toString()));
         Set<String> collectionSet = New.set();
-        Map<String, Map<String, List<IconRecord>>> collectionToSubCatIconRecMap = New.map();
-        String defaultSubCat = "DEFAULT";
-        for (IconRecord rec : records)
+        Map<String, Map<String, List<IconRecord>>> iconRecordMapCollection = New.map();
+        String defaultSubCategory = "DEFAULT";
+        for (IconRecord record : records)
         {
-            String collection = rec.getCollectionName() == null ? IconRecord.DEFAULT_COLLECTION : rec.getCollectionName();
+            String collection = record.getCollectionName() == null ? IconRecord.DEFAULT_COLLECTION : record.getCollectionName();
             if (collection == null)
             {
                 collection = IconRecord.DEFAULT_COLLECTION;
             }
 
             collectionSet.add(collection);
-            String subCat = rec.getSubCategory() == null ? defaultSubCat : rec.getSubCategory();
+            String subCategory = record.getSubCategory() == null ? defaultSubCategory : record.getSubCategory();
 
-            Map<String, List<IconRecord>> subCatToRecListMap = collectionToSubCatIconRecMap.get(collection);
-            if (subCatToRecListMap == null)
+            Map<String, List<IconRecord>> iconRecordMap = iconRecordMapCollection.get(collection);
+            if (iconRecordMap == null)
             {
-                subCatToRecListMap = New.map();
-                collectionToSubCatIconRecMap.put(collection, subCatToRecListMap);
+                iconRecordMap = New.map();
+                iconRecordMapCollection.put(collection, iconRecordMap);
             }
 
-            List<IconRecord> recList = subCatToRecListMap.get(subCat);
-            if (recList == null)
+            List<IconRecord> recordList = iconRecordMap.get(subCategory);
+            if (recordList == null)
             {
-                recList = New.linkedList();
-                subCatToRecListMap.put(subCat, recList);
+                recordList = New.linkedList();
+                iconRecordMap.put(subCategory, recordList);
             }
-            recList.add(rec);
+            recordList.add(record);
         }
 
-        buildTreeFromMaps(this, collectionSet, collectionToSubCatIconRecMap, defaultSubCat);
+        buildTreeFromMaps(this, collectionSet, iconRecordMapCollection, defaultSubCategory);
         setExpanded(true);
     }
 
@@ -92,12 +92,11 @@ public class TreeBuilder extends TreeItem<String>
      *
      * @param rootNode the root node
      * @param collectionSet the collection set
-     * @param collectionToSubCatIconRecMap the collection to sub cat icon rec
-     *            map
-     * @param defaultSubCat the default sub cat
+     * @param iconRecordMapCollection the collection of icon record collections
+     * @param defaultSubCategory the default sub category
      */
     private void buildTreeFromMaps(TreeItem<String> rootNode, Set<String> collectionSet,
-            Map<String, Map<String, List<IconRecord>>> collectionToSubCatIconRecMap, String defaultSubCat)
+            Map<String, Map<String, List<IconRecord>>> iconRecordMapCollection, String defaultSubCategory)
     {
         List<String> collectionList = New.list(collectionSet);
         Collections.sort(collectionList);
@@ -114,15 +113,15 @@ public class TreeBuilder extends TreeItem<String>
         for (String collection : collectionList)
         {
             TreeItem<String> mainNode = new TreeItem<>();
-            Map<String, List<IconRecord>> subToRecListMap = collectionToSubCatIconRecMap.get(collection);
-            if (subToRecListMap != null)
+            Map<String, List<IconRecord>> iconRecordMap = iconRecordMapCollection.get(collection);
+            if (iconRecordMap != null)
             {
-                List<String> subCatList = New.list(subToRecListMap.keySet());
-                Collections.sort(subCatList);
+                List<String> subCategoryList = New.list(iconRecordMap.keySet());
+                Collections.sort(subCategoryList);
 
-                if (subCatList.remove(defaultSubCat))
+                if (subCategoryList.remove(defaultSubCategory))
                 {
-                    List<IconRecord> defaultRecList = subToRecListMap.get(defaultSubCat);
+                    List<IconRecord> defaultRecList = iconRecordMap.get(defaultSubCategory);
                     myIconTreeObject = DefaultIconRecordTreeItemObject.createLeafNode(mainNode, collection, defaultRecList,
                             IconRecordTreeItemUserObject.NameType.COLLECTION, null);
                     myRecordMap.put(collection, myIconTreeObject.getRecords(true));
@@ -135,16 +134,16 @@ public class TreeBuilder extends TreeItem<String>
                 }
 
                 getChildren().add(myIconTreeObject.getMyTreeItem().get());
-                for (String subCat : subCatList)
+                for (String subCategory : subCategoryList)
                 {
-                    TreeItem<String> depNode = new TreeItem<>();
-                    myIconTreeObject = DefaultIconRecordTreeItemObject.createLeafNode(depNode, subCat, subToRecListMap.get(subCat),
+                    TreeItem<String> newNode = new TreeItem<>();
+                    myIconTreeObject = DefaultIconRecordTreeItemObject.createLeafNode(newNode, subCategory, iconRecordMap.get(subCategory),
                             IconRecordTreeItemUserObject.NameType.SUBCATEGORY, collection);
                     mainNode.getChildren().add(myIconTreeObject.getMyTreeItem().get());
-                    myRecordMap.put(subCat, myIconTreeObject.getRecords(true));
-                    ArrayList<IconRecord> test = new ArrayList<>(myRecordMap.get(collection));
-                    test.addAll(myIconTreeObject.getRecords(true));
-                    myRecordMap.put(collection, test);
+                    myRecordMap.put(subCategory, myIconTreeObject.getRecords(true));
+                    ArrayList<IconRecord> iconRecords = new ArrayList<>(myRecordMap.get(collection));
+                    iconRecords.addAll(myIconTreeObject.getRecords(true));
+                    myRecordMap.put(collection, iconRecords);
                 }
             }
         }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TreeBuilder.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/panels/TreeBuilder.java
@@ -59,27 +59,10 @@ public class TreeBuilder extends TreeItem<String>
         for (IconRecord record : records)
         {
             String collection = record.getCollectionName() == null ? IconRecord.DEFAULT_COLLECTION : record.getCollectionName();
-            if (collection == null)
-            {
-                collection = IconRecord.DEFAULT_COLLECTION;
-            }
-
             collectionSet.add(collection);
             String subCategory = record.getSubCategory() == null ? defaultSubCategory : record.getSubCategory();
-
-            Map<String, List<IconRecord>> iconRecordMap = iconRecordMapCollection.get(collection);
-            if (iconRecordMap == null)
-            {
-                iconRecordMap = New.map();
-                iconRecordMapCollection.put(collection, iconRecordMap);
-            }
-
-            List<IconRecord> recordList = iconRecordMap.get(subCategory);
-            if (recordList == null)
-            {
-                recordList = New.linkedList();
-                iconRecordMap.put(subCategory, recordList);
-            }
+            Map<String, List<IconRecord>> iconRecordMap = iconRecordMapCollection.computeIfAbsent(collection, k -> New.map());
+            List<IconRecord> recordList = iconRecordMap.computeIfAbsent(subCategory, k -> New.linkedList());
             recordList.add(record);
         }
 

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/AddIconDialog.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/AddIconDialog.java
@@ -60,9 +60,6 @@ public class AddIconDialog extends JFXDialog
      */
     private void loadFromFolder(String collectionName, String subCollectionName)
     {
-        String colName = collectionName;
-        String subcategory = subCollectionName;
-
         MnemonicFileChooser chooser = new MnemonicFileChooser(myPanelModel.getToolbox().getPreferencesRegistry(),
                 "IconManagerFrame");
 
@@ -75,8 +72,8 @@ public class AddIconDialog extends JFXDialog
             File resultFile = chooser.getSelectedFile();
             try
             {
-                List<DefaultIconProvider> providerList = IconProviderFactory.createFromDirectory(resultFile, colName,
-                        "IconManager", true, subcategory);
+                List<DefaultIconProvider> providerList = IconProviderFactory.createFromDirectory(resultFile, collectionName,
+                        "IconManager", true, subCollectionName);
                 myPanelModel.getIconRegistry().addIcons(providerList, this);
             }
             catch (IOException e)

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/AddIconDialog.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/AddIconDialog.java
@@ -22,13 +22,13 @@ public class AddIconDialog extends JFXDialog
     private static final long serialVersionUID = -4136694415228468073L;
 
     /** The model for UI elements. */
-    private PanelModel myPanelModel;
+    private final PanelModel myPanelModel;
 
     /** The panel calling this window. */
-    private Window myOwner;
+    private final Window myOwner;
 
     /** The pane displaying UI elements. */
-    private AddIconPane myAddIconPane;
+    private final AddIconPane myAddIconPane;
 
     /**
      * Creates a new window containing the collection name and sub collection

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconCustomizerDialog.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconCustomizerDialog.java
@@ -38,7 +38,7 @@ public class IconCustomizerDialog extends JFXDialog
     private final IconRegistry myIconRegistry;
 
     /** the current UI model. */
-    private PanelModel myPanelModel;
+    private final PanelModel myPanelModel;
 
     /**
      * Wraps the IconCustomizerPane into a java swing window.

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconPopupMenu.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconPopupMenu.java
@@ -36,10 +36,10 @@ public class IconPopupMenu extends ContextMenu
         removeAction.setOnAction(event -> selector.delete(false));
 
         MenuItem unSelectAction = new MenuItem("Deselect All Icons");
-        unSelectAction.setOnAction(event -> selector.unSelectIcons());
+        unSelectAction.setOnAction(event -> selector.unSelectAllIcons());
 
         MenuItem deSelectAction = new MenuItem("Deselect Icon");
-        deSelectAction.setOnAction(event -> EventQueue.invokeLater(() -> selector.unSelectIcon()));
+        deSelectAction.setOnAction(event -> EventQueue.invokeLater(() -> selector.unSelectSingleIcon()));
 
         getItems().addAll(favoriteAction, rotateAction, deSelectAction, unSelectAction, removeAction, deleteAction);
     }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconPopupMenu.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconPopupMenu.java
@@ -23,8 +23,8 @@ public class IconPopupMenu extends ContextMenu
     {
         IconPopupMenuImpl selector = new IconPopupMenuImpl(panelModel);
 
-        MenuItem favAction = new MenuItem("Add Selected Icon(s) to Favorites");
-        favAction.setOnAction(event -> selector.addToFav());
+        MenuItem favoriteAction = new MenuItem("Add Selected Icon(s) to Favorites");
+        favoriteAction.setOnAction(event -> selector.addToFav());
 
         MenuItem rotateAction = new MenuItem("Customize Icon");
         rotateAction.setOnAction(event -> EventQueue.invokeLater(() -> selector.customize()));
@@ -41,6 +41,6 @@ public class IconPopupMenu extends ContextMenu
         MenuItem deSelectAction = new MenuItem("Deselect Icon");
         deSelectAction.setOnAction(event -> EventQueue.invokeLater(() -> selector.unSelectIcon()));
 
-        getItems().addAll(favAction, rotateAction, deSelectAction, unSelectAction, removeAction, deleteAction);
+        getItems().addAll(favoriteAction, rotateAction, deSelectAction, unSelectAction, removeAction, deleteAction);
     }
 }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconPopupMenu.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconPopupMenu.java
@@ -17,11 +17,11 @@ public class IconPopupMenu extends ContextMenu
     /**
      * The main method to instantiate a new IconPopupMenu.
      *
-     * @param thePanelModel the model used to get registry items.
+     * @param panelModel the model used to get registry items.
      */
-    public IconPopupMenu(PanelModel thePanelModel)
+    public IconPopupMenu(PanelModel panelModel)
     {
-        IconPopupMenuImpl selector = new IconPopupMenuImpl(thePanelModel);
+        IconPopupMenuImpl selector = new IconPopupMenuImpl(panelModel);
 
         MenuItem favAction = new MenuItem("Add Selected Icon(s) to Favorites");
         favAction.setOnAction(event -> selector.addToFav());
@@ -30,7 +30,7 @@ public class IconPopupMenu extends ContextMenu
         rotateAction.setOnAction(event -> EventQueue.invokeLater(() -> selector.customize()));
 
         MenuItem deleteAction = new MenuItem("Delete Selected Icon(s)");
-        deleteAction.setOnAction(event ->selector.delete(true));
+        deleteAction.setOnAction(event -> selector.delete(true));
 
         MenuItem removeAction = new MenuItem("Remove Selected Icon(s)");
         removeAction.setOnAction(event -> selector.delete(false));

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconProjDialog.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconProjDialog.java
@@ -71,9 +71,8 @@ public class IconProjDialog extends JFXDialog
     {
         MantleToolboxUtils.getMantleToolbox(myToolbox).getIconRegistry().getManagerPrefs().getIconWidth()
                 .set(myPanelModel.getCurrentTileWidth().get());
-        MantleToolboxUtils.getMantleToolbox(myToolbox).getIconRegistry().getManagerPrefs().getTreeSelection()
-                .set((TreeItem<String>)myPanelModel.getTreeObject().getMyObsTree().get().getSelectionModel().selectedItemProperty()
-                        .get());
+        MantleToolboxUtils.getMantleToolbox(myToolbox).getIconRegistry().getManagerPrefs().setTreeSelection((TreeItem<String>)myPanelModel
+                .getTreeObject().getMyObsTree().get().getSelectionModel().selectedItemProperty().get());
     }
 
     /** Packages UI elements into one pane. */

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconProjDialog.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconProjDialog.java
@@ -17,13 +17,13 @@ import javafx.scene.layout.AnchorPane;
 public class IconProjDialog extends JFXDialog
 {
     /** The model to be shared between all the UI elements. */
-    private PanelModel myPanelModel;
+    private final PanelModel myPanelModel;
 
     /** The model for the display panels. */
-    private ViewModel myViewModel = new ViewModel();
+    private final ViewModel myViewModel;
 
     /** The Toolbox. */
-    private Toolbox myToolbox;
+    private final Toolbox myToolbox;
 
     /**
      * Constructor.
@@ -45,6 +45,7 @@ public class IconProjDialog extends JFXDialog
         myPanelModel = new PanelModel(myToolbox);
         myPanelModel.setOwner(owner);
         myPanelModel.setIconRegistry(MantleToolboxUtils.getMantleToolbox(tb).getIconRegistry());
+        myViewModel = new ViewModel();
         myViewModel.setMultiSelectEnabled(multiSelectEnabled);
         myPanelModel.setViewModel(myViewModel);
         setMinimumSize(new Dimension(800, 600));

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconProjDialog.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/iconproject/view/IconProjDialog.java
@@ -71,7 +71,7 @@ public class IconProjDialog extends JFXDialog
     {
         MantleToolboxUtils.getMantleToolbox(myToolbox).getIconRegistry().getManagerPrefs().getIconWidth()
                 .set(myPanelModel.getCurrentTileWidth().get());
-        MantleToolboxUtils.getMantleToolbox(myToolbox).getIconRegistry().getManagerPrefs().getInitTreeSelection()
+        MantleToolboxUtils.getMantleToolbox(myToolbox).getIconRegistry().getManagerPrefs().getTreeSelection()
                 .set((TreeItem<String>)myPanelModel.getTreeObject().getMyObsTree().get().getSelectionModel().selectedItemProperty()
                         .get());
     }


### PR DESCRIPTION
Fixes

## Proposed Changes

  - icon names display correctly when underscores are in the name
  - icon size feature disabled in list mode
  - rollover text adjustment for icons, right click menu works on first click
  - code cleanup to remove extraneous bits and make it easier to read
