### PR TITLE
 VORTEX-6120 

### DIFF
--- a/open-sphere-plugins/csv/src/main/java/io/opensphere/csv/CSVTypeInfoGenerator.java
+++ b/open-sphere-plugins/csv/src/main/java/io/opensphere/csv/CSVTypeInfoGenerator.java
@@ -322,7 +322,6 @@ public final class CSVTypeInfoGenerator
     private static MapVisualizationType getVisualizationType(CSVDataSource fileSource)
     {
         MapVisualizationType geomType;
-        System.out.println(fileSource);
         if (fileSource.getParseParameters().hasType(ColumnType.WKT_GEOMETRY))
         {
             geomType = MapVisualizationType.MIXED_ELEMENTS;

--- a/open-sphere-plugins/csv/src/main/java/io/opensphere/csv/CSVTypeInfoGenerator.java
+++ b/open-sphere-plugins/csv/src/main/java/io/opensphere/csv/CSVTypeInfoGenerator.java
@@ -17,6 +17,7 @@ import io.opensphere.csvcommon.common.Utilities;
 import io.opensphere.csvcommon.config.v1.CSVColumnInfo;
 import io.opensphere.importer.config.ColumnType;
 import io.opensphere.importer.config.SpecialColumn;
+import io.opensphere.importer.config.ColumnType.Category;
 import io.opensphere.mantle.data.LoadsTo;
 import io.opensphere.mantle.data.MapVisualizationType;
 import io.opensphere.mantle.data.impl.DefaultBasicVisualizationInfo;
@@ -321,6 +322,7 @@ public final class CSVTypeInfoGenerator
     private static MapVisualizationType getVisualizationType(CSVDataSource fileSource)
     {
         MapVisualizationType geomType;
+        System.out.println(fileSource);
         if (fileSource.getParseParameters().hasType(ColumnType.WKT_GEOMETRY))
         {
             geomType = MapVisualizationType.MIXED_ELEMENTS;
@@ -337,10 +339,15 @@ public final class CSVTypeInfoGenerator
         {
             geomType = MapVisualizationType.LOB_ELEMENTS;
         }
-        else
+        else if (fileSource.getParseParameters().hasCategory(Category.SPATIAL))
         {
             geomType = MapVisualizationType.POINT_ELEMENTS;
         }
+        else
+        {
+        	geomType = MapVisualizationType.UNKNOWN;
+        }
+        
         return geomType;
     }
 


### PR DESCRIPTION
- Fixes analysis tools breaking from non-spatial csv imports
- CSVs can be imported as UNKNOWN if they do not contain spatial headers