### PR TITLE
ToolTip Text Color for Disabled Components

### DIFF
--- a/open-sphere-laf/open-sphere-dark-laf/src/main/java/io/opensphere/laf/dark/OpenSphereDarkLookAndFeel.java
+++ b/open-sphere-laf/open-sphere-dark-laf/src/main/java/io/opensphere/laf/dark/OpenSphereDarkLookAndFeel.java
@@ -293,7 +293,7 @@ public class OpenSphereDarkLookAndFeel extends MetalLookAndFeel
         final ColorUIResource col2 = OSDarkLAFUtils.getThirdColor(OpenSphereDarkLookAndFeel.getFocusColor(),
                 (Color)uiDefaults.get("TextField.inactiveBackground"));
         uiDefaults.put("ToolTip.background", col2);
-        uiDefaults.put("ToolTip.foregroundInactive", getBlack());
+        uiDefaults.put("ToolTip.foregroundInactive", OpenSphereDarkLookAndFeel.getBlack());
         uiDefaults.put("ToolTip.font", uiDefaults.get("Menu.font"));
 
         // Spinners

--- a/open-sphere-laf/open-sphere-dark-laf/src/main/java/io/opensphere/laf/dark/OpenSphereDarkLookAndFeel.java
+++ b/open-sphere-laf/open-sphere-dark-laf/src/main/java/io/opensphere/laf/dark/OpenSphereDarkLookAndFeel.java
@@ -293,7 +293,7 @@ public class OpenSphereDarkLookAndFeel extends MetalLookAndFeel
         final ColorUIResource col2 = OSDarkLAFUtils.getThirdColor(OpenSphereDarkLookAndFeel.getFocusColor(),
                 (Color)uiDefaults.get("TextField.inactiveBackground"));
         uiDefaults.put("ToolTip.background", col2);
-        uiDefaults.put("ToolTip.foregroundInactive", uiDefaults.get("ToolTip.foreground"));
+        uiDefaults.put("ToolTip.foregroundInactive", getBlack());
         uiDefaults.put("ToolTip.font", uiDefaults.get("Menu.font"));
 
         // Spinners

--- a/open-sphere-laf/open-sphere-dark-laf/src/main/java/io/opensphere/laf/dark/OpenSphereDarkLookAndFeel.java
+++ b/open-sphere-laf/open-sphere-dark-laf/src/main/java/io/opensphere/laf/dark/OpenSphereDarkLookAndFeel.java
@@ -293,6 +293,7 @@ public class OpenSphereDarkLookAndFeel extends MetalLookAndFeel
         final ColorUIResource col2 = OSDarkLAFUtils.getThirdColor(OpenSphereDarkLookAndFeel.getFocusColor(),
                 (Color)uiDefaults.get("TextField.inactiveBackground"));
         uiDefaults.put("ToolTip.background", col2);
+        uiDefaults.put("ToolTip.foregroundInactive", uiDefaults.get("ToolTip.foreground"));
         uiDefaults.put("ToolTip.font", uiDefaults.get("Menu.font"));
 
         // Spinners


### PR DESCRIPTION
Fixes

## Proposed Changes

  - The color of the text for disabled ToolTips is white instead of close-to black