### PR TITLE
VORTEX-6009: Adding support for HTTP DELETE requests with custom headers

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/server/HttpServer.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/server/HttpServer.java
@@ -45,7 +45,7 @@ public interface HttpServer
      *             to a URI.
      */
     CancellableInputStream postFile(URL postToURL, Map<String, String> metaDataParts, File fileToPost, ResponseValues response)
-            throws IOException, URISyntaxException;
+        throws IOException, URISyntaxException;
 
     /**
      * Sends a file to the specified url.
@@ -59,7 +59,7 @@ public interface HttpServer
      *             to a URI.
      */
     CancellableInputStream postFile(URL postToURL, File fileToPost, ResponseValues response)
-            throws IOException, URISyntaxException;
+        throws IOException, URISyntaxException;
 
     /**
      * Gets a host and port to connect to based on the configured proxy settings
@@ -96,6 +96,23 @@ public interface HttpServer
     CancellableInputStream sendDelete(URL url, ResponseValues response) throws IOException, URISyntaxException;
 
     /**
+     * Sends a delete request to the server.
+     *
+     * @param url The url to the server which should include any parameters.
+     * @param extraHeaderValues Header values to add to the request header.
+     * @param response The response code and message returned from the delete
+     *            request.
+     * @return The input stream containing the data returned by the delete
+     *         request.
+     * @throws IOException Thrown if an error happens when communicating with
+     *             the server.
+     * @throws URISyntaxException Thrown if an error occurs converting the URL
+     *             to a URI.
+     */
+    CancellableInputStream sendDelete(URL url, Map<String, String> extraHeaderValues, ResponseValues response)
+        throws IOException, URISyntaxException;
+
+    /**
      * Sends a get request to the server.
      *
      * @param url The url to the server which should include any parameters.
@@ -109,7 +126,7 @@ public interface HttpServer
      *             to a URI.
      */
     CancellableInputStream sendGet(URL url, Map<String, String> extraHeaderValues, ResponseValues response)
-            throws IOException, URISyntaxException;
+        throws IOException, URISyntaxException;
 
     /**
      * Sends a get request to the server.
@@ -170,7 +187,7 @@ public interface HttpServer
      */
     CancellableInputStream sendPost(URL url, InputStream postData, Map<String, String> extraHeaderValues, ResponseValues response,
             ContentType contentType)
-                    throws IOException, URISyntaxException;
+        throws IOException, URISyntaxException;
 
     /**
      * Sends a post request to the server.
@@ -186,7 +203,7 @@ public interface HttpServer
      *             to a URI.
      */
     CancellableInputStream sendPost(URL url, InputStream postData, ResponseValues response)
-            throws IOException, URISyntaxException;
+        throws IOException, URISyntaxException;
 
     /**
      * Sends a post request to the server.
@@ -203,7 +220,7 @@ public interface HttpServer
      *             to a URI.
      */
     CancellableInputStream sendPost(URL url, InputStream postData, ResponseValues response, ContentType contentType)
-            throws IOException, URISyntaxException;
+        throws IOException, URISyntaxException;
 
     /**
      * Sends a post request to the server.
@@ -222,7 +239,7 @@ public interface HttpServer
      */
     CancellableInputStream sendPost(URL url, Map<String, String> extraHeaderValues, Map<String, String> postData,
             ResponseValues response)
-                    throws IOException, URISyntaxException;
+        throws IOException, URISyntaxException;
 
     /**
      * Sends a post request to the server.
@@ -238,7 +255,7 @@ public interface HttpServer
      *             to a URI.
      */
     CancellableInputStream sendPost(URL url, Map<String, String> postData, ResponseValues response)
-            throws IOException, URISyntaxException;
+        throws IOException, URISyntaxException;
 
     /**
      * Sets the size of the buffer used when reading http messages.

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/JFXAlert.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/fx/JFXAlert.java
@@ -28,6 +28,7 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Region;
 
 /**
  * An alert dialog that renders a JavaFX component and buttons within a Swing
@@ -128,7 +129,12 @@ public class JFXAlert extends JDialog
      */
     public JFXAlert(Window owner, JFXAlertType alertType, String title, String message, ButtonType... buttons)
     {
-        this(owner, alertType, title, () -> new Label(message), buttons);
+        this(owner, alertType, title, () ->
+        {
+            Label label = new Label(message);
+            label.setMinSize(Region.USE_PREF_SIZE, Region.USE_PREF_SIZE);
+            return label;
+        }, buttons);
     }
 
     /**

--- a/open-sphere-plugins/ogc-server/src/main/java/io/opensphere/server/serverprovider/http/HttpServerImpl.java
+++ b/open-sphere-plugins/ogc-server/src/main/java/io/opensphere/server/serverprovider/http/HttpServerImpl.java
@@ -129,6 +129,16 @@ public class HttpServerImpl implements HttpServer
     }
 
     @Override
+    public CancellableInputStream sendDelete(URL url, Map<String, String> extraHeaderValues, ResponseValues response)
+        throws IOException, URISyntaxException
+    {
+        assert !EventQueue.isDispatchThread();
+        assert !Platform.isFxApplicationThread();
+
+        return myRequestorProvider.getDeleteRequestor().sendDelete(url, extraHeaderValues, response);
+    }
+
+    @Override
     public CancellableInputStream sendGet(URL url, Map<String, String> extraHeaderValues, ResponseValues response)
         throws IOException, URISyntaxException
     {
@@ -150,7 +160,8 @@ public class HttpServerImpl implements HttpServer
     /**
      * {@inheritDoc}
      *
-     * @see io.opensphere.core.server.HttpServer#sendHead(java.net.URL, java.util.Map, io.opensphere.core.server.ResponseValues)
+     * @see io.opensphere.core.server.HttpServer#sendHead(java.net.URL,
+     *      java.util.Map, io.opensphere.core.server.ResponseValues)
      */
     @Override
     public void sendHead(URL url, Map<String, String> extraHeaderValues, ResponseValues response)
@@ -165,7 +176,8 @@ public class HttpServerImpl implements HttpServer
     /**
      * {@inheritDoc}
      *
-     * @see io.opensphere.core.server.HttpServer#sendHead(java.net.URL, io.opensphere.core.server.ResponseValues)
+     * @see io.opensphere.core.server.HttpServer#sendHead(java.net.URL,
+     *      io.opensphere.core.server.ResponseValues)
      */
     @Override
     public void sendHead(URL url, ResponseValues response) throws IOException, URISyntaxException

--- a/open-sphere-plugins/ogc-server/src/main/java/io/opensphere/server/serverprovider/http/requestors/DeleteRequestor.java
+++ b/open-sphere-plugins/ogc-server/src/main/java/io/opensphere/server/serverprovider/http/requestors/DeleteRequestor.java
@@ -3,6 +3,7 @@ package io.opensphere.server.serverprovider.http.requestors;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Map;
 
 import io.opensphere.core.server.ResponseValues;
 import io.opensphere.core.util.io.CancellableInputStream;
@@ -11,9 +12,24 @@ import io.opensphere.core.util.io.CancellableInputStream;
  * Sends a delete request to the server.
  *
  */
-@FunctionalInterface
 public interface DeleteRequestor
 {
+    /**
+     * Sends a delete request to the server.
+     *
+     * @param url The url to the server which should include any parameters.
+     * @param extraHeaderValues Header values to add to the request.
+     * @param responseValues The response code and message returned from the
+     *            delete request.
+     * @return The input stream containing the data returned by the delete
+     *         request.
+     * @throws IOException Thrown if an error happens when communicating with
+     *             the server.
+     * @throws URISyntaxException If the url could not be translated to a URI.
+     */
+    CancellableInputStream sendDelete(URL url, Map<String, String> extraHeaderValues, ResponseValues responseValues)
+        throws IOException, URISyntaxException;
+
     /**
      * Sends a delete request to the server.
      *

--- a/open-sphere-plugins/ogc-server/src/main/java/io/opensphere/server/serverprovider/http/requestors/DeleteRequestorImpl.java
+++ b/open-sphere-plugins/ogc-server/src/main/java/io/opensphere/server/serverprovider/http/requestors/DeleteRequestorImpl.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Function;
 
 import com.bitsys.common.http.client.HttpClient;
@@ -30,6 +32,32 @@ public class DeleteRequestorImpl extends BaseRequestor implements DeleteRequesto
     public DeleteRequestorImpl(HttpClient client, HeaderValues headerValues)
     {
         super(client, headerValues);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see io.opensphere.server.serverprovider.http.requestors.DeleteRequestor#sendDelete(java.net.URL,
+     *      java.util.Map, io.opensphere.core.server.ResponseValues)
+     */
+    @Override
+    public CancellableInputStream sendDelete(URL url, Map<String, String> extraHeaderValues, ResponseValues responseValues)
+        throws IOException, URISyntaxException
+    {
+        HttpRequest request = HttpRequestFactory.getInstance().delete(url.toURI());
+        for (Entry<String, String> extraHeader : extraHeaderValues.entrySet())
+        {
+            request.getHeaders().put(extraHeader.getKey(), extraHeader.getValue());
+        }
+        CancellableInputStream responseStream = executeRequest(request, responseValues);
+        return handleRedirect(responseStream, responseValues, new Function<String, HttpRequest>()
+        {
+            @Override
+            public HttpRequest apply(String newUrlString)
+            {
+                return HttpRequestFactory.getInstance().delete(URI.create(newUrlString));
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
Fixes #6009

## Proposed Changes
  - Adds support for submitting HTTP Delete requests with custom headers. 
  - Fixes formatting issue in JFXAlert (unrelated but found it and fixed it anyway)
  -
