### PR TITLE
Icon Tabs

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/IconRegistry.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/IconRegistry.java
@@ -3,14 +3,13 @@ package io.opensphere.mantle.icon;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import gnu.trove.list.TIntList;
 import gnu.trove.list.TLongList;
 import io.opensphere.mantle.icon.chooser.model.IconManagerPrefs;
 import io.opensphere.mantle.icon.chooser.model.IconModel;
-import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
 
 /**
  * The Interface IconRegistry.
@@ -89,14 +88,7 @@ public interface IconRegistry
      *
      * @return the observable list in which the collection names are defined.
      */
-    ObservableList<String> getCollectionNameSet();
-
-    /**
-     * Gets the set of all collection names in use in the registry.
-     *
-     * @return the collection names
-     */
-    Set<String> getCollectionNames();
+    ObservableSet<String> getCollectionNameSet();
 
     /**
      * Gets the element ids for icon id.

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/model/IconChooserModel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/model/IconChooserModel.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.log4j.Logger;
@@ -168,11 +167,8 @@ public class IconChooserModel
     private void updateCollectionNames()
     {
         LOG.info("Updating collection names.");
-        Set<String> set = myIconRecords.stream().map(r -> r.collectionNameProperty().get()).distinct()
-                .collect(Collectors.toSet());
-
-        // ensure the default sets are present:
-        set.add(IconRecord.FAVORITES_COLLECTION);
+        
+        Set<String> set = myIconRegistry.getCollectionNames();
 
         // ensure only the items in the set are present in the list:
         myCollectionNames.retainAll(set);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/model/IconChooserModel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/model/IconChooserModel.java
@@ -162,11 +162,11 @@ public class IconChooserModel
 
     public void addCollectionName(String collection)
     {
-    	if (!myCollectionNames.contains(collection))
-    	{
-    		myCollectionNames.add(collection);
-    		myIconRegistry.getCollectionNameSet().add(collection);
-    	}
+        if (!myCollectionNames.contains(collection))
+        {
+            myCollectionNames.add(collection);
+            myIconRegistry.getCollectionNameSet().add(collection);
+        }
     }
     
     /**

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/model/IconChooserModel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/model/IconChooserModel.java
@@ -160,6 +160,12 @@ public class IconChooserModel
         return myCollectionNames;
     }
 
+    /**
+     * Adds a new collection to the registry.
+     * Called when adding and saving new tabs.
+     *
+     * @param collection The collection to add.
+     */
     public void addCollectionName(String collection)
     {
         if (!myCollectionNames.contains(collection))

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/model/IconChooserModel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/model/IconChooserModel.java
@@ -160,6 +160,15 @@ public class IconChooserModel
         return myCollectionNames;
     }
 
+    public void addCollectionName(String collection)
+    {
+    	if (!myCollectionNames.contains(collection))
+    	{
+    		myCollectionNames.add(collection);
+    		myIconRegistry.getCollectionNameSet().add(collection);
+    	}
+    }
+    
     /**
      * Updates the list of collection names to match the unique set defined
      * within the icon records.
@@ -168,7 +177,7 @@ public class IconChooserModel
     {
         LOG.info("Updating collection names.");
         
-        Set<String> set = myIconRegistry.getCollectionNames();
+        Set<String> set = myIconRegistry.getCollectionNameSet();
 
         // ensure only the items in the set are present in the list:
         myCollectionNames.retainAll(set);

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/view/IconSelectionPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/view/IconSelectionPanel.java
@@ -105,13 +105,13 @@ public class IconSelectionPanel extends BorderPane
         addTabs(collectionNames);
         myIconChooserModel.getCollectionNames().addListener((final ListChangeListener.Change<? extends String> c) ->
         {
-        	c.next();
-        	List<? extends String> added = c.getAddedSubList();
-        	
-        	if (myIconTabs.getTabs().filtered(tab -> added.contains(tab.getText())).isEmpty())
-        	{    		
-        		addTabs(added);
-        	}
+            c.next();
+            List<? extends String> added = c.getAddedSubList();
+            
+            if (myIconTabs.getTabs().filtered(tab -> added.contains(tab.getText())).isEmpty())
+            {            
+                addTabs(added);
+            }
         });
 
         myIconTabs.getTabs().addListener((final ListChangeListener.Change<? extends Tab> c) ->
@@ -159,7 +159,7 @@ public class IconSelectionPanel extends BorderPane
 
     private void addTabs(List<? extends String> collectionNames)
     {
-    	for (final String collection : collectionNames)
+        for (final String collection : collectionNames)
         {
             IconGridView content;
             if (StringUtils.equalsIgnoreCase(IconRecord.FAVORITES_COLLECTION, collection))
@@ -200,10 +200,10 @@ public class IconSelectionPanel extends BorderPane
         myIconTabs.getTabs().add(myIconTabs.getTabs().size(), tab);
         myIconTabs.getSelectionModel().select(tab);
         tab.textProperty().addListener((obs, oldV, newV) -> {
-			if (tab.getTabEditPhase().equals(TabEditPhase.PERSISTING))
-			{
-				myIconChooserModel.addCollectionName(newV);
-			}
+            if (tab.getTabEditPhase().equals(TabEditPhase.PERSISTING))
+            {
+                myIconChooserModel.addCollectionName(newV);
+            }
         });
         tab.tabEditPhaseProperty().set(TabEditPhase.EDITING);
     }

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/view/IconSelectionPanel.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/view/IconSelectionPanel.java
@@ -15,8 +15,6 @@ import io.opensphere.core.util.lang.Pair;
 import io.opensphere.mantle.icon.IconRecord;
 import io.opensphere.mantle.icon.chooser.model.IconChooserModel;
 import io.opensphere.mantle.icon.chooser.model.IconModel;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.transformation.SortedList;
@@ -157,6 +155,11 @@ public class IconSelectionPanel extends BorderPane
         });
     }
 
+    /**
+     * Helper to avoid code duplication. Adds tabs when collections are updated, or the window is initialized.
+     *
+     * @param collectionNames List of collections to create tabs for.
+     */
     private void addTabs(List<? extends String> collectionNames)
     {
         for (final String collection : collectionNames)

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/IconRegistryImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/IconRegistryImpl.java
@@ -50,6 +50,7 @@ import io.opensphere.mantle.icon.config.v1.IconRegistryConfig;
 import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableSet;
 
 /**
  * The Class IconRegistryImpl.
@@ -107,7 +108,7 @@ public class IconRegistryImpl implements IconRegistry
     private final IconManagerPrefs myIconManagerPrefs = new IconManagerPrefs();
 
     /** An observable list of collection names. */
-    private final ObservableList<String> myCollectionNames = FXCollections.observableArrayList();
+    private final ObservableSet<String> myCollectionNames = FXCollections.observableSet();
 
     /**
      * Instantiates a new icon registry impl.
@@ -214,32 +215,9 @@ public class IconRegistryImpl implements IconRegistry
     }
 
     @Override
-    public ObservableList<String> getCollectionNameSet()
+    public ObservableSet<String> getCollectionNameSet()
     {
         return myCollectionNames;
-    }
-
-    @Override
-    public Set<String> getCollectionNames()
-    {
-        final Set<String> nameSet = New.set();
-        nameSet.add(IconRecord.DEFAULT_COLLECTION);
-        nameSet.add(IconRecord.USER_ADDED_COLLECTION);
-        nameSet.add(IconRecord.FAVORITES_COLLECTION);
-        myIconRegistryLock.lock();
-        try
-        {
-            myIconIdToIconRecordMap.forEachEntry((iconId, rec) ->
-            {
-                nameSet.add(rec.collectionNameProperty().get());
-                return true;
-            });
-        }
-        finally
-        {
-            myIconRegistryLock.unlock();
-        }
-        return nameSet;
     }
 
     @Override
@@ -789,6 +767,7 @@ public class IconRegistryImpl implements IconRegistry
         {
             record = new DefaultIconRecord(getId(provider, overrideId), provider);
             record.favoriteProperty().set(provider.isFavorite());
+            myCollectionNames.add(record.collectionNameProperty().get());
             myIconIdToIconRecordMap.put(record.idProperty().get(), record);
             myIconRecordToIconIdMap.put(record, record.idProperty().get());
             myIconRecords.add(record);
@@ -838,6 +817,10 @@ public class IconRegistryImpl implements IconRegistry
     /** Loads the icons. */
     private void load()
     {
+    	myCollectionNames.add(IconRecord.DEFAULT_COLLECTION);
+    	myCollectionNames.add(IconRecord.USER_ADDED_COLLECTION);
+    	myCollectionNames.add(IconRecord.FAVORITES_COLLECTION);
+    	
         final IconRegistryConfig config = myPrefs.getJAXBObject(IconRegistryConfig.class, PREFERENCE_KEY,
                 new IconRegistryConfig());
         if (config != null && config.getIconRecords() != null && !config.getIconRecords().isEmpty())

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/IconRegistryImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/IconRegistryImpl.java
@@ -817,10 +817,10 @@ public class IconRegistryImpl implements IconRegistry
     /** Loads the icons. */
     private void load()
     {
-    	myCollectionNames.add(IconRecord.DEFAULT_COLLECTION);
-    	myCollectionNames.add(IconRecord.USER_ADDED_COLLECTION);
-    	myCollectionNames.add(IconRecord.FAVORITES_COLLECTION);
-    	
+        myCollectionNames.add(IconRecord.DEFAULT_COLLECTION);
+        myCollectionNames.add(IconRecord.USER_ADDED_COLLECTION);
+        myCollectionNames.add(IconRecord.FAVORITES_COLLECTION);
+        
         final IconRegistryConfig config = myPrefs.getJAXBObject(IconRegistryConfig.class, PREFERENCE_KEY,
                 new IconRegistryConfig());
         if (config != null && config.getIconRecords() != null && !config.getIconRecords().isEmpty())

--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/IconRegistryImpl.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/impl/IconRegistryImpl.java
@@ -8,7 +8,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;


### PR DESCRIPTION
Fixes 290,291

## Proposed Changes

- Only track and update `myCollectionNames` observable set in `IconRegistry`
- Update set when icons are added and their collection does not exist
- Use set for collection names instead of scanning every icon record
- When new tab is added and saved, update collections
- When new collections are added, update tabs
  - doesn't loop