### PR TITLE
VORTEX-6099 Skip span

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/animation/impl/DefaultContinuousAnimationPlan.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/animation/impl/DefaultContinuousAnimationPlan.java
@@ -350,17 +350,28 @@ public class DefaultContinuousAnimationPlan extends DefaultAnimationPlan impleme
         TimeSpan parentSpan = getTimeSpanForState(new DefaultAnimationState(lastStep, state.getDirection()));
         TimeSpan limitedParentSpan = getLimitWindow().getIntersection(parentSpan);
         TimeSpan startSpan;
-        if (limitedParentSpan.contains(state.getActiveTimeSpan()))
+        long end, start;
+        if (limitedParentSpan != null)
         {
-            startSpan = state.getActiveTimeSpan();
+        	if (limitedParentSpan.contains(state.getActiveTimeSpan()))
+        	{
+        		startSpan = state.getActiveTimeSpan();
+        	}
+        	else
+        	{
+        		startSpan = forward ? TimeSpan.get(limitedParentSpan.getStart(), myActiveWindowDuration)
+        				: TimeSpan.get(myActiveWindowDuration, limitedParentSpan.getEnd());
+        	}
+        	end = limitedParentSpan.getEnd();
+        	start = limitedParentSpan.getStart();
         }
         else
         {
-            startSpan = forward ? TimeSpan.get(limitedParentSpan.getStart(), myActiveWindowDuration)
-                    : TimeSpan.get(myActiveWindowDuration, limitedParentSpan.getEnd());
+        	startSpan = state.getActiveTimeSpan();
+        	end = getLimitWindow().getEnd();
+        	start = getLimitWindow().getStart();
         }
-        long gap = forward ? limitedParentSpan.getEnd() - startSpan.getEnd()
-                : startSpan.getStart() - limitedParentSpan.getStart();
+        long gap = forward ? end - startSpan.getEnd() : startSpan.getStart() - start;
         long stepCount = gap / Milliseconds.get(getAdvanceDuration()).longValue();
         Duration adjustment = getAdvanceDuration().multiply(stepCount);
         TimeSpan lastSpan = forward ? startSpan.plus(adjustment) : startSpan.minus(adjustment);

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/animation/impl/DefaultContinuousAnimationPlan.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/animation/impl/DefaultContinuousAnimationPlan.java
@@ -353,23 +353,23 @@ public class DefaultContinuousAnimationPlan extends DefaultAnimationPlan impleme
         long end, start;
         if (limitedParentSpan != null)
         {
-        	if (limitedParentSpan.contains(state.getActiveTimeSpan()))
-        	{
-        		startSpan = state.getActiveTimeSpan();
-        	}
-        	else
-        	{
-        		startSpan = forward ? TimeSpan.get(limitedParentSpan.getStart(), myActiveWindowDuration)
-        				: TimeSpan.get(myActiveWindowDuration, limitedParentSpan.getEnd());
-        	}
-        	end = limitedParentSpan.getEnd();
-        	start = limitedParentSpan.getStart();
+            if (limitedParentSpan.contains(state.getActiveTimeSpan()))
+            {
+                startSpan = state.getActiveTimeSpan();
+            }
+            else
+            {
+                startSpan = forward ? TimeSpan.get(limitedParentSpan.getStart(), myActiveWindowDuration)
+                        : TimeSpan.get(myActiveWindowDuration, limitedParentSpan.getEnd());
+            }
+            end = limitedParentSpan.getEnd();
+            start = limitedParentSpan.getStart();
         }
         else
         {
-        	startSpan = state.getActiveTimeSpan();
-        	end = getLimitWindow().getEnd();
-        	start = getLimitWindow().getStart();
+            startSpan = state.getActiveTimeSpan();
+            end = getLimitWindow().getEnd();
+            start = getLimitWindow().getStart();
         }
         long gap = forward ? end - startSpan.getEnd() : startSpan.getStart() - start;
         long stepCount = gap / Milliseconds.get(getAdvanceDuration()).longValue();


### PR DESCRIPTION
Fixes VORTEX-6099

## Proposed Changes
- If we cannot get the intersection between the limit window and the full animation span, end before the skip. Instances where this would happen:
  - Time span ends immediately after skip
  - Time span ends during skip
  - Time span ends before skip, but not containing active span, and extension would place it inside the skip