### PR TITLE
Ft quickcopy

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/appl/MenuInit.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/appl/MenuInit.java
@@ -367,21 +367,21 @@ public class MenuInit
         {
             toolbox.getMapManager().getStandardViewer().resetView();
             Quantify.collectMetric("mist3d.menu-bar.edit.units.reset-to-default");
-        },
-        KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_DOWN_MASK)));
+        }, KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_DOWN_MASK)));
 
-        //        // Add toolbar item
-        //        final JCheckBoxMenuItem toolbarItem = new JCheckBoxMenuItem("Toolbar");
-        //        toolbarItem.setSelected(toolbox.getUIRegistry().getToolbarComponentRegistry().getToolbarManager().isVisible());
-        //        toolbarItem.addActionListener(new ActionListener()
-        //        {
-        //            @Override
-        //            public void actionPerformed(ActionEvent arg0)
-        //            {
-        //                toolbox.getUIRegistry().getToolbarComponentRegistry().getToolbarManager().setVisible(toolbarItem.isSelected());
-        //            }
-        //        });
-        //        viewMenu.add(toolbarItem);
+        // // Add toolbar item
+        // final JCheckBoxMenuItem toolbarItem = new
+        // JCheckBoxMenuItem("Toolbar");
+        // toolbarItem.setSelected(toolbox.getUIRegistry().getToolbarComponentRegistry().getToolbarManager().isVisible());
+        // toolbarItem.addActionListener(new ActionListener()
+        // {
+        // @Override
+        // public void actionPerformed(ActionEvent arg0)
+        // {
+        // toolbox.getUIRegistry().getToolbarComponentRegistry().getToolbarManager().setVisible(toolbarItem.isSelected());
+        // }
+        // });
+        // viewMenu.add(toolbarItem);
 
         // Add Projection
         mbr.getMenu(MenuBarRegistry.MAIN_MENU_BAR, MenuBarRegistry.VIEW_MENU, MenuBarRegistry.PROJECTION_MENU);
@@ -455,8 +455,7 @@ public class MenuInit
         final JCheckBoxMenuItem terrainLock = new JCheckBoxMenuItem("Lock Terrain");
         terrainLock.addActionListener(e ->
         {
-            Quantify.collectEnableDisableMetric("mist3d.menu-bar.tools.lock-terrain",
-                    terrainLock.isSelected());
+            Quantify.collectEnableDisableMetric("mist3d.menu-bar.tools.lock-terrain", terrainLock.isSelected());
             AbstractProjection.setTerrainLocked(terrainLock.isSelected());
         });
         return terrainLock;

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/map/MapManagerMenuProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/map/MapManagerMenuProvider.java
@@ -25,7 +25,7 @@ import io.opensphere.core.mgrs.UTM;
 import io.opensphere.core.model.Altitude.ReferenceLevel;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.Position;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.length.Length;
 import io.opensphere.core.util.AwesomeIconSolid;
 import io.opensphere.core.util.collections.New;
@@ -70,7 +70,7 @@ public class MapManagerMenuProvider
                 {
                     if (myUnitsRegistry != null)
                     {
-                        Class<? extends Angle> angleUnits = myUnitsRegistry.getPreferredUnits(Angle.class);
+                        Class<? extends Coordinates> angleUnits = myUnitsRegistry.getPreferredUnits(Coordinates.class);
                         String label = pos.toDisplayString(angleUnits, (Class<? extends Length>)null);
 
                         try

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/model/GeographicPosition.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/model/GeographicPosition.java
@@ -6,7 +6,7 @@ import java.util.List;
 import io.opensphere.core.math.Vector2d;
 import io.opensphere.core.math.Vector3d;
 import io.opensphere.core.model.Altitude.ReferenceLevel;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.angle.DecimalDegrees;
 import io.opensphere.core.units.length.Length;
 
@@ -265,13 +265,13 @@ public class GeographicPosition implements Position, Serializable
      * @param lengthUnits The length units.
      * @return The display string.
      */
-    public String toDisplayString(Class<? extends Angle> angleUnits, Class<? extends Length> lengthUnits)
+    public String toDisplayString(Class<? extends Coordinates> angleUnits, Class<? extends Length> lengthUnits)
     {
         StringBuilder sb = new StringBuilder();
         if (angleUnits != null)
         {
-            Angle lat = Angle.create(angleUnits, getLat());
-            Angle lon = Angle.create(angleUnits, getLon());
+            Coordinates lat = Coordinates.create(angleUnits, getLat());
+            Coordinates lon = Coordinates.create(angleUnits, getLon());
             sb.append(lat.toShortLabelString(15, 6, 'N', 'S')).append(' ').append(lon.toShortLabelString(15, 6, 'E', 'W'));
         }
         if (lengthUnits != null)

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/AngleUnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/AngleUnitsProvider.java
@@ -28,6 +28,7 @@ public final class AngleUnitsProvider extends AbstractUnitsProvider<Angle>
         units.add(DegreesMinutesSeconds.class);
         units.add(DegDecimalMin.class);
         units.add(DecimalDegrees.class);
+        units.add(MGRS.class);
         setPreferredUnits(units.get(0));
     }
 

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/AngleUnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/AngleUnitsProvider.java
@@ -10,7 +10,7 @@ import io.opensphere.core.util.lang.ImpossibleException;
 /**
  * A units provider for angle units.
  */
-public final class AngleUnitsProvider extends AbstractUnitsProvider<Angle>
+public final class AngleUnitsProvider extends AbstractUnitsProvider<Coordinates>
 {
     /**
      * Constructor. This initializes the units provider with the following
@@ -24,7 +24,7 @@ public final class AngleUnitsProvider extends AbstractUnitsProvider<Angle>
      */
     public AngleUnitsProvider()
     {
-        List<Class<? extends Angle>> units = getAvailableUnitsUnsync();
+        List<Class<? extends Coordinates>> units = getAvailableUnitsUnsync();
         units.add(DegreesMinutesSeconds.class);
         units.add(DegDecimalMin.class);
         units.add(DecimalDegrees.class);
@@ -33,59 +33,59 @@ public final class AngleUnitsProvider extends AbstractUnitsProvider<Angle>
     }
 
     @Override
-    public <T extends Angle> T convert(Class<T> desiredType, Angle source) throws InvalidUnitsException
+    public <T extends Coordinates> T convert(Class<T> desiredType, Coordinates source) throws InvalidUnitsException
     {
-        return Angle.create(desiredType, source);
+        return Coordinates.create(desiredType, source);
     }
 
     @Override
-    public <T extends Angle> T fromUnitsAndMagnitude(Class<T> type, Number magnitude) throws InvalidUnitsException
+    public <T extends Coordinates> T fromUnitsAndMagnitude(Class<T> type, Number magnitude) throws InvalidUnitsException
     {
-        return Angle.create(type, magnitude.doubleValue());
+        return Coordinates.create(type, magnitude.doubleValue());
     }
 
     @Override
-    public Class<? extends Angle> getDisplayClass(Angle value)
+    public Class<? extends Coordinates> getDisplayClass(Coordinates value)
     {
         return value.getClass();
     }
 
     @Override
-    public String getLongLabel(Class<? extends Angle> type, boolean plural) throws InvalidUnitsException
+    public String getLongLabel(Class<? extends Coordinates> type, boolean plural) throws InvalidUnitsException
     {
-        return Angle.getLongLabel(type);
+        return Coordinates.getLongLabel(type);
     }
 
     @Override
-    public String getSelectionLabel(Class<? extends Angle> type) throws InvalidUnitsException
+    public String getSelectionLabel(Class<? extends Coordinates> type) throws InvalidUnitsException
     {
-        return Angle.getSelectionLabel(type);
+        return Coordinates.getSelectionLabel(type);
     }
 
     @Override
-    public String getShortLabel(Class<? extends Angle> type, boolean plural) throws InvalidUnitsException
+    public String getShortLabel(Class<? extends Coordinates> type, boolean plural) throws InvalidUnitsException
     {
-        return Angle.getShortLabel(type);
+        return Coordinates.getShortLabel(type);
     }
 
     @Override
-    public Class<Angle> getSuperType()
+    public Class<Coordinates> getSuperType()
     {
-        return Angle.class;
+        return Coordinates.class;
     }
 
     @Override
-    public Class<? extends Angle> getUnitsWithLongLabel(String label)
+    public Class<? extends Coordinates> getUnitsWithLongLabel(String label)
     {
         Lock lock = getLock();
         lock.lock();
         try
         {
-            for (Class<? extends Angle> type : getAvailableUnitsUnsync())
+            for (Class<? extends Coordinates> type : getAvailableUnitsUnsync())
             {
                 try
                 {
-                    if (Angle.getLongLabel(type).equalsIgnoreCase(label) || Angle.getLongLabel(type).equalsIgnoreCase(label))
+                    if (Coordinates.getLongLabel(type).equalsIgnoreCase(label) || Coordinates.getLongLabel(type).equalsIgnoreCase(label))
                     {
                         return type;
                     }
@@ -104,7 +104,7 @@ public final class AngleUnitsProvider extends AbstractUnitsProvider<Angle>
     }
 
     @Override
-    public String toShortLabelString(Angle obj)
+    public String toShortLabelString(Coordinates obj)
     {
         return obj.toShortLabelString();
     }
@@ -112,12 +112,12 @@ public final class AngleUnitsProvider extends AbstractUnitsProvider<Angle>
     @Override
     protected Class<? extends Number> getValueType()
     {
-        return Angle.VALUE_TYPE;
+        return Coordinates.VALUE_TYPE;
     }
 
     @Override
-    protected void testUnits(Class<? extends Angle> type) throws InvalidUnitsException
+    protected void testUnits(Class<? extends Coordinates> type) throws InvalidUnitsException
     {
-        Angle.create(type, 0.);
+        Coordinates.create(type, 0.);
     }
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/Coordinates.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/Coordinates.java
@@ -11,7 +11,7 @@ import io.opensphere.core.util.lang.ExpectedCloneableException;
 /**
  * A formatting-aware representation of an angle.
  */
-public abstract class Angle implements Cloneable, Serializable, Comparable<Angle>, JAXBable<JAXBAngle>
+public abstract class Coordinates implements Cloneable, Serializable, Comparable<Coordinates>, JAXBable<JAXBAngle>
 {
     /** Serial version UID. */
     private static final long serialVersionUID = 1L;
@@ -34,13 +34,13 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      * @throws InvalidUnitsException If the type is invalid.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Angle> T create(Class<T> type, Angle from) throws InvalidUnitsException
+    public static <T extends Coordinates> T create(Class<T> type, Coordinates from) throws InvalidUnitsException
     {
         if (type.isInstance(from))
         {
             return (T)from;
         }
-        return UnitsUtilities.create(type, Angle.class, from);
+        return UnitsUtilities.create(type, Coordinates.class, from);
     }
 
     /**
@@ -52,7 +52,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      * @return The new angle object.
      * @throws InvalidUnitsException If the type is invalid.
      */
-    public static <T extends Angle> T create(Class<T> type, double magnitude) throws InvalidUnitsException
+    public static <T extends Coordinates> T create(Class<T> type, double magnitude) throws InvalidUnitsException
     {
         return UnitsUtilities.create(type, VALUE_TYPE, Double.valueOf(magnitude));
     }
@@ -65,7 +65,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      *         instantiated.
      * @throws InvalidUnitsException If the angle type is invalid.
      */
-    public static String getLongLabel(Class<? extends Angle> type) throws InvalidUnitsException
+    public static String getLongLabel(Class<? extends Coordinates> type) throws InvalidUnitsException
     {
         return create(type, 0.).getLongLabel();
     }
@@ -78,7 +78,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      * @return The label.
      * @throws InvalidUnitsException If the type is invalid.
      */
-    public static String getSelectionLabel(Class<? extends Angle> type) throws InvalidUnitsException
+    public static String getSelectionLabel(Class<? extends Coordinates> type) throws InvalidUnitsException
     {
         return create(type, 0.).getSelectionLabel();
     }
@@ -91,7 +91,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      *         instantiated.
      * @throws InvalidUnitsException If the angle type is invalid.
      */
-    public static String getShortLabel(Class<? extends Angle> type) throws InvalidUnitsException
+    public static String getShortLabel(Class<? extends Coordinates> type) throws InvalidUnitsException
     {
         return create(type, 0.).getShortLabel();
     }
@@ -101,17 +101,17 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      *
      * @param magnitude The magnitude of the angle in degrees.
      */
-    protected Angle(double magnitude)
+    protected Coordinates(double magnitude)
     {
         myMagnitude = magnitude % 360.;
     }
 
     @Override
-    public Angle clone()
+    public Coordinates clone()
     {
         try
         {
-            return (Angle)super.clone();
+            return (Coordinates)super.clone();
         }
         catch (CloneNotSupportedException e)
         {
@@ -120,7 +120,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
     }
 
     @Override
-    public int compareTo(Angle o)
+    public int compareTo(Coordinates o)
     {
         double delta = getMagnitude() - o.getMagnitude();
         return delta < -MathUtil.DBL_EPSILON ? -1 : delta > MathUtil.DBL_EPSILON ? 1 : 0;
@@ -137,7 +137,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
         {
             return false;
         }
-        Angle other = (Angle)obj;
+        Coordinates other = (Coordinates)obj;
         return Math.abs(getMagnitude() - other.getMagnitude()) <= MathUtil.DBL_EPSILON;
     }
 

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/Coordinates.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/Coordinates.java
@@ -27,10 +27,10 @@ public abstract class Coordinates implements Cloneable, Serializable, Comparable
      * the input angle is already in the requested units, it will be returned
      * as-is.
      *
-     * @param <T> The type of the angle object.
-     * @param type The type of the angle object.
-     * @param from The source angle object.
-     * @return The new angle object.
+     * @param <T> The type of the Coordinates object.
+     * @param type The type of the Coordinates object.
+     * @param from The source Coordinates object.
+     * @return The new Coordinates object.
      * @throws InvalidUnitsException If the type is invalid.
      */
     @SuppressWarnings("unchecked")
@@ -44,7 +44,7 @@ public abstract class Coordinates implements Cloneable, Serializable, Comparable
     }
 
     /**
-     * Create a new angle object.
+     * Create a new Coordinates object.
      *
      * @param <T> The type of the angle object.
      * @param type The type of the angle object.

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DecimalDegrees.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DecimalDegrees.java
@@ -3,10 +3,10 @@ package io.opensphere.core.units.angle;
 /**
  * An angle represented as decimal degrees.
  */
-public final class DecimalDegrees extends Angle
+public final class DecimalDegrees extends Coordinates
 {
     /** Long label. */
-    public static final String DEGREES_LONG_LABEL = "decimal degrees";
+    public static final String DEGREES_LONG_LABEL = "Decimal Degrees";
 
     /** Short label. */
     public static final String DEGREES_SHORT_LABEL = "\u00B0";
@@ -19,7 +19,7 @@ public final class DecimalDegrees extends Angle
      *
      * @param ang The other angle.
      */
-    public DecimalDegrees(Angle ang)
+    public DecimalDegrees(Coordinates ang)
     {
         super(ang.getMagnitude());
     }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegDecimalMin.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegDecimalMin.java
@@ -4,7 +4,7 @@ import io.opensphere.core.model.LatLonAlt;
 
 /** For formatting angles (i.e., lat/lon) in degrees and decimal minutes. */
 @SuppressWarnings("serial")
-public class DegDecimalMin extends Angle
+public class DegDecimalMin extends Coordinates
 {
     /** The precision for angular minutes. */
     private static final int MINUTES_PRECISION = 3;
@@ -22,7 +22,7 @@ public class DegDecimalMin extends Angle
     @Override
     public String getLongLabel()
     {
-        return "degrees decimal minutes";
+        return "Degrees Decimal Minutes";
     }
 
     @Override

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegreesMinutesSeconds.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegreesMinutesSeconds.java
@@ -186,7 +186,7 @@ public final class DegreesMinutesSeconds extends Coordinates
     }
 
     /**
-     * Construct this angle from another angle.
+     * Construct this Coordinate from another Coordinate.
      *
      * @param ang The other angle.
      */
@@ -198,7 +198,7 @@ public final class DegreesMinutesSeconds extends Coordinates
     /**
      * Constructor.
      *
-     * @param degrees The magnitude of the angle in degrees.
+     * @param degrees The magnitude of the Coordinate in degrees.
      */
     public DegreesMinutesSeconds(double degrees)
     {
@@ -248,7 +248,7 @@ public final class DegreesMinutesSeconds extends Coordinates
     }
 
     /**
-     * Get the integer degrees portion of the angle.
+     * Get the integer degrees portion of the Coordinate.
      *
      * @return The degrees.
      */
@@ -258,7 +258,7 @@ public final class DegreesMinutesSeconds extends Coordinates
     }
 
     /**
-     * Get the integer minutes portion of the angle.
+     * Get the integer minutes portion of the Coordinate.
      *
      * @return The minutes.
      */
@@ -269,7 +269,7 @@ public final class DegreesMinutesSeconds extends Coordinates
     }
 
     /**
-     * Get the seconds portion of the angle.
+     * Get the seconds portion of the Coordinate.
      *
      * @return The seconds.
      */

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegreesMinutesSeconds.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegreesMinutesSeconds.java
@@ -6,10 +6,10 @@ import io.opensphere.core.util.MathUtil;
 /**
  * An angle represented as degrees/minutes/seconds.
  */
-public final class DegreesMinutesSeconds extends Angle
+public final class DegreesMinutesSeconds extends Coordinates
 {
     /** Long label. */
-    public static final String DMS_LONG_LABEL = "degrees minutes seconds";
+    public static final String DMS_LONG_LABEL = "Degrees Minutes Seconds";
 
     /** Short label. */
     public static final String DMS_SHORT_LABEL = "\u00B0'\"";
@@ -190,7 +190,7 @@ public final class DegreesMinutesSeconds extends Angle
      *
      * @param ang The other angle.
      */
-    public DegreesMinutesSeconds(Angle ang)
+    public DegreesMinutesSeconds(Coordinates ang)
     {
         super(ang.getMagnitude());
     }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/JAXBAngle.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/JAXBAngle.java
@@ -10,25 +10,25 @@ import io.opensphere.core.util.JAXBWrapper;
 import io.opensphere.core.util.Utilities;
 
 /**
- * Wrapper for an {@link Angle} that can be marshalled and unmarshalled using
+ * Wrapper for an {@link Coordinates} that can be marshalled and unmarshalled using
  * JAXB.
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-public class JAXBAngle implements JAXBWrapper<Angle>
+public class JAXBAngle implements JAXBWrapper<Coordinates>
 {
     /** The magnitude. */
     private double myMagnitude;
 
     /** The units. */
-    private Class<? extends Angle> myUnits;
+    private Class<? extends Coordinates> myUnits;
 
     /**
      * Constructor.
      *
      * @param angle The wrapped angle.
      */
-    public JAXBAngle(Angle angle)
+    public JAXBAngle(Coordinates angle)
     {
         myUnits = angle.getClass();
         myMagnitude = angle.getMagnitude();
@@ -59,9 +59,9 @@ public class JAXBAngle implements JAXBWrapper<Angle>
     }
 
     @Override
-    public Angle getWrappedObject()
+    public Coordinates getWrappedObject()
     {
-        return Angle.create(myUnits, myMagnitude);
+        return Coordinates.create(myUnits, myMagnitude);
     }
 
     @Override

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
@@ -1,18 +1,13 @@
 package io.opensphere.core.units.angle;
 
-import io.opensphere.core.mgrs.MGRSConverter;
-
 public class MGRS extends Coordinates
 
 {
 
     /**
-     * 
+     * The serial ID.
      */
     private static final long serialVersionUID = 8396025878700604825L;
-
-    /** An MGRS converter. */
-    static final MGRSConverter MGRS_CONVERTER = new MGRSConverter();
 
     /**
      * Construct with a specified value in degrees.

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
@@ -2,7 +2,7 @@ package io.opensphere.core.units.angle;
 
 import io.opensphere.core.mgrs.MGRSConverter;
 
-public class MGRS extends Angle
+public class MGRS extends Coordinates
 
 {
 

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
@@ -1,0 +1,63 @@
+package io.opensphere.core.units.angle;
+
+import io.opensphere.core.mgrs.MGRSConverter;
+
+public class MGRS extends Angle
+
+{
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 8396025878700604825L;
+
+    /** An MGRS converter. */
+    static final MGRSConverter MGRS_CONVERTER = new MGRSConverter();
+
+    /**
+     * Construct with a specified value in degrees.
+     *
+     * @param magnitude degrees
+     */
+    public MGRS(double magnitude)
+    {
+        super(magnitude);
+    }
+
+    @Override
+    public String getLongLabel()
+    {
+        return "MGRS";
+    }
+
+    @Override
+    public String getShortLabel()
+    {
+        return "MGRS";
+    }
+
+    @Override
+    public String toShortLabelString()
+    {
+        return "";
+    }
+
+    @Override
+    public String toShortLabelString(char pos, char neg)
+    {
+        return "";
+    }
+
+    @Override
+    public String toShortLabelString(int width, int precision)
+    {
+        return "";
+    }
+
+    @Override
+    public String toShortLabelString(int width, int precision, char positive, char negative)
+    {
+        return "";
+    }
+
+}

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/AngleUnitsProviderTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/AngleUnitsProviderTest.java
@@ -36,17 +36,17 @@ public class AngleUnitsProviderTest
     @Test
     public void testAddAndRemoveAngleType() throws InvalidUnitsException
     {
-        Ref<Collection<Class<? extends Angle>>> r = new Ref<>();
-        UnitsChangeListener<Angle> listener = new UnitsChangeListener<Angle>()
+        Ref<Collection<Class<? extends Coordinates>>> r = new Ref<>();
+        UnitsChangeListener<Coordinates> listener = new UnitsChangeListener<Coordinates>()
         {
             @Override
-            public void availableUnitsChanged(Class<Angle> superType, Collection<Class<? extends Angle>> newTypes)
+            public void availableUnitsChanged(Class<Coordinates> superType, Collection<Class<? extends Coordinates>> newTypes)
             {
                 r.val = new LinkedList<>(newTypes);
             }
 
             @Override
-            public void preferredUnitsChanged(Class<? extends Angle> type)
+            public void preferredUnitsChanged(Class<? extends Coordinates> type)
             {
             }
         };
@@ -57,16 +57,16 @@ public class AngleUnitsProviderTest
         units.addUnits(DecimalDegrees.class);
         Assert.assertEquals(null, r.val);
 
-        Collection<Class<? extends Angle>> expected = new LinkedList<>();
+        Collection<Class<? extends Coordinates>> expected = new LinkedList<>();
         expected.add(DegDecimalMin.class);
-        listener.availableUnitsChanged(Angle.class, expected);
+        listener.availableUnitsChanged(Coordinates.class, expected);
         Assert.assertEquals(expected, r.val);
         expected.add(DecimalDegrees.class);
         units.removeUnits(DegreesMinutesSeconds.class);
         Assert.assertEquals(expected, r.val);
 
         expected.add(DegreesMinutesSeconds.class);
-        listener.availableUnitsChanged(Angle.class, expected);
+        listener.availableUnitsChanged(Coordinates.class, expected);
         Assert.assertEquals(expected, r.val);
         units.addUnits(DegreesMinutesSeconds.class);
         Assert.assertEquals(expected, r.val);
@@ -97,7 +97,7 @@ public class AngleUnitsProviderTest
     }
 
     /**
-     * Test for {@link AngleUnitsProvider#convert(Class, Angle)}.
+     * Test for {@link AngleUnitsProvider#convert(Class, Coordinates)}.
      */
     @Test
     public void testConvert()
@@ -152,7 +152,7 @@ public class AngleUnitsProviderTest
         AngleUnitsProvider units = new AngleUnitsProvider();
         units.setPreferredUnits(DecimalDegrees.class);
         @SuppressWarnings("unchecked")
-        UnitsProvider.UnitsChangeListener<Angle> listener = EasyMock.createStrictMock(UnitsProvider.UnitsChangeListener.class);
+        UnitsProvider.UnitsChangeListener<Coordinates> listener = EasyMock.createStrictMock(UnitsProvider.UnitsChangeListener.class);
         EasyMock.replay(listener);
         units.addListener(listener);
         // Listener should not be called.
@@ -166,7 +166,7 @@ public class AngleUnitsProviderTest
     }
 
     /**
-     * Test for {@link AngleUnitsProvider#toShortLabelString(Angle)} and
+     * Test for {@link AngleUnitsProvider#toShortLabelString(Coordinates)} and
      * {@link AngleUnitsProvider#fromShortLabelString(String)}.
      */
     @Test
@@ -175,12 +175,12 @@ public class AngleUnitsProviderTest
         AngleUnitsProvider units = new AngleUnitsProvider();
         DecimalDegrees input = new DecimalDegrees(34.545124);
         String str = units.toShortLabelString(input);
-        Angle output = units.fromShortLabelString(str);
+        Coordinates output = units.fromShortLabelString(str);
         Assert.assertEquals(input, output);
     }
 
     /** Adapter for Angle class. */
-    private abstract static class AngleAdapter extends Angle
+    private abstract static class AngleAdapter extends Coordinates
     {
         /** Serial version UID. */
         private static final long serialVersionUID = 1L;
@@ -266,7 +266,7 @@ public class AngleUnitsProviderTest
          *
          * @param angle The angle.
          */
-        public InvalidAngle2(Angle angle)
+        public InvalidAngle2(Coordinates angle)
         {
             super(angle.getMagnitude());
         }

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/DecimalDegreesTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/DecimalDegreesTest.java
@@ -15,17 +15,17 @@ public class DecimalDegreesTest
     @Test
     public void testClone()
     {
-        Angle ang = new DecimalDegrees(34.54512);
+        Coordinates ang = new DecimalDegrees(34.54512);
         Assert.assertEquals(ang.getMagnitude(), ang.clone().getMagnitude(), 0.);
     }
 
     /**
-     * Test {@link Angle#compareTo(Angle)}.
+     * Test {@link Coordinates#compareTo(Coordinates)}.
      */
     @Test
     public void testCompareTo()
     {
-        Angle ang = new DecimalDegrees(34.54512);
+        Coordinates ang = new DecimalDegrees(34.54512);
         Assert.assertEquals(0, ang.compareTo(new DecimalDegrees(34.54512)));
         Assert.assertTrue(ang.compareTo(new DecimalDegrees(34.54513)) < 0);
         Assert.assertTrue(ang.compareTo(new DecimalDegrees(34.54511)) > 0);
@@ -46,7 +46,7 @@ public class DecimalDegreesTest
     @Test
     public void testHashCode()
     {
-        Angle ang = new DecimalDegrees(34.54512);
+        Coordinates ang = new DecimalDegrees(34.54512);
         Assert.assertEquals(ang.hashCode(), new DecimalDegrees(34.54512).hashCode());
         Assert.assertFalse(ang.hashCode() == new DecimalDegrees(34.545125).hashCode());
     }
@@ -57,14 +57,14 @@ public class DecimalDegreesTest
     @Test
     public void testLabels()
     {
-        Angle ang = new DecimalDegrees(34.54512);
+        Coordinates ang = new DecimalDegrees(34.54512);
         Assert.assertTrue(ang.getLongLabel().length() > 0);
         Assert.assertTrue(ang.getShortLabel().length() > 0);
         Assert.assertTrue(ang.toString().length() > 0);
     }
 
     /**
-     * Test {@link Angle#toShortLabelString()}.
+     * Test {@link Coordinates#toShortLabelString()}.
      */
     @Test
     public void testToShortLabelString()
@@ -79,7 +79,7 @@ public class DecimalDegreesTest
     }
 
     /**
-     * Test {@link Angle#toShortLabelString(char, char)}.
+     * Test {@link Coordinates#toShortLabelString(char, char)}.
      */
     @Test
     public void testToShortLabelStringCharChar()

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/DegreesMinutesSecondsTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/DegreesMinutesSecondsTest.java
@@ -15,17 +15,17 @@ public class DegreesMinutesSecondsTest
     @Test
     public void testClone()
     {
-        Angle ang = new DegreesMinutesSeconds(34.54512);
+        Coordinates ang = new DegreesMinutesSeconds(34.54512);
         Assert.assertEquals(ang.getMagnitude(), ang.clone().getMagnitude(), 0.);
     }
 
     /**
-     * Test {@link Angle#compareTo(Angle)}.
+     * Test {@link Coordinates#compareTo(Coordinates)}.
      */
     @Test
     public void testCompareTo()
     {
-        Angle ang = new DegreesMinutesSeconds(34.54512);
+        Coordinates ang = new DegreesMinutesSeconds(34.54512);
         Assert.assertEquals(0, ang.compareTo(new DegreesMinutesSeconds(34.54512)));
         Assert.assertTrue(ang.compareTo(new DegreesMinutesSeconds(34.54513)) < 0);
         Assert.assertTrue(ang.compareTo(new DegreesMinutesSeconds(34.54511)) > 0);
@@ -46,7 +46,7 @@ public class DegreesMinutesSecondsTest
     @Test
     public void testHashCode()
     {
-        Angle ang = new DegreesMinutesSeconds(34.54512);
+        Coordinates ang = new DegreesMinutesSeconds(34.54512);
         Assert.assertEquals(ang.hashCode(), new DegreesMinutesSeconds(34.54512).hashCode());
         Assert.assertFalse(ang.hashCode() == new DegreesMinutesSeconds(34.545125).hashCode());
     }
@@ -57,14 +57,14 @@ public class DegreesMinutesSecondsTest
     @Test
     public void testLabels()
     {
-        Angle ang = new DegreesMinutesSeconds(34.54512);
+        Coordinates ang = new DegreesMinutesSeconds(34.54512);
         Assert.assertTrue(ang.getLongLabel().length() > 0);
         Assert.assertTrue(ang.getShortLabel().length() > 0);
         Assert.assertTrue(ang.toString().length() > 0);
     }
 
     /**
-     * Test {@link Angle#toShortLabelString()}.
+     * Test {@link Coordinates#toShortLabelString()}.
      */
     @Test
     public void testToShortLabelString()
@@ -98,7 +98,7 @@ public class DegreesMinutesSecondsTest
     }
 
     /**
-     * Test {@link Angle#toShortLabelString(char, char)}.
+     * Test {@link Coordinates#toShortLabelString(char, char)}.
      */
     @Test
     public void testToShortLabelStringCharChar()
@@ -132,7 +132,7 @@ public class DegreesMinutesSecondsTest
     }
 
     /**
-     * Test {@link Angle#toShortLabelString(int, int)}.
+     * Test {@link Coordinates#toShortLabelString(int, int)}.
      */
     @Test
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/JAXBAngleTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/JAXBAngleTest.java
@@ -24,10 +24,10 @@ public class JAXBAngleTest
     @Test
     public void test() throws JAXBException, ClassNotFoundException
     {
-        Angle result;
+        Coordinates result;
         Element el;
 
-        Angle testDD = new DecimalDegrees(24.352);
+        Coordinates testDD = new DecimalDegrees(24.352);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         XMLUtilities.writeXMLObject(new JAXBAngle(testDD), baos);
 
@@ -36,10 +36,10 @@ public class JAXBAngleTest
 
         baos.reset();
         el = XMLUtilities.marshalJAXBableToElement(testDD);
-        result = XMLUtilities.readJAXBableObject(el, Angle.class);
+        result = XMLUtilities.readJAXBableObject(el, Coordinates.class);
         Assert.assertEquals(result, testDD);
 
-        Angle testDMS = new DegreesMinutesSeconds(24.352);
+        Coordinates testDMS = new DegreesMinutesSeconds(24.352);
         baos.reset();
         XMLUtilities.writeXMLObject(new JAXBAngle(testDMS), baos);
 
@@ -48,7 +48,7 @@ public class JAXBAngleTest
 
         baos.reset();
         el = XMLUtilities.marshalJAXBableToElement(testDMS);
-        result = XMLUtilities.readJAXBableObject(el, Angle.class);
+        result = XMLUtilities.readJAXBableObject(el, Coordinates.class);
         Assert.assertEquals(result, testDMS);
     }
 }

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
@@ -13,7 +13,7 @@ import io.opensphere.core.UnitsRegistry;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.units.UnitsProvider;
 import io.opensphere.core.units.UnitsProvider.UnitsChangeListener;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.length.Length;
 
 /** Panel that displays the cursor position. */
@@ -26,15 +26,15 @@ public class CursorPositionPanel extends JPanel
     private final JLabel myAltLabel = new JLabel();
 
     /** A listener for changes to the preferred angle units. */
-    private final transient UnitsChangeListener<Angle> myAngleUnitsChangeListener = new UnitsChangeListener<Angle>()
+    private final transient UnitsChangeListener<Coordinates> myAngleUnitsChangeListener = new UnitsChangeListener<Coordinates>()
     {
         @Override
-        public void availableUnitsChanged(Class<Angle> superType, Collection<Class<? extends Angle>> newTypes)
+        public void availableUnitsChanged(Class<Coordinates> superType, Collection<Class<? extends Coordinates>> newTypes)
         {
         }
 
         @Override
-        public void preferredUnitsChanged(Class<? extends Angle> type)
+        public void preferredUnitsChanged(Class<? extends Coordinates> type)
         {
             myPreferredAngleUnits = type;
         }
@@ -65,7 +65,7 @@ public class CursorPositionPanel extends JPanel
     private final JLabel myMGRSLabel = new JLabel();
 
     /** The currently preferred angle units. */
-    private volatile Class<? extends Angle> myPreferredAngleUnits;
+    private volatile Class<? extends Coordinates> myPreferredAngleUnits;
 
     /** The currently preferred length units. */
     private volatile Class<? extends Length> myPreferredLengthUnits;
@@ -83,7 +83,7 @@ public class CursorPositionPanel extends JPanel
         UnitsProvider<Length> lengthProvider = unitsRegistry.getUnitsProvider(Length.class);
         lengthProvider.addListener(myLengthUnitsChangeListener);
         myPreferredLengthUnits = lengthProvider.getPreferredUnits();
-        UnitsProvider<Angle> angleProvider = unitsRegistry.getUnitsProvider(Angle.class);
+        UnitsProvider<Coordinates> angleProvider = unitsRegistry.getUnitsProvider(Coordinates.class);
         angleProvider.addListener(myAngleUnitsChangeListener);
         myPreferredAngleUnits = angleProvider.getPreferredUnits();
 
@@ -179,8 +179,8 @@ public class CursorPositionPanel extends JPanel
         {
             if (myPreferredAngleUnits != null)
             {
-                Angle lat = Angle.create(myPreferredAngleUnits, latLonAlt.getLatD());
-                Angle lon = Angle.create(myPreferredAngleUnits, latLonAlt.getLonD());
+                Coordinates lat = Coordinates.create(myPreferredAngleUnits, latLonAlt.getLatD());
+                Coordinates lon = Coordinates.create(myPreferredAngleUnits, latLonAlt.getLonD());
 
                 myLatLabel.setText(lat.toShortLabelString(15, 6, 'N', 'S'));
                 myLonLabel.setText(lon.toShortLabelString(15, 6, 'E', 'W'));

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
@@ -14,7 +14,6 @@ import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.WindowConstants;
 
-import io.opensphere.core.Toolbox;
 import io.opensphere.core.UnitsRegistry;
 import io.opensphere.core.control.DiscreteEventAdapter;
 import io.opensphere.core.mgrs.MGRSConverter;
@@ -22,7 +21,7 @@ import io.opensphere.core.mgrs.UTM;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.units.UnitsProvider;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.angle.DecimalDegrees;
 import io.opensphere.core.units.angle.DegDecimalMin;
 import io.opensphere.core.units.angle.DegreesMinutesSeconds;
@@ -78,14 +77,14 @@ public class CursorPositionPopupManager
                     JPanel detailsPanel = new JPanel(new BorderLayout());
                     detailsPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
-                    DecimalDegrees latitudeDD = Angle.create(DecimalDegrees.class, myLocation.getLatD());
-                    DecimalDegrees longitudeDD = Angle.create(DecimalDegrees.class, myLocation.getLonD());
+                    DecimalDegrees latitudeDD = Coordinates.create(DecimalDegrees.class, myLocation.getLatD());
+                    DecimalDegrees longitudeDD = Coordinates.create(DecimalDegrees.class, myLocation.getLonD());
 
-                    DegDecimalMin latitudeDDM = Angle.create(DegDecimalMin.class, myLocation.getLatD());
-                    DegDecimalMin longitudeDDM = Angle.create(DegDecimalMin.class, myLocation.getLonD());
+                    DegDecimalMin latitudeDDM = Coordinates.create(DegDecimalMin.class, myLocation.getLatD());
+                    DegDecimalMin longitudeDDM = Coordinates.create(DegDecimalMin.class, myLocation.getLonD());
 
-                    DegreesMinutesSeconds latitudeDMS = Angle.create(DegreesMinutesSeconds.class, myLocation.getLatD());
-                    DegreesMinutesSeconds longitudeDMS = Angle.create(DegreesMinutesSeconds.class, myLocation.getLonD());
+                    DegreesMinutesSeconds latitudeDMS = Coordinates.create(DegreesMinutesSeconds.class, myLocation.getLatD());
+                    DegreesMinutesSeconds longitudeDMS = Coordinates.create(DegreesMinutesSeconds.class, myLocation.getLonD());
 
                     StringBuilder builder = new StringBuilder("DD:\t");
                     builder.append(latitudeDD.toShortLabelString(14, 6, 'N', 'S').trim()).append("\t");
@@ -124,7 +123,10 @@ public class CursorPositionPopupManager
         }
     };
 
-    /** The key listener that displays a popup with the cursor position. */
+    /**
+     * The key listener that will copy the coordinates to the clipboard in
+     * preferred format.
+     */
     private final DiscreteEventAdapter myAltListener = new DiscreteEventAdapter("Cursor Position", "Display Cursor Position",
             "Show a popup with the current mouse cursor position")
     {
@@ -136,18 +138,18 @@ public class CursorPositionPopupManager
             {
                 EventQueueUtilities.invokeLater(() ->
                 {
-                    DecimalDegrees latitudeDD = Angle.create(DecimalDegrees.class, myLocation.getLatD());
-                    DecimalDegrees longitudeDD = Angle.create(DecimalDegrees.class, myLocation.getLonD());
+                    DecimalDegrees latitudeDD = Coordinates.create(DecimalDegrees.class, myLocation.getLatD());
+                    DecimalDegrees longitudeDD = Coordinates.create(DecimalDegrees.class, myLocation.getLonD());
 
-                    DegDecimalMin latitudeDDM = Angle.create(DegDecimalMin.class, myLocation.getLatD());
-                    DegDecimalMin longitudeDDM = Angle.create(DegDecimalMin.class, myLocation.getLonD());
+                    DegDecimalMin latitudeDDM = Coordinates.create(DegDecimalMin.class, myLocation.getLatD());
+                    DegDecimalMin longitudeDDM = Coordinates.create(DegDecimalMin.class, myLocation.getLonD());
 
-                    DegreesMinutesSeconds latitudeDMS = Angle.create(DegreesMinutesSeconds.class, myLocation.getLatD());
-                    DegreesMinutesSeconds longitudeDMS = Angle.create(DegreesMinutesSeconds.class, myLocation.getLonD());
+                    DegreesMinutesSeconds latitudeDMS = Coordinates.create(DegreesMinutesSeconds.class, myLocation.getLatD());
+                    DegreesMinutesSeconds longitudeDMS = Coordinates.create(DegreesMinutesSeconds.class, myLocation.getLonD());
 
                     StringBuilder builder = new StringBuilder("");
                     Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-                    switch (myUnitsRegistry.getPreferredUnits(Angle.class).getSimpleName())
+                    switch (myUnitsRegistry.getPreferredUnits(Coordinates.class).getSimpleName())
                     {
                         case "DegreesMinutesSeconds":
                             builder.append(latitudeDMS.toShortLabelString(14, 6, 'N', 'S').trim()).append("\t");

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
@@ -58,7 +58,10 @@ public class CursorPositionPopupManager
      */
     boolean myHasElevationProvider;
 
-    /** The key listener that displays a popup with the cursor position. */
+    /**
+     * The key listener that displays a popup with the cursor position and
+     * copies all to clipboard.
+     */
     private final DiscreteEventAdapter myPopupListener = new DiscreteEventAdapter("Cursor Position", "Display Cursor Position",
             "Show a popup with the current mouse cursor position")
     {
@@ -118,6 +121,9 @@ public class CursorPositionPopupManager
                     dialog.setLocationRelativeTo(dialog.getParent());
                     dialog.pack();
                     dialog.setVisible(true);
+
+                    Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                    clipboard.setContents(new StringSelection(builder.toString()), null);
                 });
             }
         }

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
@@ -223,9 +223,9 @@ public class CursorPositionPopupManager
     }
 
     /**
-     * Gets the value of the {@link #myAltListener} field.
+     * Gets the alternatve more selective coordinate copy listener.
      *
-     * @return the value stored in the {@link #myAltListener} field.
+     * @return  the listener {@link #myAltListener}.
      */
     public DiscreteEventAdapter getAltListener()
     {

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionTransformer.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionTransformer.java
@@ -15,6 +15,7 @@ import javax.swing.JMenuItem;
 import io.opensphere.core.Toolbox;
 import io.opensphere.core.control.ControlRegistry;
 import io.opensphere.core.control.DefaultKeyPressedBinding;
+import io.opensphere.core.control.DefaultMouseBinding;
 import io.opensphere.core.control.ui.MenuBarRegistry;
 import io.opensphere.core.control.ui.ToolbarManager.SeparatorLocation;
 import io.opensphere.core.control.ui.ToolbarManager.ToolbarLocation;
@@ -104,10 +105,10 @@ final class CursorPositionTransformer extends AbstractOverlayTransformer
 
         toolbox.getControlRegistry().getControlContext(ControlRegistry.GLOBE_CONTROL_CONTEXT)
                 .addListener(myCursorPositionPopupManager.getListener(), new DefaultKeyPressedBinding(KeyEvent.VK_PERIOD));
-        
-        toolbox.getControlRegistry().getControlContext(ControlRegistry.GLOBE_CONTROL_CONTEXT)
-                .addListener(myCursorPositionPopupManager.getAltListener(), new DefaultKeyPressedBinding(KeyEvent.VK_SLASH));
 
+        toolbox.getControlRegistry().getControlContext(ControlRegistry.GLOBE_CONTROL_CONTEXT)
+                .addListener(myCursorPositionPopupManager.getAltListener(), new DefaultKeyPressedBinding(KeyEvent.VK_CAPS_LOCK));
+        
         myToolbox.getUIRegistry().getToolbarComponentRegistry().registerToolbarComponent(ToolbarLocation.SOUTH, "CursorPosition",
                 myCursorPositionPanel, 10000, SeparatorLocation.NONE);
 

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionTransformer.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionTransformer.java
@@ -3,6 +3,7 @@ package io.opensphere.overlay;
 import java.awt.Color;
 import java.awt.Point;
 import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -100,8 +101,12 @@ final class CursorPositionTransformer extends AbstractOverlayTransformer
 
         myCursorPositionPopupManager = new CursorPositionPopupManager(myToolbox.getUIRegistry().getMainFrameProvider(),
                 toolbox.getUnitsRegistry());
+
         toolbox.getControlRegistry().getControlContext(ControlRegistry.GLOBE_CONTROL_CONTEXT)
                 .addListener(myCursorPositionPopupManager.getListener(), new DefaultKeyPressedBinding(KeyEvent.VK_PERIOD));
+        
+        toolbox.getControlRegistry().getControlContext(ControlRegistry.GLOBE_CONTROL_CONTEXT)
+                .addListener(myCursorPositionPopupManager.getAltListener(), new DefaultKeyPressedBinding(KeyEvent.VK_SLASH));
 
         myToolbox.getUIRegistry().getToolbarComponentRegistry().registerToolbarComponent(ToolbarLocation.SOUTH, "CursorPosition",
                 myCursorPositionPanel, 10000, SeparatorLocation.NONE);

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/ViewerPositionTransformer.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/ViewerPositionTransformer.java
@@ -24,7 +24,7 @@ import io.opensphere.core.model.ScreenPosition;
 import io.opensphere.core.preferences.Preferences;
 import io.opensphere.core.units.UnitsProvider;
 import io.opensphere.core.units.UnitsProvider.UnitsChangeListener;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.angle.DecimalDegrees;
 import io.opensphere.core.units.length.Length;
 import io.opensphere.core.util.swing.EventQueueUtilities;
@@ -204,7 +204,7 @@ final class ViewerPositionTransformer extends AbstractOverlayTransformer
 
                 double pitch = Math.toDegrees(myToolbox.getMapManager().getStandardViewer().getPitch());
                 pitch = Math.round(pitch * precision) / precision;
-                Angle pitchAngle = Angle.create(DecimalDegrees.class, pitch);
+                Coordinates pitchAngle = Coordinates.create(DecimalDegrees.class, pitch);
                 final String pitchText = pitchAngle.toShortLabelString(10, 3);
 
                 Length elevation = Length.create(myPreferredLengthUnits,
@@ -213,7 +213,7 @@ final class ViewerPositionTransformer extends AbstractOverlayTransformer
 
                 double heading = Math.toDegrees(myToolbox.getMapManager().getStandardViewer().getHeading());
                 heading = Math.round(heading * precision) / precision;
-                Angle headingAngle = Angle.create(DecimalDegrees.class, heading);
+                Coordinates headingAngle = Coordinates.create(DecimalDegrees.class, heading);
                 final String headingText = headingAngle.toShortLabelString(9, 3);
 
                 EventQueueUtilities.invokeLater(new Runnable()

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/specific/regions/RegionRenderer.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/specific/regions/RegionRenderer.java
@@ -30,7 +30,7 @@ import io.opensphere.core.model.BoundingBoxes;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.Position;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.angle.DecimalDegrees;
 import io.opensphere.core.units.angle.DegreesMinutesSeconds;
 import io.opensphere.core.util.Utilities;
@@ -207,13 +207,13 @@ public class RegionRenderer extends DefaultTransformer implements Renderer
      * @param units The units to display.
      * @param text The output list of text.
      */
-    protected void addCoordinates(LatLonAlt southwest, LatLonAlt northeast, Class<? extends Angle> units,
+    protected void addCoordinates(LatLonAlt southwest, LatLonAlt northeast, Class<? extends Coordinates> units,
             List<? super String> text)
     {
-        text.add(StringUtilities.concat("SW: ", Angle.create(units, southwest.getLatD()).toShortLabelString('N', 'S'), " ",
-                Angle.create(units, southwest.getLonD()).toShortLabelString('E', 'W')));
-        text.add(StringUtilities.concat("NE: ", Angle.create(units, northeast.getLatD()).toShortLabelString('N', 'S'), " ",
-                Angle.create(units, northeast.getLonD()).toShortLabelString('E', 'W')));
+        text.add(StringUtilities.concat("SW: ", Coordinates.create(units, southwest.getLatD()).toShortLabelString('N', 'S'), " ",
+                Coordinates.create(units, southwest.getLonD()).toShortLabelString('E', 'W')));
+        text.add(StringUtilities.concat("NE: ", Coordinates.create(units, northeast.getLatD()).toShortLabelString('N', 'S'), " ",
+                Coordinates.create(units, northeast.getLonD()).toShortLabelString('E', 'W')));
     }
 
     /**

--- a/open-sphere-plugins/search/src/main/java/io/opensphere/search/view/SearchResultBasic.java
+++ b/open-sphere-plugins/search/src/main/java/io/opensphere/search/view/SearchResultBasic.java
@@ -7,8 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.search.SearchResult;
-import io.opensphere.core.units.angle.Angle;
 import io.opensphere.core.units.angle.DecimalDegrees;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.length.Length;
 import io.opensphere.core.units.length.Meters;
 import io.opensphere.core.util.Utilities;
@@ -197,8 +197,8 @@ public class SearchResultBasic extends GridPane implements Closeable
     private String toString(LatLonAlt location)
     {
         StringBuilder builder = new StringBuilder();
-        Angle lat = Angle.create(DecimalDegrees.class, location.getLatD());
-        Angle lon = Angle.create(DecimalDegrees.class, location.getLonD());
+        Coordinates lat = Coordinates.create(DecimalDegrees.class, location.getLatD());
+        Coordinates lon = Coordinates.create(DecimalDegrees.class, location.getLonD());
         Length alt = Length.create(Meters.class, location.getAltitude().getMagnitude());
         builder.append(lat.toShortLabelString(12, 6, 'N', 'S')).append(' ');
         builder.append(lon.toShortLabelString(12, 6, 'E', 'W'));


### PR DESCRIPTION
Fixes # VORTEX-6248: Create quick copy to clipboard ability for feature info

## Proposed Changes

  - Rename "angle" to "Coordinates" in the Edits->Units Menu.
  - Add MGRS to Coordinates sub-menu.
  - Added hotkey "Caps Lock" while on globe context to copy the coordinates in the sub menu selected above. 
 - Original "." popup message still usable, but also copies all coordinates/text to clipboard.
