### PR TITLE
VORTEX-6036: Using multi-polygons to query

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/BufferRegionCreator.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/BufferRegionCreator.java
@@ -183,7 +183,7 @@ public class BufferRegionCreator
     {
         if (myPreviewGeometry != null)
         {
-            if (myGeometry != null && myGeometry instanceof MultiPolygonGeometry)
+            if (myGeometry instanceof MultiPolygonGeometry)
             {
                 MultiPolygonGeometry geometry = (MultiPolygonGeometry)myGeometry;
                 Collection<PolygonGeometry> geometries = geometry.getGeometries();
@@ -191,7 +191,7 @@ public class BufferRegionCreator
 
                 geometry.receiveObjects(this, geometries, Collections.emptyList());
             }
-            else if (myGeometry != null && myGeometry instanceof GeometryGroupGeometry)
+            else if (myGeometry instanceof GeometryGroupGeometry)
             {
                 GeometryGroupGeometry geometry = (GeometryGroupGeometry)myGeometry;
                 Collection<Geometry> geometries = geometry.getGeometries();

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/BufferRegionCreator.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/BufferRegionCreator.java
@@ -3,6 +3,7 @@ package io.opensphere.mantle.plugin.selection;
 import java.awt.Frame;
 import java.awt.MouseInfo;
 import java.awt.Point;
+import java.util.Collection;
 import java.util.Collections;
 
 import javax.swing.JOptionPane;
@@ -15,6 +16,8 @@ import io.opensphere.core.control.action.ActionContext;
 import io.opensphere.core.control.action.context.ContextIdentifiers;
 import io.opensphere.core.control.action.context.GeometryContextKey;
 import io.opensphere.core.geometry.Geometry;
+import io.opensphere.core.geometry.GeometryGroupGeometry;
+import io.opensphere.core.geometry.MultiPolygonGeometry;
 import io.opensphere.core.geometry.PolygonGeometry;
 import io.opensphere.core.units.UnitsProvider;
 import io.opensphere.core.units.length.Kilometers;
@@ -180,7 +183,26 @@ public class BufferRegionCreator
     {
         if (myPreviewGeometry != null)
         {
-            unregisterGeometry(myPreviewGeometry);
+            if (myGeometry != null && myGeometry instanceof MultiPolygonGeometry)
+            {
+                MultiPolygonGeometry geometry = (MultiPolygonGeometry)myGeometry;
+                Collection<PolygonGeometry> geometries = geometry.getGeometries();
+                unregisterGeometry(myPreviewGeometry);
+
+                geometry.receiveObjects(this, geometries, Collections.emptyList());
+            }
+            else if (myGeometry != null && myGeometry instanceof GeometryGroupGeometry)
+            {
+                GeometryGroupGeometry geometry = (GeometryGroupGeometry)myGeometry;
+                Collection<Geometry> geometries = geometry.getGeometries();
+                unregisterGeometry(myPreviewGeometry);
+
+                geometry.receiveObjects(this, geometries, Collections.emptyList());
+            }
+            else
+            {
+                unregisterGeometry(myPreviewGeometry);
+            }
         }
         myPreviewGeometry = null;
     }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionHandler.java
@@ -27,6 +27,7 @@ import io.opensphere.core.control.action.context.ContextIdentifiers;
 import io.opensphere.core.control.action.context.GeometryContextKey;
 import io.opensphere.core.control.action.context.MultiGeometryContextKey;
 import io.opensphere.core.control.action.context.ScreenPositionContextKey;
+import io.opensphere.core.geometry.AbstractGeometryGroup;
 import io.opensphere.core.geometry.Geometry;
 import io.opensphere.core.geometry.GeometryGroupGeometry;
 import io.opensphere.core.geometry.MultiPolygonGeometry;
@@ -504,12 +505,21 @@ public class SelectionHandler
             Quantify.collectMetric("mist3d.tracks.create-buffer-for-selected-segment");
             myBufferRegionCreator.createBuffer(myLastGeometry);
         }
-        else if (myLastGeometry instanceof PolygonGeometry || (myLastGeometry instanceof GeometryGroupGeometry
-                && ((GeometryGroupGeometry)myLastGeometry).getGeometries().iterator().next() instanceof PolygonGeometry))
+        else if (myLastGeometry instanceof PolygonGeometry)
         {
             Set<PolygonGeometry> geom = Collections.singleton((PolygonGeometry)myLastGeometry);
             myLastGeometry = null;
             doPurgeCheck(cmd, geom);
+        }
+        else if (myLastGeometry instanceof AbstractGeometryGroup)
+        {
+            if (((AbstractGeometryGroup)myLastGeometry).getGeometries().iterator().next() instanceof PolygonGeometry)
+            {
+                Set<PolygonGeometry> childGeometries = ((AbstractGeometryGroup)myLastGeometry).getGeometries().stream()
+                        .map(g -> (PolygonGeometry)g).collect(Collectors.toSet());
+                myLastGeometry = null;
+                doPurgeCheck(cmd, childGeometries);
+            }
         }
         else if (myLastGeometry instanceof PolylineGeometry || myLastGeometry instanceof PointGeometry)
         {


### PR DESCRIPTION
Fixes #6036

## Proposed Changes
  - For multi-polygonal areas (e.g.: multiple islands), users should be able to create buffer regions, and using those buffer regions, execute a query.
