### PR TITLE
VORTEX-6075 Add data window should color icons with layer colors.

### DIFF
--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/util/ClockAndOrColorLabel.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/util/ClockAndOrColorLabel.java
@@ -78,6 +78,17 @@ public class ClockAndOrColorLabel extends JComponent
     }
 
     /**
+     * Colors the icon.
+     *
+     * @param color the new color
+     */
+    public void setColor(Color color)
+    {
+        myColor = color;
+        mixColorIntoIcon(myColor);
+    }
+
+    /**
      * Sets the type.
      *
      * @param dti the new type


### PR DESCRIPTION
Fixes VORTEX-6075

## Proposed Changes

  - Icons in the add data menu are colored based off the data group they are assigned to
  - Data groups with a single layer use the color of the layer for the icon
  - Data groups with more than one layer but have tile render properties use the color from the properties
  - Data groups that fall under neither default to white