### PR TITLE
VORTEX-6226: Increase Plugin Init Timeout

### DIFF
--- a/open-sphere-base/core/src/main/resources/system.properties
+++ b/open-sphere-base/core/src/main/resources/system.properties
@@ -121,7 +121,7 @@ opensphere.pipeline.highAccuracy.threshold=750000
 #opensphere.pipeline.gpuMemorySizeBytes=2147483648
 
 # Max amount of time we have to initialize all the plugins
-opensphere.pluginInit.timeoutMs=60000
+opensphere.pluginInit.timeoutMs=300000
 
 # Path to the local database storage.
 opensphere.db.path=${opensphere.path.runtime}/db


### PR DESCRIPTION
Fixes VORTEX-6226

## Proposed Changes

  - Plugin init timeout increased 5x to 5 minutes total