### PR TITLE
VORTEX-6187: Fixing issue that removes settings panel from detail popup when layer is deactivated.

### DIFF
--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/layerdetail/LayerDetailPanel.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/layers/layerdetail/LayerDetailPanel.java
@@ -485,14 +485,14 @@ public class LayerDetailPanel extends JPanel
             myTabPane.setBackground(new Color(0, 0, 0, 0));
             ((JideTabbedPane)myTabPane).setTabShape(JideTabbedPane.SHAPE_ROUNDED_VSNET);
             myTabPane.setTabPlacement(SwingConstants.TOP);
-            
+
             myTabPane.addTab(DETAILS_TAB, getDetailsPanel());
             myTabPane.setSelectedIndex(0);
             myTabPane.setBackgroundAt(0, Colors.LF_PRIMARY2);
             myTabPane.setForeground(Color.WHITE);
-            
+
             myTabPane.addChangeListener(new TabChangeListener());
-            
+
             myTabPane.addTab(SETTINGS_TAB, getSettingsPanel());
             if (!Boolean.getBoolean("opensphere.productionMode"))
             {
@@ -586,8 +586,7 @@ public class LayerDetailPanel extends JPanel
      * Update ui details.
      */
     private void updateUIDetails()
-    {
-        getTabPane().remove(getSettingsPanel());
+    { 
         if (!Boolean.getBoolean("opensphere.productionMode"))
         {
             getTabPane().remove(getDebugPanel());
@@ -607,11 +606,14 @@ public class LayerDetailPanel extends JPanel
                         timeSpan);
             }
             getLayerTimeLabel().setText(layerTimeString);
-            getSettingsPanel().removeAll();
             final Component settingsComponent = myDGI.getAssistant().getSettingsUIComponent(getSettingsPanel().getSize(), myDGI);
             if (settingsComponent != null)
             {
-                myTabPane.addTab(SETTINGS_TAB, getSettingsPanel());
+                if (myTabPane.indexOfTab(SETTINGS_TAB) == -1)
+                {
+                    myTabPane.addTab(SETTINGS_TAB, getSettingsPanel());
+                }
+                getSettingsPanel().removeAll();
                 getSettingsPanel().add(settingsComponent, BorderLayout.CENTER);
                 getSettingsPanel().invalidate();
                 getSettingsPanel().revalidate();


### PR DESCRIPTION
Fixes VORTEX-6187

## Proposed Changes
  - Don't hide the settings panel when the layer is deactivated.
