### PR TITLE
VORTEX-6192: Updating version number to 5.2.6.1

### DIFF
--- a/open-sphere-base/analysis/pom.xml
+++ b/open-sphere-base/analysis/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere-base</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-base/auxiliary/pom.xml
+++ b/open-sphere-base/auxiliary/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere-base</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-base/column-mappings/pom.xml
+++ b/open-sphere-base/column-mappings/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere-base</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 	<artifactId>column-mappings</artifactId>
 	<packaging>jar</packaging>

--- a/open-sphere-base/control-panels/pom.xml
+++ b/open-sphere-base/control-panels/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere-base</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-base/core/pom.xml
+++ b/open-sphere-base/core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere-base</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-base/mantle/pom.xml
+++ b/open-sphere-base/mantle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere-base</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-base/overlay/pom.xml
+++ b/open-sphere-base/overlay/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere-base</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-base/pom.xml
+++ b/open-sphere-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<artifactId>open-sphere-base</artifactId>

--- a/open-sphere-base/test-support/pom.xml
+++ b/open-sphere-base/test-support/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere-base</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-base/xyz-tile/pom.xml
+++ b/open-sphere-base/xyz-tile/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere-base</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-config/default-config/pom.xml
+++ b/open-sphere-config/default-config/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.open-sphere</groupId>
         <artifactId>open-sphere-config</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
     <name>${application.display.name} Default Configuration</name>
     <build>

--- a/open-sphere-config/pom.xml
+++ b/open-sphere-config/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 	<name>${application.display.name} Configurations</name>
 	<packaging>pom</packaging>

--- a/open-sphere-development-utilities/open-sphere-launcher-creator/pom.xml
+++ b/open-sphere-development-utilities/open-sphere-launcher-creator/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.open-sphere.development</groupId>
         <artifactId>open-sphere-development-utilities</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
 
     <artifactId>open-sphere-launcher-creator</artifactId>

--- a/open-sphere-development-utilities/plugin-archetype/pom.xml
+++ b/open-sphere-development-utilities/plugin-archetype/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.open-sphere.development</groupId>
 		<artifactId>development-utilities</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<artifactId>plugin-archetype</artifactId>

--- a/open-sphere-development-utilities/pom.xml
+++ b/open-sphere-development-utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.open-sphere</groupId>
         <artifactId>open-sphere</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
 
     <groupId>io.open-sphere.development</groupId>

--- a/open-sphere-install/open-sphere-install-linux64/pom.xml
+++ b/open-sphere-install/open-sphere-install-linux64/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.open-sphere.install</groupId>
         <artifactId>open-sphere-install</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
     <artifactId>open-sphere-install-linux64</artifactId>
     <name>${application.display.name} Installer (Linux 64-Bit)</name>

--- a/open-sphere-install/open-sphere-install-natives-linux64/pom.xml
+++ b/open-sphere-install/open-sphere-install-natives-linux64/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.open-sphere.install</groupId>
         <artifactId>open-sphere-install</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
     <artifactId>open-sphere-install-natives-linux64</artifactId>
     <name>${application.display.name} Native Libraries - Linux64</name>

--- a/open-sphere-install/open-sphere-install-natives-windows64/pom.xml
+++ b/open-sphere-install/open-sphere-install-natives-windows64/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.open-sphere.install</groupId>
         <artifactId>open-sphere-install</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
     <artifactId>open-sphere-install-natives-windows64</artifactId>
     <name>${application.display.name} Native Libraries - Windows64</name>

--- a/open-sphere-install/open-sphere-install-panels/pom.xml
+++ b/open-sphere-install/open-sphere-install-panels/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.open-sphere.install</groupId>
         <artifactId>open-sphere-install</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
     <artifactId>open-sphere-install-panels</artifactId>
     <name>${application.display.name} Custom Installer Panels</name>

--- a/open-sphere-install/open-sphere-install-windows64/pom.xml
+++ b/open-sphere-install/open-sphere-install-windows64/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.open-sphere.install</groupId>
         <artifactId>open-sphere-install</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
     <artifactId>open-sphere-install-windows64</artifactId>
     <name>${application.display.name} Installer (Windows 64-Bit)</name>

--- a/open-sphere-install/open-sphere-izpack-configuration/pom.xml
+++ b/open-sphere-install/open-sphere-izpack-configuration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.open-sphere.install</groupId>
         <artifactId>open-sphere-install</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
     <artifactId>open-sphere-izpack-configuration</artifactId>
     <name>${application.display.name} IZPack Installer Configuration</name>

--- a/open-sphere-install/pom.xml
+++ b/open-sphere-install/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.open-sphere</groupId>
         <artifactId>open-sphere</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
     <groupId>io.open-sphere.install</groupId>
     <artifactId>open-sphere-install</artifactId>

--- a/open-sphere-laf/open-sphere-dark-laf/pom.xml
+++ b/open-sphere-laf/open-sphere-dark-laf/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere-laf</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<artifactId>open-sphere-dark-laf</artifactId>

--- a/open-sphere-laf/pom.xml
+++ b/open-sphere-laf/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<artifactId>open-sphere-laf</artifactId>

--- a/open-sphere-maven-plugins/install-descriptor-maven-plugin/pom.xml
+++ b/open-sphere-maven-plugins/install-descriptor-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.open-sphere.build</groupId>
         <artifactId>open-sphere-maven-plugins</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
 
     <artifactId>install-descriptor-maven-plugin</artifactId>

--- a/open-sphere-maven-plugins/pom.xml
+++ b/open-sphere-maven-plugins/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.open-sphere</groupId>
         <artifactId>open-sphere</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
 
     <groupId>io.open-sphere.build</groupId>

--- a/open-sphere-plugins/arcgis/pom.xml
+++ b/open-sphere-plugins/arcgis/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/city/pom.xml
+++ b/open-sphere-plugins/city/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/csv-common/pom.xml
+++ b/open-sphere-plugins/csv-common/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/csv/pom.xml
+++ b/open-sphere-plugins/csv/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.open-sphere.plugins</groupId>
         <artifactId>open-sphere-plugins</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/feature-actions/pom.xml
+++ b/open-sphere-plugins/feature-actions/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/feedback/pom.xml
+++ b/open-sphere-plugins/feedback/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/filter-builder/pom.xml
+++ b/open-sphere-plugins/filter-builder/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 

--- a/open-sphere-plugins/geopackage/pom.xml
+++ b/open-sphere-plugins/geopackage/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/google-places/pom.xml
+++ b/open-sphere-plugins/google-places/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 

--- a/open-sphere-plugins/heatmap/pom.xml
+++ b/open-sphere-plugins/heatmap/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.open-sphere.plugins</groupId>
         <artifactId>open-sphere-plugins</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/hud/pom.xml
+++ b/open-sphere-plugins/hud/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/icon-manager/pom.xml
+++ b/open-sphere-plugins/icon-manager/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.open-sphere.plugins</groupId>
     <artifactId>open-sphere-plugins</artifactId>
-    <version>5.2.6</version>
+    <version>5.2.6.1</version>
   </parent>
   <artifactId>icon-manager</artifactId>
   <name>Icon Manager</name>

--- a/open-sphere-plugins/imagery/pom.xml
+++ b/open-sphere-plugins/imagery/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/import/pom.xml
+++ b/open-sphere-plugins/import/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/infinity/pom.xml
+++ b/open-sphere-plugins/infinity/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/kml/pom.xml
+++ b/open-sphere-plugins/kml/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/mapbox/pom.xml
+++ b/open-sphere-plugins/mapbox/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 

--- a/open-sphere-plugins/mapzen/pom.xml
+++ b/open-sphere-plugins/mapzen/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<artifactId>mapzen</artifactId>

--- a/open-sphere-plugins/merge/pom.xml
+++ b/open-sphere-plugins/merge/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/my-places/pom.xml
+++ b/open-sphere-plugins/my-places/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.open-sphere.plugins</groupId>
         <artifactId>open-sphere-plugins</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/ogc-server/pom.xml
+++ b/open-sphere-plugins/ogc-server/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/open-sensor-hub/pom.xml
+++ b/open-sphere-plugins/open-sensor-hub/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/open-street-map/pom.xml
+++ b/open-sphere-plugins/open-street-map/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/pom.xml
+++ b/open-sphere-plugins/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.open-sphere</groupId>
         <artifactId>open-sphere</artifactId>
-        <version>5.2.6</version>
+        <version>5.2.6.1</version>
     </parent>
 
     <groupId>io.open-sphere.plugins</groupId>

--- a/open-sphere-plugins/search/pom.xml
+++ b/open-sphere-plugins/search/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/open-sphere-plugins/shapefile/pom.xml
+++ b/open-sphere-plugins/shapefile/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 

--- a/open-sphere-plugins/stk-terrain/pom.xml
+++ b/open-sphere-plugins/stk-terrain/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 

--- a/open-sphere-plugins/subterrain/pom.xml
+++ b/open-sphere-plugins/subterrain/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 

--- a/open-sphere-plugins/terrain-profile/pom.xml
+++ b/open-sphere-plugins/terrain-profile/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 

--- a/open-sphere-plugins/view-quick-picker/pom.xml
+++ b/open-sphere-plugins/view-quick-picker/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 	<artifactId>view-quick-picker</artifactId>
 	<name>view-quick-picker</name>

--- a/open-sphere-plugins/wfs/pom.xml
+++ b/open-sphere-plugins/wfs/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 

--- a/open-sphere-plugins/wms/pom.xml
+++ b/open-sphere-plugins/wms/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 

--- a/open-sphere-plugins/wps/pom.xml
+++ b/open-sphere-plugins/wps/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.open-sphere.plugins</groupId>
 		<artifactId>open-sphere-plugins</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 

--- a/open-sphere-suite/pom.xml
+++ b/open-sphere-suite/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.open-sphere</groupId>
 		<artifactId>open-sphere</artifactId>
-		<version>5.2.6</version>
+		<version>5.2.6.1</version>
 	</parent>
 
 	<groupId>io.open-sphere.suite</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.open-sphere</groupId>
 	<artifactId>open-sphere</artifactId>
-	<version>5.2.6</version>
+	<version>5.2.6.1</version>
 	<packaging>pom</packaging>
 	<name>${application.display.name}</name>
 	<description>


### PR DESCRIPTION
Fixes VORTEX-6192

## Proposed Changes
  - Update POM Version to 5.2.6.1
