### PR TITLE
VORTEX-6111: Feature missing lables render wrong

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/StyleUtils.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/data/geom/style/impl/StyleUtils.java
@@ -119,7 +119,7 @@ public final class StyleUtils
         {
             return TimeSpanUtility.formatTimeSpan(new SimpleDateFormat(DateTimeFormats.DATE_TIME_FORMAT), timeSpan);
         }
-        return Objects.toString(provider.getValue(colName));
+        return Objects.toString(provider.getValue(colName), "");
     }
 
     /**


### PR DESCRIPTION
Fixes #6111

## Proposed Changes
  - When a label's value is null, it was incorrectly using the word "null" instead of leaving it blank. Fixing this.
