### PR TITLE
Feature Action Drag&Drop

### DIFF
--- a/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/editor/ui/DragDropHandler.java
+++ b/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/editor/ui/DragDropHandler.java
@@ -3,7 +3,6 @@ package io.opensphere.featureactions.editor.ui;
 import java.util.List;
 
 import javafx.scene.control.ListCell;
-import javafx.scene.control.ListView;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.TransferMode;
@@ -32,8 +31,6 @@ public class DragDropHandler
      * The group being dragged.
      */
     private SimpleFeatureActionGroup myDragGroup;
-
-    private ListCell<SimpleFeatureAction> myDropTarget;
     
     /**
      * The list the drag item is coming from.
@@ -83,7 +80,6 @@ public class DragDropHandler
             if (db.hasString())
             {
                 event.acceptTransferModes(TransferMode.COPY_OR_MOVE);
-                myDropTarget = cell;
             }
         });
 
@@ -99,20 +95,19 @@ public class DragDropHandler
                 
                 if (cellAction == null)
                 {
-                	group.getActions().add(action);
+                    group.getActions().add(action);
                 }
                 else
                 {
-                	int featureIndex = group.getActions().indexOf(cellAction);
-                	featureIndex += featureIndex < myDragIndex ? 0 : 1;
+                    int featureIndex = group.getActions().indexOf(cellAction);
+                    featureIndex += featureIndex < myDragIndex ? 0 : 1;
 
-	                group.getActions().add(featureIndex, action);
+                    group.getActions().add(featureIndex, action);
                 }
                 
                 event.setDropCompleted(true);
                 
                 myDragAction = null;
-                myDropTarget = null;
             }
             else
             {
@@ -120,34 +115,6 @@ public class DragDropHandler
             }
         });
     }
-    
-//    public void handleListView(SimpleFeatureActionGroup group, ListView<SimpleFeatureAction> view)
-//    {
-//    	view.setOnDragDropped(event ->
-//    	{
-//    		Dragboard db = event.getDragboard();
-//    		if (db.hasString() && myDragAction != null)
-//    		{
-//    			SimpleFeatureAction action = myDragAction;
-//                group.getActions().remove(myDragIndex);
-//                if (myDropTarget != null)
-//                {
-//                	group.getActions().add(myDropTarget.getIndex()+1, action);
-//                }
-//                else
-//                {                	
-//                	group.getActions().add(action);
-//                }
-//                event.setDropCompleted(true);
-//                myDragAction = null;
-//                myDropTarget = null;
-//    		}
-//    		else
-//    		{
-//    			event.setDropCompleted(false);
-//    		}
-//    	});
-//    }
 
     /**
      * Handles dragging and dropping actions to other groups.
@@ -189,7 +156,6 @@ public class DragDropHandler
                     group.getActions().add(action);
                     event.setDropCompleted(true);
                     myDragAction = null;
-                    myDropTarget = null;
                 }
                 else if (myDragGroup != null)
                 {

--- a/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/editor/ui/SimpleFeatureActionEditorBinder.java
+++ b/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/editor/ui/SimpleFeatureActionEditorBinder.java
@@ -2,6 +2,7 @@ package io.opensphere.featureactions.editor.ui;
 
 import java.awt.Component;
 import java.awt.EventQueue;
+import java.util.Objects;
 import java.util.Set;
 
 import io.opensphere.controlpanels.layers.importdata.ImportDataController;
@@ -186,7 +187,7 @@ public class SimpleFeatureActionEditorBinder
         int indexOf = 0;
         for (TitledPane titled : myEditor.getAccordion().getPanes())
         {
-            if (((FeatureActionTitledPane)titled).getTitle().getText().equals(group.getGroupName()))
+            if (Objects.deepEquals(((FeatureActionTitledPane)titled).getTitle().getText(), group.getGroupName()))
             {
                 break;
             }


### PR DESCRIPTION
Fixes 297

## Proposed Changes
- Fix drag and drop removing cells when not dropping onto another cell
- Fix drag and drop not respecting drag direction
  - Dragging up will place _before_ a cell, dragging down will place _after_
- Fix drag and drop panes duplicating themselves somehow
- Fix pane names being null (not sure what causes) causing an exception and preventing their deletion