### PR TITLE
VORTEX-6058: Defaulting time to off when saving states

### DIFF
--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/animation/state/LiveStateController.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/animation/state/LiveStateController.java
@@ -126,7 +126,7 @@ public class LiveStateController extends AbstractModuleStateController
     @Override
     public boolean isSaveStateByDefault()
     {
-        return true;
+        return false;
     }
 
     @Override

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/appl/TimeManagerStateController.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/appl/TimeManagerStateController.java
@@ -217,7 +217,7 @@ public class TimeManagerStateController extends AbstractModuleStateController
     @Override
     public boolean isSaveStateByDefault()
     {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Fixes #6058

## Proposed Changes
  - Set default time setting to off when saving states

