### PR TITLE
Baseball Card Boundary Fix

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/ContextKey.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/ContextKey.java
@@ -1,0 +1,28 @@
+package io.opensphere.mantle.data;
+
+import java.util.Collection;
+
+import io.opensphere.mantle.data.DataGroupInfo.DataGroupContextKey;
+import io.opensphere.mantle.data.DataGroupInfo.MultiDataGroupContextKey;
+
+/**
+ * A marker interface to provide a common base for
+ * {@link DataGroupContextKey} and {@link MultiDataGroupContextKey} to
+ * implement.
+ */
+public interface ContextKey
+{
+    /**
+     * Get the dataGroups.
+     *
+     * @return the dataGroups
+     */
+    Collection<DataGroupInfo> getDataGroups();
+
+    /**
+     * Get the dataTypes.
+     *
+     * @return the dataTypes
+     */
+    Collection<DataTypeInfo> getDataTypes();
+}


### PR DESCRIPTION
Fixes

## Proposed Changes

  - Distance creation from center point checks cardinal directions to prevent errors when creating baseball card on edge of world. If world size is too small, gives warning to user.