### PR TITLE
Ft quickcopyfix

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/UnitsRegistry.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/UnitsRegistry.java
@@ -241,6 +241,17 @@ public interface UnitsRegistry
     <T> Class<? extends T> getPreferredUnits(Class<T> unitsSupertype) throws UnitsProviderNotFoundException;
 
     /**
+     * Get the preferred units from this unit provider.
+     *
+     * @param <T> The type of units.
+     * @param unitsSupertype The type of units.
+     * @return The preferred units.
+     * @throws UnitsProviderNotFoundException If the units provider has not been
+     *             installed.
+     */
+    <T> Class<? extends T> getPrevPreferredUnits(Class<T> unitsSupertype) throws UnitsProviderNotFoundException;
+
+    /**
      * Get the units provider for a category of units.
      *
      * @param <T> The type of units.

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/appl/MenuInit.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/appl/MenuInit.java
@@ -21,10 +21,15 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.WindowConstants;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
 
 import io.opensphere.core.Toolbox;
 import io.opensphere.core.capture.CaptureMenuInit;
@@ -241,6 +246,7 @@ public class MenuInit
 
         // Add Units
         final JMenu unitsMenu = new JMenu("Units");
+
         for (UnitsProvider<?> unitsProvider : toolbox.getUnitsRegistry().getUnitsProviders())
         {
             JMenu subMenu = new JMenu(unitsProvider.getSuperType().getSimpleName());
@@ -252,6 +258,7 @@ public class MenuInit
             Quantify.collectMetric("mist3d.menu-bar.edit.units.reset-to-default");
             toolbox.getUnitsRegistry().resetAllPreferredUnits(e.getSource());
         }));
+
         editMenu.add(unitsMenu);
     }
 
@@ -402,7 +409,10 @@ public class MenuInit
             unitsItem.addActionListener(e ->
             {
                 Quantify.collectMetric("mist3d.menu-bar.edit.units.set-units-to-" + units.getSimpleName());
+                
+                unitsProvider.setPrevPreferredUnits(unitsProvider.getPreferredUnits());
                 unitsProvider.setPreferredUnits(units);
+                System.out.println("setPreferredUnits to:" + units.getSimpleName());
             });
             subMenu.add(unitsItem);
         }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/appl/MenuInit.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/appl/MenuInit.java
@@ -47,6 +47,8 @@ import io.opensphere.core.projection.AbstractProjection;
 import io.opensphere.core.quantify.Quantify;
 import io.opensphere.core.units.UnitsProvider;
 import io.opensphere.core.units.UnitsProvider.UnitsChangeListener;
+import io.opensphere.core.units.angle.Coordinates;
+import io.opensphere.core.units.length.Length;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.core.util.swing.SwingUtilities;
 
@@ -412,7 +414,6 @@ public class MenuInit
                 
                 unitsProvider.setPrevPreferredUnits(unitsProvider.getPreferredUnits());
                 unitsProvider.setPreferredUnits(units);
-                System.out.println("setPreferredUnits to:" + units.getSimpleName());
             });
             subMenu.add(unitsItem);
         }
@@ -434,8 +435,18 @@ public class MenuInit
                     ((AbstractButton)component).setSelected(((AbstractButton)component).getText().equals(selectionLabel));
                 }
             }
+
+            @Override
+            public void prevpreferredUnitsChanged(Class<? extends T> preferredType)
+            {
+                
+            }
+
+ 
         };
         listener.preferredUnitsChanged(unitsProvider.getPreferredUnits());
+        listener.prevpreferredUnitsChanged(unitsProvider.getPrevPreferredUnits());
+        
         myUnitsChangeListeners.add(listener);
         unitsProvider.addListener(listener);
     }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/appl/MenuInit.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/appl/MenuInit.java
@@ -435,14 +435,6 @@ public class MenuInit
                     ((AbstractButton)component).setSelected(((AbstractButton)component).getText().equals(selectionLabel));
                 }
             }
-
-            @Override
-            public void prevpreferredUnitsChanged(Class<? extends T> preferredType)
-            {
-                
-            }
-
- 
         };
         listener.preferredUnitsChanged(unitsProvider.getPreferredUnits());
         listener.prevpreferredUnitsChanged(unitsProvider.getPrevPreferredUnits());

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/appl/MenuInit.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/appl/MenuInit.java
@@ -367,21 +367,21 @@ public class MenuInit
         {
             toolbox.getMapManager().getStandardViewer().resetView();
             Quantify.collectMetric("mist3d.menu-bar.edit.units.reset-to-default");
-        },
-        KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_DOWN_MASK)));
+        }, KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_DOWN_MASK)));
 
-        //        // Add toolbar item
-        //        final JCheckBoxMenuItem toolbarItem = new JCheckBoxMenuItem("Toolbar");
-        //        toolbarItem.setSelected(toolbox.getUIRegistry().getToolbarComponentRegistry().getToolbarManager().isVisible());
-        //        toolbarItem.addActionListener(new ActionListener()
-        //        {
-        //            @Override
-        //            public void actionPerformed(ActionEvent arg0)
-        //            {
-        //                toolbox.getUIRegistry().getToolbarComponentRegistry().getToolbarManager().setVisible(toolbarItem.isSelected());
-        //            }
-        //        });
-        //        viewMenu.add(toolbarItem);
+        // // Add toolbar item
+        // final JCheckBoxMenuItem toolbarItem = new
+        // JCheckBoxMenuItem("Toolbar");
+        // toolbarItem.setSelected(toolbox.getUIRegistry().getToolbarComponentRegistry().getToolbarManager().isVisible());
+        // toolbarItem.addActionListener(new ActionListener()
+        // {
+        // @Override
+        // public void actionPerformed(ActionEvent arg0)
+        // {
+        // toolbox.getUIRegistry().getToolbarComponentRegistry().getToolbarManager().setVisible(toolbarItem.isSelected());
+        // }
+        // });
+        // viewMenu.add(toolbarItem);
 
         // Add Projection
         mbr.getMenu(MenuBarRegistry.MAIN_MENU_BAR, MenuBarRegistry.VIEW_MENU, MenuBarRegistry.PROJECTION_MENU);
@@ -455,8 +455,7 @@ public class MenuInit
         final JCheckBoxMenuItem terrainLock = new JCheckBoxMenuItem("Lock Terrain");
         terrainLock.addActionListener(e ->
         {
-            Quantify.collectEnableDisableMetric("mist3d.menu-bar.tools.lock-terrain",
-                    terrainLock.isSelected());
+            Quantify.collectEnableDisableMetric("mist3d.menu-bar.tools.lock-terrain", terrainLock.isSelected());
             AbstractProjection.setTerrainLocked(terrainLock.isSelected());
         });
         return terrainLock;

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/appl/UnitsRegistryImpl.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/appl/UnitsRegistryImpl.java
@@ -47,14 +47,14 @@ final class UnitsRegistryImpl implements UnitsRegistry
 
     @Override
     public <S, T extends S> T convert(Class<S> unitsSupertype, Class<T> desiredUnits, S from)
-            throws InvalidUnitsException, UnitsProviderNotFoundException
+        throws InvalidUnitsException, UnitsProviderNotFoundException
     {
         return getUnitsProvider(unitsSupertype).convert(desiredUnits, from);
     }
 
     @Override
     public <T> T convertUsingLongLabel(Class<T> unitsSupertype, T magnitude, String longLabel)
-            throws UnitsParseException, UnitsProviderNotFoundException, InvalidUnitsException
+        throws UnitsParseException, UnitsProviderNotFoundException, InvalidUnitsException
     {
         Class<? extends T> type = getUnitsProvider(unitsSupertype).getUnitsWithLongLabel(longLabel);
         if (type == null)
@@ -66,7 +66,7 @@ final class UnitsRegistryImpl implements UnitsRegistry
 
     @Override
     public <T> T convertUsingShortLabel(Class<T> unitsSupertype, T magnitude, String shortLabel)
-            throws UnitsParseException, UnitsProviderNotFoundException, InvalidUnitsException
+        throws UnitsParseException, UnitsProviderNotFoundException, InvalidUnitsException
     {
         UnitsProvider<T> unitsProvider = getUnitsProvider(unitsSupertype);
         return unitsProvider.convert(unitsProvider.getUnitsWithShortLabel(shortLabel), magnitude);
@@ -74,14 +74,14 @@ final class UnitsRegistryImpl implements UnitsRegistry
 
     @Override
     public <T> T fromLongLabelString(Class<T> unitsSupertype, String label)
-            throws UnitsParseException, UnitsProviderNotFoundException
+        throws UnitsParseException, UnitsProviderNotFoundException
     {
         return getUnitsProvider(unitsSupertype).fromLongLabelString(label);
     }
 
     @Override
     public <T> T fromMagnitudeAndLongLabel(Class<T> unitsSupertype, Number magnitude, String longLabel)
-            throws UnitsParseException, InvalidUnitsException, UnitsProviderNotFoundException
+        throws UnitsParseException, InvalidUnitsException, UnitsProviderNotFoundException
     {
         UnitsProvider<T> unitsProvider = getUnitsProvider(unitsSupertype);
         return unitsProvider.fromMagnitudeAndLongLabel(magnitude, longLabel);
@@ -89,7 +89,7 @@ final class UnitsRegistryImpl implements UnitsRegistry
 
     @Override
     public <T> T fromMagnitudeAndShortLabel(Class<T> unitsSupertype, Number magnitude, String shortLabel)
-            throws UnitsParseException, UnitsProviderNotFoundException, InvalidUnitsException
+        throws UnitsParseException, UnitsProviderNotFoundException, InvalidUnitsException
     {
         UnitsProvider<T> unitsProvider = getUnitsProvider(unitsSupertype);
         return unitsProvider.fromMagnitudeAndShortLabel(magnitude, shortLabel);
@@ -97,35 +97,35 @@ final class UnitsRegistryImpl implements UnitsRegistry
 
     @Override
     public <T> T fromShortLabelString(Class<T> unitsSupertype, String label)
-            throws UnitsParseException, UnitsProviderNotFoundException
+        throws UnitsParseException, UnitsProviderNotFoundException
     {
         return getUnitsProvider(unitsSupertype).fromShortLabelString(label);
     }
 
     @Override
     public <T> T fromUnitsAndMagnitude(Class<? super T> unitsSupertype, Class<T> type, Number magnitude)
-            throws InvalidUnitsException, UnitsProviderNotFoundException
+        throws InvalidUnitsException, UnitsProviderNotFoundException
     {
         return getUnitsProvider(unitsSupertype).fromUnitsAndMagnitude(type, magnitude);
     }
 
     @Override
     public <T> Collection<Class<? extends T>> getAvailableUnits(Class<T> unitsSupertype, boolean allowAutoscale)
-            throws UnitsProviderNotFoundException
+        throws UnitsProviderNotFoundException
     {
         return getUnitsProvider(unitsSupertype).getAvailableUnits(allowAutoscale);
     }
 
     @Override
     public <T> String[] getAvailableUnitsSelectionLabels(Class<T> unitsSupertype, boolean allowAutoscale)
-            throws UnitsProviderNotFoundException
+        throws UnitsProviderNotFoundException
     {
         return getUnitsProvider(unitsSupertype).getAvailableUnitsSelectionLabels(allowAutoscale);
     }
 
     @Override
     public <T> Class<? extends T> getPreferredFixedScaleUnits(Class<T> unitsSupertype, T value)
-            throws UnitsProviderNotFoundException
+        throws UnitsProviderNotFoundException
     {
         return getUnitsProvider(unitsSupertype).getPreferredFixedScaleUnits(value);
     }
@@ -134,6 +134,12 @@ final class UnitsRegistryImpl implements UnitsRegistry
     public <T> Class<? extends T> getPreferredUnits(Class<T> unitsSupertype) throws UnitsProviderNotFoundException
     {
         return getUnitsProvider(unitsSupertype).getPreferredUnits();
+    }
+
+    @Override
+    public <T> Class<? extends T> getPrevPreferredUnits(Class<T> unitsSupertype) throws UnitsProviderNotFoundException
+    {
+        return getUnitsProvider(unitsSupertype).getPrevPreferredUnits();
     }
 
     @Override
@@ -156,7 +162,7 @@ final class UnitsRegistryImpl implements UnitsRegistry
 
     @Override
     public <T> Class<? extends T> getUnitsWithSelectionLabel(Class<T> unitsSupertype, String label)
-            throws UnitsProviderNotFoundException
+        throws UnitsProviderNotFoundException
     {
         return getUnitsProvider(unitsSupertype).getUnitsWithSelectionLabel(label);
     }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/map/MapManagerMenuProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/map/MapManagerMenuProvider.java
@@ -25,7 +25,7 @@ import io.opensphere.core.mgrs.UTM;
 import io.opensphere.core.model.Altitude.ReferenceLevel;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.Position;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.length.Length;
 import io.opensphere.core.util.AwesomeIconSolid;
 import io.opensphere.core.util.collections.New;
@@ -70,7 +70,7 @@ public class MapManagerMenuProvider
                 {
                     if (myUnitsRegistry != null)
                     {
-                        Class<? extends Angle> angleUnits = myUnitsRegistry.getPreferredUnits(Angle.class);
+                        Class<? extends Coordinates> angleUnits = myUnitsRegistry.getPreferredUnits(Coordinates.class);
                         String label = pos.toDisplayString(angleUnits, (Class<? extends Length>)null);
 
                         try

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/map/MapManagerMenuProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/map/MapManagerMenuProvider.java
@@ -141,8 +141,8 @@ public class MapManagerMenuProvider
         builder.append(longitudeDDM.toShortLabelString(14, 6, 'E', 'W').trim()).append("\n");
 
         builder.append("MGRS:\t");
-        MGRSConverter test = new MGRSConverter();
-        builder.append(test.createString(new UTM(pos)));
+        MGRSConverter converter = new MGRSConverter();
+        builder.append(converter.createString(new UTM(pos)));
 
         if (myHasElevationProvider)
         {

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/map/MapManagerMenuProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/map/MapManagerMenuProvider.java
@@ -6,9 +6,11 @@ import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.swing.BorderFactory;
 import javax.swing.JDialog;
+import javax.swing.JFrame;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -74,6 +76,8 @@ public class MapManagerMenuProvider
      */
     private final ContextMenuProvider<ScreenPositionContextKey> myDefaultContextMenuProvider = new ContextMenuProvider<>()
     {
+        private int counter;
+
         @Override
         public List<JMenuItem> getMenuItems(String contextId, ScreenPositionContextKey key)
         {
@@ -90,10 +94,12 @@ public class MapManagerMenuProvider
                 JMenuItem copyToClipboard = new JMenuItem("Open Coordinate Viewer",
                         new GenericFontIcon(AwesomeIconSolid.MAP_MARKER, Color.WHITE));
 
-                JDialog cordMenu = cordMenu(pos);
-                copyToClipboard.addActionListener(e -> cordMenu.setVisible(true));
+                copyToClipboard.addActionListener(e ->
+                {
+                    JDialog cordMenu = CordMenu(pos,++counter);
+                    cordMenu.setVisible(true);
+                });
                 menuItems.add(copyToClipboard);
-
             }
             return menuItems;
         }
@@ -109,13 +115,14 @@ public class MapManagerMenuProvider
      * The popup menu for coordinate information.
      * 
      * @param pos the geographic position on the globe.
+     * @param counter 
      * @return dialog the popup window.
      */
-    private final JDialog CordMenu(GeographicPosition pos)
+    private final JDialog CordMenu(GeographicPosition pos, int counter)
     {
 
         JDialog dialog = new JDialog();
-        dialog.setTitle("Coordinate Menu");
+        dialog.setTitle("Mouse Position " + counter);
         JPanel detailsPanel = new JPanel(new BorderLayout());
         detailsPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
@@ -160,6 +167,7 @@ public class MapManagerMenuProvider
         dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         dialog.setLocationRelativeTo(dialog.getParent());
         dialog.pack();
+        dialog.setAlwaysOnTop(true);
         return dialog;
     }
 

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/map/MapManagerMenuProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/map/MapManagerMenuProvider.java
@@ -90,8 +90,8 @@ public class MapManagerMenuProvider
                 JMenuItem copyToClipboard = new JMenuItem("Open Coordinate Viewer",
                         new GenericFontIcon(AwesomeIconSolid.MAP_MARKER, Color.WHITE));
 
-                JDialog theCordMenu = CordMenu(pos);
-                copyToClipboard.addActionListener(arg0 -> theCordMenu.setVisible(true));
+                JDialog cordMenu = cordMenu(pos);
+                copyToClipboard.addActionListener(e -> cordMenu.setVisible(true));
                 menuItems.add(copyToClipboard);
 
             }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/model/GeographicPosition.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/model/GeographicPosition.java
@@ -6,7 +6,7 @@ import java.util.List;
 import io.opensphere.core.math.Vector2d;
 import io.opensphere.core.math.Vector3d;
 import io.opensphere.core.model.Altitude.ReferenceLevel;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.angle.DecimalDegrees;
 import io.opensphere.core.units.length.Length;
 
@@ -265,13 +265,13 @@ public class GeographicPosition implements Position, Serializable
      * @param lengthUnits The length units.
      * @return The display string.
      */
-    public String toDisplayString(Class<? extends Angle> angleUnits, Class<? extends Length> lengthUnits)
+    public String toDisplayString(Class<? extends Coordinates> angleUnits, Class<? extends Length> lengthUnits)
     {
         StringBuilder sb = new StringBuilder();
         if (angleUnits != null)
         {
-            Angle lat = Angle.create(angleUnits, getLat());
-            Angle lon = Angle.create(angleUnits, getLon());
+            Coordinates lat = Coordinates.create(angleUnits, getLat());
+            Coordinates lon = Coordinates.create(angleUnits, getLon());
             sb.append(lat.toShortLabelString(15, 6, 'N', 'S')).append(' ').append(lon.toShortLabelString(15, 6, 'E', 'W'));
         }
         if (lengthUnits != null)

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/AbstractUnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/AbstractUnitsProvider.java
@@ -467,5 +467,4 @@ public abstract class AbstractUnitsProvider<T> implements UnitsProvider<T>
         }
         notifyPrevChanges(units);
     }
-
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/AbstractUnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/AbstractUnitsProvider.java
@@ -464,7 +464,7 @@ public abstract class AbstractUnitsProvider<T> implements UnitsProvider<T>
             {
                 myPreferences.putString(myPrefsKey, getSelectionLabel(units), this);
             }
+            notifyPrevChanges(units);
         }
-        notifyPrevChanges(units);
     }
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/AbstractUnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/AbstractUnitsProvider.java
@@ -409,7 +409,17 @@ public abstract class AbstractUnitsProvider<T> implements UnitsProvider<T>
     {
         myChangeSupport.notifyListeners(listener -> listener.preferredUnitsChanged(preferredType), null);
     }
-
+    
+    /**
+     * Notify listeners of changes.
+     *
+     * @param preferredType The new preferred units.
+     */
+    protected void notifyPrevChanges(final Class<? extends T> preferredType)
+    {
+        myChangeSupport.notifyListeners(listener -> listener.prevpreferredUnitsChanged(preferredType), null);
+    }
+    
     /**
      * Notify listeners of changes.
      *
@@ -453,12 +463,10 @@ public abstract class AbstractUnitsProvider<T> implements UnitsProvider<T>
         {
             if (myPreferences != null)
             {
-                System.out.println("settings the old");
-                System.out.println(units.getSimpleName());
                 myPreferences.putString(myPrefsKey, getSelectionLabel(units), this);
             }
         }
-        notifyChanges(units);
+        notifyPrevChanges(units);
     }
 
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/AbstractUnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/AbstractUnitsProvider.java
@@ -60,7 +60,6 @@ public abstract class AbstractUnitsProvider<T> implements UnitsProvider<T>
     /** The previously preferred units. */
     private final AtomicReference<Class<? extends T>> myPrevPreferredUnits = new AtomicReference<>();
 
-
     @Override
     public void addListener(UnitsChangeListener<T> listener)
     {

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/AbstractUnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/AbstractUnitsProvider.java
@@ -452,7 +452,7 @@ public abstract class AbstractUnitsProvider<T> implements UnitsProvider<T>
     }
 
     /**
-     * Set the preferred units using the selection label.
+     * Set the previous preferred units using the selection label.
      *
      * @param selectionLabel The long label.
      */

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/UnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/UnitsProvider.java
@@ -169,6 +169,13 @@ public interface UnitsProvider<T>
      * @return The preferred units.
      */
     Class<? extends T> getPreferredUnits();
+    
+    /**
+     * Get the preferred units from this unit provider.
+     *
+     * @return The preferred units.
+     */
+    Class<? extends T> getPrevPreferredUnits();
 
     /**
      * Get a selection label for a type. This is a label that could be used to
@@ -286,5 +293,13 @@ public interface UnitsProvider<T>
          * @param type The new preferred unit type.
          */
         void preferredUnitsChanged(Class<? extends T> type);
+
     }
+    
+    /**
+     * Method called when the preferred units change in this unit provider.
+     *
+     * @param type The previous preferred unit type.
+     */
+    void setPrevPreferredUnits(Class<? extends T> units);
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/UnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/UnitsProvider.java
@@ -10,7 +10,7 @@ import io.opensphere.core.units.length.Length;
  * Interface for facilities that provide units.
  *
  * @param <T> The supertype of the unit types in this provider.
- */ 
+ */
 public interface UnitsProvider<T>
 {
     /**

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/UnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/UnitsProvider.java
@@ -171,9 +171,9 @@ public interface UnitsProvider<T>
      * @return The preferred units.
      */
     Class<? extends T> getPreferredUnits();
-    
+
     /**
-     * Get the preferred units from this unit provider.
+     * Get the previous preferred units from this unit provider.
      *
      * @return The preferred units.
      */
@@ -289,7 +289,7 @@ public interface UnitsProvider<T>
          */
         default void availableUnitsChanged(Class<T> superType, Collection<Class<? extends T>> newTypes)
         {
-            
+
         };
 
         /**
@@ -302,16 +302,17 @@ public interface UnitsProvider<T>
         /**
          * Method called when the preferred units change in this unit provider.
          *
-         * @param Coordinates The new preferred unit type.
+         * @param Coordinates The previous preferred unit type.
          */
-        default void prevpreferredUnitsChanged(Class<? extends T> preferredType) {
-            
+        default void prevpreferredUnitsChanged(Class<? extends T> preferredType)
+        {
+
         };
 
     }
-    
+
     /**
-     * Method called when the preferred units change in this unit provider.
+     * Set the previous preferred units for this unit provider.
      *
      * @param type The previous preferred unit type.
      */

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/UnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/UnitsProvider.java
@@ -3,12 +3,14 @@ package io.opensphere.core.units;
 import java.util.Collection;
 
 import io.opensphere.core.preferences.Preferences;
+import io.opensphere.core.units.angle.Coordinates;
+import io.opensphere.core.units.length.Length;
 
 /**
  * Interface for facilities that provide units.
  *
  * @param <T> The supertype of the unit types in this provider.
- */
+ */ 
 public interface UnitsProvider<T>
 {
     /**
@@ -285,7 +287,10 @@ public interface UnitsProvider<T>
          * @param superType The supertype of the unit types that changed.
          * @param newTypes The types after the change.
          */
-        void availableUnitsChanged(Class<T> superType, Collection<Class<? extends T>> newTypes);
+        default void availableUnitsChanged(Class<T> superType, Collection<Class<? extends T>> newTypes)
+        {
+            
+        };
 
         /**
          * Method called when the preferred units change in this unit provider.
@@ -293,6 +298,15 @@ public interface UnitsProvider<T>
          * @param type The new preferred unit type.
          */
         void preferredUnitsChanged(Class<? extends T> type);
+
+        /**
+         * Method called when the preferred units change in this unit provider.
+         *
+         * @param Coordinates The new preferred unit type.
+         */
+        default void prevpreferredUnitsChanged(Class<? extends T> preferredType) {
+            
+        };
 
     }
     

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/AngleUnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/AngleUnitsProvider.java
@@ -30,6 +30,7 @@ public final class AngleUnitsProvider extends AbstractUnitsProvider<Coordinates>
         units.add(DecimalDegrees.class);
         units.add(MGRS.class);
         setPreferredUnits(units.get(0));
+        //setPrevPreferredUnits(units.get(0));
     }
 
     @Override

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/AngleUnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/AngleUnitsProvider.java
@@ -30,7 +30,7 @@ public final class AngleUnitsProvider extends AbstractUnitsProvider<Coordinates>
         units.add(DecimalDegrees.class);
         units.add(MGRS.class);
         setPreferredUnits(units.get(0));
-        //setPrevPreferredUnits(units.get(0));
+        setPrevPreferredUnits(units.get(0));
     }
 
     @Override

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/AngleUnitsProvider.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/AngleUnitsProvider.java
@@ -10,7 +10,7 @@ import io.opensphere.core.util.lang.ImpossibleException;
 /**
  * A units provider for angle units.
  */
-public final class AngleUnitsProvider extends AbstractUnitsProvider<Angle>
+public final class AngleUnitsProvider extends AbstractUnitsProvider<Coordinates>
 {
     /**
      * Constructor. This initializes the units provider with the following
@@ -24,67 +24,68 @@ public final class AngleUnitsProvider extends AbstractUnitsProvider<Angle>
      */
     public AngleUnitsProvider()
     {
-        List<Class<? extends Angle>> units = getAvailableUnitsUnsync();
+        List<Class<? extends Coordinates>> units = getAvailableUnitsUnsync();
         units.add(DegreesMinutesSeconds.class);
         units.add(DegDecimalMin.class);
         units.add(DecimalDegrees.class);
+        units.add(MGRS.class);
         setPreferredUnits(units.get(0));
     }
 
     @Override
-    public <T extends Angle> T convert(Class<T> desiredType, Angle source) throws InvalidUnitsException
+    public <T extends Coordinates> T convert(Class<T> desiredType, Coordinates source) throws InvalidUnitsException
     {
-        return Angle.create(desiredType, source);
+        return Coordinates.create(desiredType, source);
     }
 
     @Override
-    public <T extends Angle> T fromUnitsAndMagnitude(Class<T> type, Number magnitude) throws InvalidUnitsException
+    public <T extends Coordinates> T fromUnitsAndMagnitude(Class<T> type, Number magnitude) throws InvalidUnitsException
     {
-        return Angle.create(type, magnitude.doubleValue());
+        return Coordinates.create(type, magnitude.doubleValue());
     }
 
     @Override
-    public Class<? extends Angle> getDisplayClass(Angle value)
+    public Class<? extends Coordinates> getDisplayClass(Coordinates value)
     {
         return value.getClass();
     }
 
     @Override
-    public String getLongLabel(Class<? extends Angle> type, boolean plural) throws InvalidUnitsException
+    public String getLongLabel(Class<? extends Coordinates> type, boolean plural) throws InvalidUnitsException
     {
-        return Angle.getLongLabel(type);
+        return Coordinates.getLongLabel(type);
     }
 
     @Override
-    public String getSelectionLabel(Class<? extends Angle> type) throws InvalidUnitsException
+    public String getSelectionLabel(Class<? extends Coordinates> type) throws InvalidUnitsException
     {
-        return Angle.getSelectionLabel(type);
+        return Coordinates.getSelectionLabel(type);
     }
 
     @Override
-    public String getShortLabel(Class<? extends Angle> type, boolean plural) throws InvalidUnitsException
+    public String getShortLabel(Class<? extends Coordinates> type, boolean plural) throws InvalidUnitsException
     {
-        return Angle.getShortLabel(type);
+        return Coordinates.getShortLabel(type);
     }
 
     @Override
-    public Class<Angle> getSuperType()
+    public Class<Coordinates> getSuperType()
     {
-        return Angle.class;
+        return Coordinates.class;
     }
 
     @Override
-    public Class<? extends Angle> getUnitsWithLongLabel(String label)
+    public Class<? extends Coordinates> getUnitsWithLongLabel(String label)
     {
         Lock lock = getLock();
         lock.lock();
         try
         {
-            for (Class<? extends Angle> type : getAvailableUnitsUnsync())
+            for (Class<? extends Coordinates> type : getAvailableUnitsUnsync())
             {
                 try
                 {
-                    if (Angle.getLongLabel(type).equalsIgnoreCase(label) || Angle.getLongLabel(type).equalsIgnoreCase(label))
+                    if (Coordinates.getLongLabel(type).equalsIgnoreCase(label) || Coordinates.getLongLabel(type).equalsIgnoreCase(label))
                     {
                         return type;
                     }
@@ -103,7 +104,7 @@ public final class AngleUnitsProvider extends AbstractUnitsProvider<Angle>
     }
 
     @Override
-    public String toShortLabelString(Angle obj)
+    public String toShortLabelString(Coordinates obj)
     {
         return obj.toShortLabelString();
     }
@@ -111,12 +112,12 @@ public final class AngleUnitsProvider extends AbstractUnitsProvider<Angle>
     @Override
     protected Class<? extends Number> getValueType()
     {
-        return Angle.VALUE_TYPE;
+        return Coordinates.VALUE_TYPE;
     }
 
     @Override
-    protected void testUnits(Class<? extends Angle> type) throws InvalidUnitsException
+    protected void testUnits(Class<? extends Coordinates> type) throws InvalidUnitsException
     {
-        Angle.create(type, 0.);
+        Coordinates.create(type, 0.);
     }
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/Coordinates.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/Coordinates.java
@@ -11,7 +11,7 @@ import io.opensphere.core.util.lang.ExpectedCloneableException;
 /**
  * A formatting-aware representation of an angle.
  */
-public abstract class Angle implements Cloneable, Serializable, Comparable<Angle>, JAXBable<JAXBAngle>
+public abstract class Coordinates implements Cloneable, Serializable, Comparable<Coordinates>, JAXBable<JAXBAngle>
 {
     /** Serial version UID. */
     private static final long serialVersionUID = 1L;
@@ -23,8 +23,8 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
     private final double myMagnitude;
 
     /**
-     * Return an angle in the specified units equivalent to another angle. If
-     * the input angle is already in the requested units, it will be returned
+     * Return a Coordinate in the specified units equivalent to another Coordinate. If
+     * the input coordinate is already in the requested units, it will be returned
      * as-is.
      *
      * @param <T> The type of the angle object.
@@ -34,25 +34,25 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      * @throws InvalidUnitsException If the type is invalid.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Angle> T create(Class<T> type, Angle from) throws InvalidUnitsException
+    public static <T extends Coordinates> T create(Class<T> type, Coordinates from) throws InvalidUnitsException
     {
         if (type.isInstance(from))
         {
             return (T)from;
         }
-        return UnitsUtilities.create(type, Angle.class, from);
+        return UnitsUtilities.create(type, Coordinates.class, from);
     }
 
     /**
      * Create a new angle object.
      *
-     * @param <T> The type of the angle object.
-     * @param type The type of the angle object.
+     * @param <T> The type of the Coordinate object.
+     * @param type The type of the Coordinate object.
      * @param magnitude The magnitude of the new object.
-     * @return The new angle object.
+     * @return The new Coordinate object.
      * @throws InvalidUnitsException If the type is invalid.
      */
-    public static <T extends Angle> T create(Class<T> type, double magnitude) throws InvalidUnitsException
+    public static <T extends Coordinates> T create(Class<T> type, double magnitude) throws InvalidUnitsException
     {
         return UnitsUtilities.create(type, VALUE_TYPE, Double.valueOf(magnitude));
     }
@@ -65,7 +65,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      *         instantiated.
      * @throws InvalidUnitsException If the angle type is invalid.
      */
-    public static String getLongLabel(Class<? extends Angle> type) throws InvalidUnitsException
+    public static String getLongLabel(Class<? extends Coordinates> type) throws InvalidUnitsException
     {
         return create(type, 0.).getLongLabel();
     }
@@ -78,7 +78,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      * @return The label.
      * @throws InvalidUnitsException If the type is invalid.
      */
-    public static String getSelectionLabel(Class<? extends Angle> type) throws InvalidUnitsException
+    public static String getSelectionLabel(Class<? extends Coordinates> type) throws InvalidUnitsException
     {
         return create(type, 0.).getSelectionLabel();
     }
@@ -91,7 +91,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      *         instantiated.
      * @throws InvalidUnitsException If the angle type is invalid.
      */
-    public static String getShortLabel(Class<? extends Angle> type) throws InvalidUnitsException
+    public static String getShortLabel(Class<? extends Coordinates> type) throws InvalidUnitsException
     {
         return create(type, 0.).getShortLabel();
     }
@@ -101,17 +101,17 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
      *
      * @param magnitude The magnitude of the angle in degrees.
      */
-    protected Angle(double magnitude)
+    protected Coordinates(double magnitude)
     {
         myMagnitude = magnitude % 360.;
     }
 
     @Override
-    public Angle clone()
+    public Coordinates clone()
     {
         try
         {
-            return (Angle)super.clone();
+            return (Coordinates)super.clone();
         }
         catch (CloneNotSupportedException e)
         {
@@ -120,7 +120,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
     }
 
     @Override
-    public int compareTo(Angle o)
+    public int compareTo(Coordinates o)
     {
         double delta = getMagnitude() - o.getMagnitude();
         return delta < -MathUtil.DBL_EPSILON ? -1 : delta > MathUtil.DBL_EPSILON ? 1 : 0;
@@ -137,7 +137,7 @@ public abstract class Angle implements Cloneable, Serializable, Comparable<Angle
         {
             return false;
         }
-        Angle other = (Angle)obj;
+        Coordinates other = (Coordinates)obj;
         return Math.abs(getMagnitude() - other.getMagnitude()) <= MathUtil.DBL_EPSILON;
     }
 

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DecimalDegrees.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DecimalDegrees.java
@@ -3,10 +3,10 @@ package io.opensphere.core.units.angle;
 /**
  * An angle represented as decimal degrees.
  */
-public final class DecimalDegrees extends Angle
+public final class DecimalDegrees extends Coordinates
 {
     /** Long label. */
-    public static final String DEGREES_LONG_LABEL = "decimal degrees";
+    public static final String DEGREES_LONG_LABEL = "Decimal Degrees";
 
     /** Short label. */
     public static final String DEGREES_SHORT_LABEL = "\u00B0";
@@ -19,7 +19,7 @@ public final class DecimalDegrees extends Angle
      *
      * @param ang The other angle.
      */
-    public DecimalDegrees(Angle ang)
+    public DecimalDegrees(Coordinates ang)
     {
         super(ang.getMagnitude());
     }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegDecimalMin.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegDecimalMin.java
@@ -4,7 +4,7 @@ import io.opensphere.core.model.LatLonAlt;
 
 /** For formatting angles (i.e., lat/lon) in degrees and decimal minutes. */
 @SuppressWarnings("serial")
-public class DegDecimalMin extends Angle
+public class DegDecimalMin extends Coordinates
 {
     /** The precision for angular minutes. */
     private static final int MINUTES_PRECISION = 3;
@@ -22,7 +22,7 @@ public class DegDecimalMin extends Angle
     @Override
     public String getLongLabel()
     {
-        return "degrees decimal minutes";
+        return "Degrees Decimal Minutes";
     }
 
     @Override

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegreesMinutesSeconds.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/DegreesMinutesSeconds.java
@@ -6,10 +6,10 @@ import io.opensphere.core.util.MathUtil;
 /**
  * An angle represented as degrees/minutes/seconds.
  */
-public final class DegreesMinutesSeconds extends Angle
+public final class DegreesMinutesSeconds extends Coordinates
 {
     /** Long label. */
-    public static final String DMS_LONG_LABEL = "degrees minutes seconds";
+    public static final String DMS_LONG_LABEL = "Degrees Minutes Seconds";
 
     /** Short label. */
     public static final String DMS_SHORT_LABEL = "\u00B0'\"";
@@ -190,7 +190,7 @@ public final class DegreesMinutesSeconds extends Angle
      *
      * @param ang The other angle.
      */
-    public DegreesMinutesSeconds(Angle ang)
+    public DegreesMinutesSeconds(Coordinates ang)
     {
         super(ang.getMagnitude());
     }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/JAXBAngle.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/JAXBAngle.java
@@ -10,25 +10,25 @@ import io.opensphere.core.util.JAXBWrapper;
 import io.opensphere.core.util.Utilities;
 
 /**
- * Wrapper for an {@link Angle} that can be marshalled and unmarshalled using
+ * Wrapper for an {@link Coordinates} that can be marshalled and unmarshalled using
  * JAXB.
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-public class JAXBAngle implements JAXBWrapper<Angle>
+public class JAXBAngle implements JAXBWrapper<Coordinates>
 {
     /** The magnitude. */
     private double myMagnitude;
 
     /** The units. */
-    private Class<? extends Angle> myUnits;
+    private Class<? extends Coordinates> myUnits;
 
     /**
      * Constructor.
      *
      * @param angle The wrapped angle.
      */
-    public JAXBAngle(Angle angle)
+    public JAXBAngle(Coordinates angle)
     {
         myUnits = angle.getClass();
         myMagnitude = angle.getMagnitude();
@@ -59,9 +59,9 @@ public class JAXBAngle implements JAXBWrapper<Angle>
     }
 
     @Override
-    public Angle getWrappedObject()
+    public Coordinates getWrappedObject()
     {
-        return Angle.create(myUnits, myMagnitude);
+        return Coordinates.create(myUnits, myMagnitude);
     }
 
     @Override

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
@@ -32,27 +32,27 @@ public class MGRS extends Coordinates
     }
 
     @Override
-    public String toShortLabelString()
+    public String toShortLabelString()throws UnsupportedOperationException
     {
-        return "";
+        throw new UnsupportedOperationException("MGRS only has one format for display");
     }
 
     @Override
-    public String toShortLabelString(char pos, char neg)
+    public String toShortLabelString(char pos, char neg)throws UnsupportedOperationException
     {
-        return "";
+        throw new UnsupportedOperationException("\"MGRS only has one format for display");
     }
 
     @Override
-    public String toShortLabelString(int width, int precision)
+    public String toShortLabelString(int width, int precision) throws UnsupportedOperationException
     {
-        return "";
+        throw new UnsupportedOperationException("MGRS only has one format for display");
     }
 
     @Override
-    public String toShortLabelString(int width, int precision, char positive, char negative)
+    public String toShortLabelString(int width, int precision, char positive, char negative)throws UnsupportedOperationException
     {
-        return "";
+        throw new UnsupportedOperationException("MGRS only has one format for display");
     }
 
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
@@ -1,9 +1,9 @@
 package io.opensphere.core.units.angle;
 
+/** A Coordinate represented in the military grid reference system. */
 public class MGRS extends Coordinates
 
 {
-
     /**
      * The serial ID.
      */
@@ -32,13 +32,13 @@ public class MGRS extends Coordinates
     }
 
     @Override
-    public String toShortLabelString()throws UnsupportedOperationException
+    public String toShortLabelString() throws UnsupportedOperationException
     {
         throw new UnsupportedOperationException("MGRS only has one format for display");
     }
 
     @Override
-    public String toShortLabelString(char pos, char neg)throws UnsupportedOperationException
+    public String toShortLabelString(char pos, char neg) throws UnsupportedOperationException
     {
         throw new UnsupportedOperationException("MGRS only has one format for display");
     }
@@ -50,9 +50,8 @@ public class MGRS extends Coordinates
     }
 
     @Override
-    public String toShortLabelString(int width, int precision, char positive, char negative)throws UnsupportedOperationException
+    public String toShortLabelString(int width, int precision, char positive, char negative) throws UnsupportedOperationException
     {
         throw new UnsupportedOperationException("MGRS only has one format for display");
     }
-
 }

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
@@ -1,0 +1,58 @@
+package io.opensphere.core.units.angle;
+
+public class MGRS extends Coordinates
+
+{
+
+    /**
+     * The serial ID.
+     */
+    private static final long serialVersionUID = 8396025878700604825L;
+
+    /**
+     * Construct with a specified value in degrees.
+     *
+     * @param magnitude degrees
+     */
+    public MGRS(double magnitude)
+    {
+        super(magnitude);
+    }
+
+    @Override
+    public String getLongLabel()
+    {
+        return "MGRS";
+    }
+
+    @Override
+    public String getShortLabel()
+    {
+        return "MGRS";
+    }
+
+    @Override
+    public String toShortLabelString()
+    {
+        return "";
+    }
+
+    @Override
+    public String toShortLabelString(char pos, char neg)
+    {
+        return "";
+    }
+
+    @Override
+    public String toShortLabelString(int width, int precision)
+    {
+        return "";
+    }
+
+    @Override
+    public String toShortLabelString(int width, int precision, char positive, char negative)
+    {
+        return "";
+    }
+
+}

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
@@ -40,7 +40,7 @@ public class MGRS extends Coordinates
     @Override
     public String toShortLabelString(char pos, char neg)throws UnsupportedOperationException
     {
-        throw new UnsupportedOperationException("\"MGRS only has one format for display");
+        throw new UnsupportedOperationException("MGRS only has one format for display");
     }
 
     @Override

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
@@ -2,7 +2,6 @@ package io.opensphere.core.units.angle;
 
 /** A Coordinate represented in the military grid reference system. */
 public class MGRS extends Coordinates
-
 {
     /**
      * The serial ID.

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/units/angle/MGRS.java
@@ -22,7 +22,7 @@ public class MGRS extends Coordinates
     @Override
     public String getLongLabel()
     {
-        return "MGRS";
+        return "Military Grid Reference System";
     }
 
     @Override

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/AngleUnitsProviderTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/AngleUnitsProviderTest.java
@@ -36,17 +36,17 @@ public class AngleUnitsProviderTest
     @Test
     public void testAddAndRemoveAngleType() throws InvalidUnitsException
     {
-        Ref<Collection<Class<? extends Angle>>> r = new Ref<>();
-        UnitsChangeListener<Angle> listener = new UnitsChangeListener<Angle>()
+        Ref<Collection<Class<? extends Coordinates>>> r = new Ref<>();
+        UnitsChangeListener<Coordinates> listener = new UnitsChangeListener<Coordinates>()
         {
             @Override
-            public void availableUnitsChanged(Class<Angle> superType, Collection<Class<? extends Angle>> newTypes)
+            public void availableUnitsChanged(Class<Coordinates> superType, Collection<Class<? extends Coordinates>> newTypes)
             {
                 r.val = new LinkedList<>(newTypes);
             }
 
             @Override
-            public void preferredUnitsChanged(Class<? extends Angle> type)
+            public void preferredUnitsChanged(Class<? extends Coordinates> type)
             {
             }
         };
@@ -57,16 +57,16 @@ public class AngleUnitsProviderTest
         units.addUnits(DecimalDegrees.class);
         Assert.assertEquals(null, r.val);
 
-        Collection<Class<? extends Angle>> expected = new LinkedList<>();
+        Collection<Class<? extends Coordinates>> expected = new LinkedList<>();
         expected.add(DegDecimalMin.class);
-        listener.availableUnitsChanged(Angle.class, expected);
+        listener.availableUnitsChanged(Coordinates.class, expected);
         Assert.assertEquals(expected, r.val);
         expected.add(DecimalDegrees.class);
         units.removeUnits(DegreesMinutesSeconds.class);
         Assert.assertEquals(expected, r.val);
 
         expected.add(DegreesMinutesSeconds.class);
-        listener.availableUnitsChanged(Angle.class, expected);
+        listener.availableUnitsChanged(Coordinates.class, expected);
         Assert.assertEquals(expected, r.val);
         units.addUnits(DegreesMinutesSeconds.class);
         Assert.assertEquals(expected, r.val);
@@ -97,7 +97,7 @@ public class AngleUnitsProviderTest
     }
 
     /**
-     * Test for {@link AngleUnitsProvider#convert(Class, Angle)}.
+     * Test for {@link AngleUnitsProvider#convert(Class, Coordinates)}.
      */
     @Test
     public void testConvert()
@@ -152,7 +152,7 @@ public class AngleUnitsProviderTest
         AngleUnitsProvider units = new AngleUnitsProvider();
         units.setPreferredUnits(DecimalDegrees.class);
         @SuppressWarnings("unchecked")
-        UnitsProvider.UnitsChangeListener<Angle> listener = EasyMock.createStrictMock(UnitsProvider.UnitsChangeListener.class);
+        UnitsProvider.UnitsChangeListener<Coordinates> listener = EasyMock.createStrictMock(UnitsProvider.UnitsChangeListener.class);
         EasyMock.replay(listener);
         units.addListener(listener);
         // Listener should not be called.
@@ -166,7 +166,7 @@ public class AngleUnitsProviderTest
     }
 
     /**
-     * Test for {@link AngleUnitsProvider#toShortLabelString(Angle)} and
+     * Test for {@link AngleUnitsProvider#toShortLabelString(Coordinates)} and
      * {@link AngleUnitsProvider#fromShortLabelString(String)}.
      */
     @Test
@@ -175,12 +175,12 @@ public class AngleUnitsProviderTest
         AngleUnitsProvider units = new AngleUnitsProvider();
         DecimalDegrees input = new DecimalDegrees(34.545124);
         String str = units.toShortLabelString(input);
-        Angle output = units.fromShortLabelString(str);
+        Coordinates output = units.fromShortLabelString(str);
         Assert.assertEquals(input, output);
     }
 
     /** Adapter for Angle class. */
-    private abstract static class AngleAdapter extends Angle
+    private abstract static class AngleAdapter extends Coordinates
     {
         /** Serial version UID. */
         private static final long serialVersionUID = 1L;
@@ -266,7 +266,7 @@ public class AngleUnitsProviderTest
          *
          * @param angle The angle.
          */
-        public InvalidAngle2(Angle angle)
+        public InvalidAngle2(Coordinates angle)
         {
             super(angle.getMagnitude());
         }

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/DecimalDegreesTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/DecimalDegreesTest.java
@@ -15,17 +15,17 @@ public class DecimalDegreesTest
     @Test
     public void testClone()
     {
-        Angle ang = new DecimalDegrees(34.54512);
+        Coordinates ang = new DecimalDegrees(34.54512);
         Assert.assertEquals(ang.getMagnitude(), ang.clone().getMagnitude(), 0.);
     }
 
     /**
-     * Test {@link Angle#compareTo(Angle)}.
+     * Test {@link Coordinates#compareTo(Coordinates)}.
      */
     @Test
     public void testCompareTo()
     {
-        Angle ang = new DecimalDegrees(34.54512);
+        Coordinates ang = new DecimalDegrees(34.54512);
         Assert.assertEquals(0, ang.compareTo(new DecimalDegrees(34.54512)));
         Assert.assertTrue(ang.compareTo(new DecimalDegrees(34.54513)) < 0);
         Assert.assertTrue(ang.compareTo(new DecimalDegrees(34.54511)) > 0);
@@ -46,7 +46,7 @@ public class DecimalDegreesTest
     @Test
     public void testHashCode()
     {
-        Angle ang = new DecimalDegrees(34.54512);
+        Coordinates ang = new DecimalDegrees(34.54512);
         Assert.assertEquals(ang.hashCode(), new DecimalDegrees(34.54512).hashCode());
         Assert.assertFalse(ang.hashCode() == new DecimalDegrees(34.545125).hashCode());
     }
@@ -57,14 +57,14 @@ public class DecimalDegreesTest
     @Test
     public void testLabels()
     {
-        Angle ang = new DecimalDegrees(34.54512);
+        Coordinates ang = new DecimalDegrees(34.54512);
         Assert.assertTrue(ang.getLongLabel().length() > 0);
         Assert.assertTrue(ang.getShortLabel().length() > 0);
         Assert.assertTrue(ang.toString().length() > 0);
     }
 
     /**
-     * Test {@link Angle#toShortLabelString()}.
+     * Test {@link Coordinates#toShortLabelString()}.
      */
     @Test
     public void testToShortLabelString()
@@ -79,7 +79,7 @@ public class DecimalDegreesTest
     }
 
     /**
-     * Test {@link Angle#toShortLabelString(char, char)}.
+     * Test {@link Coordinates#toShortLabelString(char, char)}.
      */
     @Test
     public void testToShortLabelStringCharChar()

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/DegreesMinutesSecondsTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/DegreesMinutesSecondsTest.java
@@ -15,17 +15,17 @@ public class DegreesMinutesSecondsTest
     @Test
     public void testClone()
     {
-        Angle ang = new DegreesMinutesSeconds(34.54512);
+        Coordinates ang = new DegreesMinutesSeconds(34.54512);
         Assert.assertEquals(ang.getMagnitude(), ang.clone().getMagnitude(), 0.);
     }
 
     /**
-     * Test {@link Angle#compareTo(Angle)}.
+     * Test {@link Coordinates#compareTo(Coordinates)}.
      */
     @Test
     public void testCompareTo()
     {
-        Angle ang = new DegreesMinutesSeconds(34.54512);
+        Coordinates ang = new DegreesMinutesSeconds(34.54512);
         Assert.assertEquals(0, ang.compareTo(new DegreesMinutesSeconds(34.54512)));
         Assert.assertTrue(ang.compareTo(new DegreesMinutesSeconds(34.54513)) < 0);
         Assert.assertTrue(ang.compareTo(new DegreesMinutesSeconds(34.54511)) > 0);
@@ -46,7 +46,7 @@ public class DegreesMinutesSecondsTest
     @Test
     public void testHashCode()
     {
-        Angle ang = new DegreesMinutesSeconds(34.54512);
+        Coordinates ang = new DegreesMinutesSeconds(34.54512);
         Assert.assertEquals(ang.hashCode(), new DegreesMinutesSeconds(34.54512).hashCode());
         Assert.assertFalse(ang.hashCode() == new DegreesMinutesSeconds(34.545125).hashCode());
     }
@@ -57,14 +57,14 @@ public class DegreesMinutesSecondsTest
     @Test
     public void testLabels()
     {
-        Angle ang = new DegreesMinutesSeconds(34.54512);
+        Coordinates ang = new DegreesMinutesSeconds(34.54512);
         Assert.assertTrue(ang.getLongLabel().length() > 0);
         Assert.assertTrue(ang.getShortLabel().length() > 0);
         Assert.assertTrue(ang.toString().length() > 0);
     }
 
     /**
-     * Test {@link Angle#toShortLabelString()}.
+     * Test {@link Coordinates#toShortLabelString()}.
      */
     @Test
     public void testToShortLabelString()
@@ -98,7 +98,7 @@ public class DegreesMinutesSecondsTest
     }
 
     /**
-     * Test {@link Angle#toShortLabelString(char, char)}.
+     * Test {@link Coordinates#toShortLabelString(char, char)}.
      */
     @Test
     public void testToShortLabelStringCharChar()
@@ -132,7 +132,7 @@ public class DegreesMinutesSecondsTest
     }
 
     /**
-     * Test {@link Angle#toShortLabelString(int, int)}.
+     * Test {@link Coordinates#toShortLabelString(int, int)}.
      */
     @Test
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/JAXBAngleTest.java
+++ b/open-sphere-base/core/src/test/java/io/opensphere/core/units/angle/JAXBAngleTest.java
@@ -15,7 +15,7 @@ import io.opensphere.core.util.XMLUtilities;
 public class JAXBAngleTest
 {
     /**
-     * Test marshalling and unmarshalling a {@link Angle} using
+     * Test marshalling and unmarshalling a {@link Coordinates} using
      * {@link JAXBAngle}.
      *
      * @throws JAXBException If there is a JAXB error.
@@ -24,10 +24,10 @@ public class JAXBAngleTest
     @Test
     public void test() throws JAXBException, ClassNotFoundException
     {
-        Angle result;
+        Coordinates result;
         Element el;
 
-        Angle testDD = new DecimalDegrees(24.352);
+        Coordinates testDD = new DecimalDegrees(24.352);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         XMLUtilities.writeXMLObject(new JAXBAngle(testDD), baos);
 
@@ -36,10 +36,10 @@ public class JAXBAngleTest
 
         baos.reset();
         el = XMLUtilities.marshalJAXBableToElement(testDD);
-        result = XMLUtilities.readJAXBableObject(el, Angle.class);
+        result = XMLUtilities.readJAXBableObject(el, Coordinates.class);
         Assert.assertEquals(result, testDD);
 
-        Angle testDMS = new DegreesMinutesSeconds(24.352);
+        Coordinates testDMS = new DegreesMinutesSeconds(24.352);
         baos.reset();
         XMLUtilities.writeXMLObject(new JAXBAngle(testDMS), baos);
 
@@ -48,7 +48,7 @@ public class JAXBAngleTest
 
         baos.reset();
         el = XMLUtilities.marshalJAXBableToElement(testDMS);
-        result = XMLUtilities.readJAXBableObject(el, Angle.class);
+        result = XMLUtilities.readJAXBableObject(el, Coordinates.class);
         Assert.assertEquals(result, testDMS);
     }
 }

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
@@ -30,12 +30,6 @@ public class CursorPositionPanel extends JPanel
     private final transient UnitsChangeListener<Coordinates> myAngleUnitsChangeListener = new UnitsChangeListener<Coordinates>()
     {
         @Override
-        public void availableUnitsChanged(Class<Coordinates> superType, Collection<Class<? extends Coordinates>> newTypes)
-        {
-
-        }
-
-        @Override
         public void preferredUnitsChanged(Class<? extends Coordinates> type)
         {
             myPreferredCoordUnits = type;
@@ -55,22 +49,10 @@ public class CursorPositionPanel extends JPanel
     private final transient UnitsChangeListener<Length> myLengthUnitsChangeListener = new UnitsChangeListener<Length>()
     {
         @Override
-        public void availableUnitsChanged(Class<Length> superType, Collection<Class<? extends Length>> newTypes)
-        {
-        }
-
-        @Override
         public void preferredUnitsChanged(Class<? extends Length> type)
         {
             myPreferredLengthUnits = type;
         }
-
-        @Override
-        public void prevpreferredUnitsChanged(Class<? extends Length> preferredType)
-        {
-            
-        }
-     
     };
 
     /** The Lon label. */

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
@@ -214,7 +214,6 @@ public class CursorPositionPanel extends JPanel
             {
                 myAltLabel.setText("");
             }
-
         }
     }
 

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
@@ -79,7 +79,7 @@ public class CursorPositionPanel extends JPanel
     public CursorPositionPanel(Font font, UnitsRegistry unitsRegistry)
     {
         super(new GridBagLayout());
-        myUnitsRegistry = unitsRegistry;
+        
         UnitsProvider<Length> lengthProvider = unitsRegistry.getUnitsProvider(Length.class);
         lengthProvider.addListener(myLengthUnitsChangeListener);
         myPreferredLengthUnits = lengthProvider.getPreferredUnits();

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
@@ -184,7 +184,7 @@ public class CursorPositionPanel extends JPanel
         myMGRSLabel.setText(mgrsText);
         if (latLonAlt != null)
         {
-            if (myPreferredCoordUnits.getSimpleName() != "MGRS")
+            if (!myPreferredCoordUnits.getSimpleName().equals("MGRS"))
             {
                 Coordinates lat = Coordinates.create(myPreferredCoordUnits, latLonAlt.getLatD());
                 Coordinates lon = Coordinates.create(myPreferredCoordUnits, latLonAlt.getLonD());
@@ -192,8 +192,7 @@ public class CursorPositionPanel extends JPanel
                 myLatLabel.setText(lat.toShortLabelString(15, 6, 'N', 'S'));
                 myLonLabel.setText(lon.toShortLabelString(15, 6, 'E', 'W'));
             }
-
-            if (myPreferredCoordUnits.getSimpleName().equals("MGRS"))
+            else 
             {
                 Coordinates lat = Coordinates.create(myPrevPreferredCoordUnits, latLonAlt.getLatD());
                 Coordinates lon = Coordinates.create(myPrevPreferredCoordUnits, latLonAlt.getLonD());

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
@@ -70,8 +70,6 @@ public class CursorPositionPanel extends JPanel
     /** The currently preferred length units. */
     private volatile Class<? extends Length> myPreferredLengthUnits;
 
-    private UnitsRegistry myUnitsRegistry;
-
     /**
      * Constructor.
      *

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
@@ -34,7 +34,7 @@ public class CursorPositionPanel extends JPanel
         {
             myPreferredCoordUnits = type;
         }
-        
+
         @Override
         public void prevpreferredUnitsChanged(Class<? extends Coordinates> preferredType)
         {

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
@@ -40,6 +40,12 @@ public class CursorPositionPanel extends JPanel
         {
             myPreferredCoordUnits = type;
         }
+        
+        @Override
+        public void prevpreferredUnitsChanged(Class<? extends Coordinates> preferredType)
+        {
+            myPrevPreferredCoordUnits = preferredType;
+        }
     };
 
     /** The Lat label. */
@@ -58,6 +64,13 @@ public class CursorPositionPanel extends JPanel
         {
             myPreferredLengthUnits = type;
         }
+
+        @Override
+        public void prevpreferredUnitsChanged(Class<? extends Length> preferredType)
+        {
+            
+        }
+     
     };
 
     /** The Lon label. */
@@ -75,6 +88,8 @@ public class CursorPositionPanel extends JPanel
     /** The currently preferred length units. */
     private volatile Class<? extends Length> myPreferredLengthUnits;
 
+    private UnitsRegistry myUnitsRegistry;
+
     /**
      * Constructor.
      *
@@ -84,7 +99,7 @@ public class CursorPositionPanel extends JPanel
     public CursorPositionPanel(Font font, UnitsRegistry unitsRegistry)
     {
         super(new GridBagLayout());
-
+        myUnitsRegistry = unitsRegistry;
         UnitsProvider<Length> lengthProvider = unitsRegistry.getUnitsProvider(Length.class);
         lengthProvider.addListener(myLengthUnitsChangeListener);
         myPreferredLengthUnits = lengthProvider.getPreferredUnits();
@@ -198,9 +213,8 @@ public class CursorPositionPanel extends JPanel
                 myLonLabel.setText(lon.toShortLabelString(15, 6, 'E', 'W'));
             }
 
-            if (myPreferredCoordUnits.getSimpleName() == "MGRS")
+            if (myPreferredCoordUnits.getSimpleName().equals("MGRS"))
             {
-                System.out.println("it is in the equals");
                 Coordinates lat = Coordinates.create(myPrevPreferredCoordUnits, latLonAlt.getLatD());
                 Coordinates lon = Coordinates.create(myPrevPreferredCoordUnits, latLonAlt.getLonD());
 

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
@@ -79,7 +79,7 @@ public class CursorPositionPanel extends JPanel
     public CursorPositionPanel(Font font, UnitsRegistry unitsRegistry)
     {
         super(new GridBagLayout());
-        
+ 
         UnitsProvider<Length> lengthProvider = unitsRegistry.getUnitsProvider(Length.class);
         lengthProvider.addListener(myLengthUnitsChangeListener);
         myPreferredLengthUnits = lengthProvider.getPreferredUnits();

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPanel.java
@@ -13,7 +13,7 @@ import io.opensphere.core.UnitsRegistry;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.units.UnitsProvider;
 import io.opensphere.core.units.UnitsProvider.UnitsChangeListener;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.length.Length;
 
 /** Panel that displays the cursor position. */
@@ -26,15 +26,15 @@ public class CursorPositionPanel extends JPanel
     private final JLabel myAltLabel = new JLabel();
 
     /** A listener for changes to the preferred angle units. */
-    private final transient UnitsChangeListener<Angle> myAngleUnitsChangeListener = new UnitsChangeListener<Angle>()
+    private final transient UnitsChangeListener<Coordinates> myAngleUnitsChangeListener = new UnitsChangeListener<Coordinates>()
     {
         @Override
-        public void availableUnitsChanged(Class<Angle> superType, Collection<Class<? extends Angle>> newTypes)
+        public void availableUnitsChanged(Class<Coordinates> superType, Collection<Class<? extends Coordinates>> newTypes)
         {
         }
 
         @Override
-        public void preferredUnitsChanged(Class<? extends Angle> type)
+        public void preferredUnitsChanged(Class<? extends Coordinates> type)
         {
             myPreferredAngleUnits = type;
         }
@@ -65,7 +65,7 @@ public class CursorPositionPanel extends JPanel
     private final JLabel myMGRSLabel = new JLabel();
 
     /** The currently preferred angle units. */
-    private volatile Class<? extends Angle> myPreferredAngleUnits;
+    private volatile Class<? extends Coordinates> myPreferredAngleUnits;
 
     /** The currently preferred length units. */
     private volatile Class<? extends Length> myPreferredLengthUnits;
@@ -83,7 +83,7 @@ public class CursorPositionPanel extends JPanel
         UnitsProvider<Length> lengthProvider = unitsRegistry.getUnitsProvider(Length.class);
         lengthProvider.addListener(myLengthUnitsChangeListener);
         myPreferredLengthUnits = lengthProvider.getPreferredUnits();
-        UnitsProvider<Angle> angleProvider = unitsRegistry.getUnitsProvider(Angle.class);
+        UnitsProvider<Coordinates> angleProvider = unitsRegistry.getUnitsProvider(Coordinates.class);
         angleProvider.addListener(myAngleUnitsChangeListener);
         myPreferredAngleUnits = angleProvider.getPreferredUnits();
 
@@ -179,8 +179,8 @@ public class CursorPositionPanel extends JPanel
         {
             if (myPreferredAngleUnits != null)
             {
-                Angle lat = Angle.create(myPreferredAngleUnits, latLonAlt.getLatD());
-                Angle lon = Angle.create(myPreferredAngleUnits, latLonAlt.getLonD());
+                Coordinates lat = Coordinates.create(myPreferredAngleUnits, latLonAlt.getLatD());
+                Coordinates lon = Coordinates.create(myPreferredAngleUnits, latLonAlt.getLonD());
 
                 myLatLabel.setText(lat.toShortLabelString(15, 6, 'N', 'S'));
                 myLonLabel.setText(lon.toShortLabelString(15, 6, 'E', 'W'));

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
@@ -10,10 +10,12 @@ import java.util.function.Supplier;
 import javax.swing.BorderFactory;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.WindowConstants;
 
+import io.opensphere.core.Notify;
 import io.opensphere.core.UnitsRegistry;
 import io.opensphere.core.control.DiscreteEventAdapter;
 import io.opensphere.core.mgrs.MGRSConverter;
@@ -119,8 +121,6 @@ public class CursorPositionPopupManager
                     dialog.pack();
                     dialog.setVisible(true);
 
-                    Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-                    clipboard.setContents(new StringSelection(builder.toString()), null);
                 });
             }
         }
@@ -133,6 +133,8 @@ public class CursorPositionPopupManager
     private final DiscreteEventAdapter myAltListener = new DiscreteEventAdapter("Cursor Position", "Display Cursor Position",
             "Show a popup with the current mouse cursor position")
     {
+
+        private String myCoordLabel;
 
         @Override
         public void eventOccurred(InputEvent event)
@@ -152,33 +154,52 @@ public class CursorPositionPopupManager
 
                     StringBuilder builder = new StringBuilder("");
                     Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                    System.out.println("current Preferred: " + myUnitsRegistry.getPreferredUnits(Coordinates.class));
+                    System.out.println("current previous Preferred: " + myUnitsRegistry.getPrevPreferredUnits(Coordinates.class));
+
                     switch (myUnitsRegistry.getPreferredUnits(Coordinates.class).getSimpleName())
                     {
                         case "DegreesMinutesSeconds":
                             builder.append(latitudeDMS.toShortLabelString(14, 6, 'N', 'S').trim()).append("\t");
                             builder.append(longitudeDMS.toShortLabelString(14, 6, 'E', 'W').trim()).append("\n");
-                            clipboard.setContents(new StringSelection(builder.toString()), null);
+                            myCoordLabel = builder.toString();
+                            clipboard.setContents(new StringSelection(myCoordLabel), null);
                             break;
 
                         case "DegDecimalMin":
                             builder.append(latitudeDDM.toShortLabelString(14, 6, 'N', 'S').trim()).append("\t");
                             builder.append(longitudeDDM.toShortLabelString(14, 6, 'E', 'W').trim()).append("\n");
-                            clipboard.setContents(new StringSelection(builder.toString()), null);
+                            myCoordLabel = builder.toString();
+                            clipboard.setContents(new StringSelection(myCoordLabel), null);
                             break;
 
                         case "DecimalDegrees":
                             builder.append(latitudeDD.toShortLabelString(14, 6, 'N', 'S').trim()).append("\t");
                             builder.append(longitudeDD.toShortLabelString(14, 6, 'E', 'W').trim()).append("\n");
-                            clipboard.setContents(new StringSelection(builder.toString()), null);
+                            myCoordLabel = builder.toString();
+                            clipboard.setContents(new StringSelection(myCoordLabel), null);
+
                             break;
 
                         case "MGRS":
                             builder.append(MGRS_CONVERTER.createString(new UTM(new GeographicPosition(myLocation))));
-                            clipboard.setContents(new StringSelection(builder.toString()), null);
+                            myCoordLabel = builder.toString();
+                            clipboard.setContents(new StringSelection(myCoordLabel), null);
                             break;
                     }
-
+                    if (myUnitsRegistry != null)
+                    {
+                        try
+                        {
+                            Notify.info("Copied " + myCoordLabel + " to clipboard");
+                        }
+                        catch (IllegalStateException ex)
+                        {
+                            JOptionPane.showMessageDialog(null, "Failed to copy to clipboard.");
+                        }
+                    }
                 });
+
             }
         }
     };

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
@@ -154,9 +154,7 @@ public class CursorPositionPopupManager
 
                     StringBuilder builder = new StringBuilder("");
                     Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-                    System.out.println("current Preferred: " + myUnitsRegistry.getPreferredUnits(Coordinates.class));
-                    System.out.println("current previous Preferred: " + myUnitsRegistry.getPrevPreferredUnits(Coordinates.class));
-
+                    
                     switch (myUnitsRegistry.getPreferredUnits(Coordinates.class).getSimpleName())
                     {
                         case "DegreesMinutesSeconds":

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
@@ -140,8 +140,6 @@ public class CursorPositionPopupManager
         {
             if (myLocation != null)
             {
-                EventQueueUtilities.invokeLater(() ->
-                {
                     DecimalDegrees latitudeDD = Coordinates.create(DecimalDegrees.class, myLocation.getLatD());
                     DecimalDegrees longitudeDD = Coordinates.create(DecimalDegrees.class, myLocation.getLonD());
 
@@ -184,19 +182,7 @@ public class CursorPositionPopupManager
                             clipboard.setContents(new StringSelection(myCoordLabel), null);
                             break;
                     }
-                    if (myUnitsRegistry != null)
-                    {
-                        try
-                        {
                             Notify.info("Copied " + myCoordLabel + " to clipboard");
-                        }
-                        catch (IllegalStateException ex)
-                        {
-                            JOptionPane.showMessageDialog(null, "Failed to copy to clipboard.");
-                        }
-                    }
-                });
-
             }
         }
     };

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionPopupManager.java
@@ -120,7 +120,6 @@ public class CursorPositionPopupManager
                     dialog.setLocationRelativeTo(dialog.getParent());
                     dialog.pack();
                     dialog.setVisible(true);
-
                 });
             }
         }

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionTransformer.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionTransformer.java
@@ -104,7 +104,7 @@ final class CursorPositionTransformer extends AbstractOverlayTransformer
                 .addListener(myCursorPositionPopupManager.getListener(), new DefaultKeyPressedBinding(KeyEvent.VK_PERIOD));
         
         toolbox.getControlRegistry().getControlContext(ControlRegistry.GLOBE_CONTROL_CONTEXT)
-        .addListener(myCursorPositionPopupManager.getAltListener(), new DefaultKeyPressedBinding(KeyEvent.VK_CAPS_LOCK));
+        .addListener(myCursorPositionPopupManager.getAltListener(), new DefaultKeyPressedBinding(KeyEvent.VK_C));
 
         myToolbox.getUIRegistry().getToolbarComponentRegistry().registerToolbarComponent(ToolbarLocation.SOUTH, "CursorPosition",
                 myCursorPositionPanel, 10000, SeparatorLocation.NONE);

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionTransformer.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionTransformer.java
@@ -102,6 +102,9 @@ final class CursorPositionTransformer extends AbstractOverlayTransformer
                 toolbox.getUnitsRegistry());
         toolbox.getControlRegistry().getControlContext(ControlRegistry.GLOBE_CONTROL_CONTEXT)
                 .addListener(myCursorPositionPopupManager.getListener(), new DefaultKeyPressedBinding(KeyEvent.VK_PERIOD));
+        
+        toolbox.getControlRegistry().getControlContext(ControlRegistry.GLOBE_CONTROL_CONTEXT)
+        .addListener(myCursorPositionPopupManager.getAltListener(), new DefaultKeyPressedBinding(KeyEvent.VK_CAPS_LOCK));
 
         myToolbox.getUIRegistry().getToolbarComponentRegistry().registerToolbarComponent(ToolbarLocation.SOUTH, "CursorPosition",
                 myCursorPositionPanel, 10000, SeparatorLocation.NONE);

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionWindow.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionWindow.java
@@ -45,7 +45,7 @@ class CursorPositionWindow extends InfoOverlayWindow
     public void addLabels()
     {
         TextLabel.Builder builder = new TextLabel.Builder();
-        builder.setText("hi");
+        builder.setText("");
         builder.setColor(Color.GREEN);
         builder.setFont(Font.SANS_SERIF + " PLAIN 12");
         GridLayoutConstraints constr = null;

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionWindow.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/CursorPositionWindow.java
@@ -45,7 +45,7 @@ class CursorPositionWindow extends InfoOverlayWindow
     public void addLabels()
     {
         TextLabel.Builder builder = new TextLabel.Builder();
-        builder.setText("");
+        builder.setText("hi");
         builder.setColor(Color.GREEN);
         builder.setFont(Font.SANS_SERIF + " PLAIN 12");
         GridLayoutConstraints constr = null;

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/ViewerPositionTransformer.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/ViewerPositionTransformer.java
@@ -24,7 +24,7 @@ import io.opensphere.core.model.ScreenPosition;
 import io.opensphere.core.preferences.Preferences;
 import io.opensphere.core.units.UnitsProvider;
 import io.opensphere.core.units.UnitsProvider.UnitsChangeListener;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.angle.DecimalDegrees;
 import io.opensphere.core.units.length.Length;
 import io.opensphere.core.util.swing.EventQueueUtilities;
@@ -204,7 +204,7 @@ final class ViewerPositionTransformer extends AbstractOverlayTransformer
 
                 double pitch = Math.toDegrees(myToolbox.getMapManager().getStandardViewer().getPitch());
                 pitch = Math.round(pitch * precision) / precision;
-                Angle pitchAngle = Angle.create(DecimalDegrees.class, pitch);
+                Coordinates pitchAngle = Coordinates.create(DecimalDegrees.class, pitch);
                 final String pitchText = pitchAngle.toShortLabelString(10, 3);
 
                 Length elevation = Length.create(myPreferredLengthUnits,
@@ -213,7 +213,7 @@ final class ViewerPositionTransformer extends AbstractOverlayTransformer
 
                 double heading = Math.toDegrees(myToolbox.getMapManager().getStandardViewer().getHeading());
                 heading = Math.round(heading * precision) / precision;
-                Angle headingAngle = Angle.create(DecimalDegrees.class, heading);
+                Coordinates headingAngle = Coordinates.create(DecimalDegrees.class, heading);
                 final String headingText = headingAngle.toShortLabelString(9, 3);
 
                 EventQueueUtilities.invokeLater(new Runnable()

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/ViewerPositionTransformer.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/ViewerPositionTransformer.java
@@ -52,21 +52,10 @@ final class ViewerPositionTransformer extends AbstractOverlayTransformer
     private final UnitsChangeListener<Length> myLengthUnitsChangeListener = new UnitsChangeListener<Length>()
     {
         @Override
-        public void availableUnitsChanged(Class<Length> superType, Collection<Class<? extends Length>> newTypes)
-        {
-        }
-
-        @Override
         public void preferredUnitsChanged(Class<? extends Length> type)
         {
             myPreferredLengthUnits = type;
             createViewPositionLabels();
-        }
-
-        @Override
-        public void prevpreferredUnitsChanged(Class<? extends Length> preferredType)
-        {
-            
         }
     };
 

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/ViewerPositionTransformer.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/ViewerPositionTransformer.java
@@ -62,6 +62,12 @@ final class ViewerPositionTransformer extends AbstractOverlayTransformer
             myPreferredLengthUnits = type;
             createViewPositionLabels();
         }
+
+        @Override
+        public void prevpreferredUnitsChanged(Class<? extends Length> preferredType)
+        {
+            
+        }
     };
 
     /** The Pitch label. */

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/arc/CompletedArcManager.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/arc/CompletedArcManager.java
@@ -172,7 +172,6 @@ public class CompletedArcManager
     /** The listener to system units changes. */
     private final UnitsChangeListener<Length> myUnitsChangeListener = new UnitsChangeListener<Length>()
     {
-
         @Override
         public void preferredUnitsChanged(final Class<? extends Length> units)
         {

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/arc/CompletedArcManager.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/arc/CompletedArcManager.java
@@ -172,10 +172,6 @@ public class CompletedArcManager
     /** The listener to system units changes. */
     private final UnitsChangeListener<Length> myUnitsChangeListener = new UnitsChangeListener<Length>()
     {
-        @Override
-        public void availableUnitsChanged(Class<Length> superType, Collection<Class<? extends Length>> newTypes)
-        {
-        }
 
         @Override
         public void preferredUnitsChanged(final Class<? extends Length> units)

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/scalebar/HUDScalebar.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/scalebar/HUDScalebar.java
@@ -65,11 +65,7 @@ public class HUDScalebar extends AbstractOverlayWindow
     /** Listener for units changes. */
     private final UnitsChangeListener<Length> myUnitsChangeListener = new UnitsChangeListener<Length>()
     {
-        @Override
-        public void availableUnitsChanged(Class<Length> superType, Collection<Class<? extends Length>> newTypes)
-        {
-        }
-
+      
         @Override
         public void preferredUnitsChanged(Class<? extends Length> type)
         {

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/scalebar/HUDScalebar.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/scalebar/HUDScalebar.java
@@ -65,7 +65,6 @@ public class HUDScalebar extends AbstractOverlayWindow
     /** Listener for units changes. */
     private final UnitsChangeListener<Length> myUnitsChangeListener = new UnitsChangeListener<Length>()
     {
-      
         @Override
         public void preferredUnitsChanged(Class<? extends Length> type)
         {

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/terrainprofile/TerrainChartElevationLabel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/terrainprofile/TerrainChartElevationLabel.java
@@ -28,7 +28,6 @@ public class TerrainChartElevationLabel extends Renderable
     /** Listener for units changes. */
     private final UnitsChangeListener<Length> myListener = new UnitsChangeListener<Length>()
     {
-    
         @Override
         public void preferredUnitsChanged(Class<? extends Length> type)
         {

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/terrainprofile/TerrainChartElevationLabel.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/terrainprofile/TerrainChartElevationLabel.java
@@ -28,11 +28,7 @@ public class TerrainChartElevationLabel extends Renderable
     /** Listener for units changes. */
     private final UnitsChangeListener<Length> myListener = new UnitsChangeListener<Length>()
     {
-        @Override
-        public void availableUnitsChanged(Class<Length> superType, Collection<Class<? extends Length>> newTypes)
-        {
-        }
-
+    
         @Override
         public void preferredUnitsChanged(Class<? extends Length> type)
         {

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/terrainprofile/TerrainProfile.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/terrainprofile/TerrainProfile.java
@@ -90,11 +90,7 @@ public class TerrainProfile extends AbstractOverlayWindow
     /** Listener for units changes. */
     private final UnitsChangeListener<Length> myListener = new UnitsChangeListener<Length>()
     {
-        @Override
-        public void availableUnitsChanged(Class<Length> superType, Collection<Class<? extends Length>> newTypes)
-        {
-        }
-
+        
         @Override
         public void preferredUnitsChanged(Class<? extends Length> type)
         {

--- a/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/terrainprofile/TerrainProfile.java
+++ b/open-sphere-base/overlay/src/main/java/io/opensphere/overlay/terrainprofile/TerrainProfile.java
@@ -90,7 +90,6 @@ public class TerrainProfile extends AbstractOverlayWindow
     /** Listener for units changes. */
     private final UnitsChangeListener<Length> myListener = new UnitsChangeListener<Length>()
     {
-        
         @Override
         public void preferredUnitsChanged(Class<? extends Length> type)
         {

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/editor/controller/AnnotationsHelper.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/editor/controller/AnnotationsHelper.java
@@ -37,10 +37,6 @@ public class AnnotationsHelper
     /** A listener for changes to the preferred units. */
     private final UnitsChangeListener<Length> myUnitsChangeListener = new UnitsChangeListener<Length>()
     {
-        @Override
-        public void availableUnitsChanged(Class<Length> superType, Collection<Class<? extends Length>> newTypes)
-        {
-        }
 
         @Override
         public void preferredUnitsChanged(Class<? extends Length> type)

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/editor/controller/AnnotationsHelper.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/editor/controller/AnnotationsHelper.java
@@ -37,7 +37,6 @@ public class AnnotationsHelper
     /** A listener for changes to the preferred units. */
     private final UnitsChangeListener<Length> myUnitsChangeListener = new UnitsChangeListener<Length>()
     {
-
         @Override
         public void preferredUnitsChanged(Class<? extends Length> type)
         {

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/specific/regions/RegionRenderer.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/myplaces/specific/regions/RegionRenderer.java
@@ -30,7 +30,7 @@ import io.opensphere.core.model.BoundingBoxes;
 import io.opensphere.core.model.GeographicPosition;
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.model.Position;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.angle.DecimalDegrees;
 import io.opensphere.core.units.angle.DegreesMinutesSeconds;
 import io.opensphere.core.util.Utilities;
@@ -207,13 +207,13 @@ public class RegionRenderer extends DefaultTransformer implements Renderer
      * @param units The units to display.
      * @param text The output list of text.
      */
-    protected void addCoordinates(LatLonAlt southwest, LatLonAlt northeast, Class<? extends Angle> units,
+    protected void addCoordinates(LatLonAlt southwest, LatLonAlt northeast, Class<? extends Coordinates> units,
             List<? super String> text)
     {
-        text.add(StringUtilities.concat("SW: ", Angle.create(units, southwest.getLatD()).toShortLabelString('N', 'S'), " ",
-                Angle.create(units, southwest.getLonD()).toShortLabelString('E', 'W')));
-        text.add(StringUtilities.concat("NE: ", Angle.create(units, northeast.getLatD()).toShortLabelString('N', 'S'), " ",
-                Angle.create(units, northeast.getLonD()).toShortLabelString('E', 'W')));
+        text.add(StringUtilities.concat("SW: ", Coordinates.create(units, southwest.getLatD()).toShortLabelString('N', 'S'), " ",
+                Coordinates.create(units, southwest.getLonD()).toShortLabelString('E', 'W')));
+        text.add(StringUtilities.concat("NE: ", Coordinates.create(units, northeast.getLatD()).toShortLabelString('N', 'S'), " ",
+                Coordinates.create(units, northeast.getLonD()).toShortLabelString('E', 'W')));
     }
 
     /**

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/tracktool/CompletedTrackManager.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/tracktool/CompletedTrackManager.java
@@ -170,7 +170,6 @@ public class CompletedTrackManager
     /** The listener to system distance unit changes. */
     private final UnitsChangeListener<Length> myDistanceUnitChangeListener = new UnitsChangeListener<Length>()
     {
-
         @Override
         public void preferredUnitsChanged(final Class<? extends Length> distanceUnits)
         {

--- a/open-sphere-plugins/my-places/src/main/java/io/opensphere/tracktool/CompletedTrackManager.java
+++ b/open-sphere-plugins/my-places/src/main/java/io/opensphere/tracktool/CompletedTrackManager.java
@@ -170,11 +170,6 @@ public class CompletedTrackManager
     /** The listener to system distance unit changes. */
     private final UnitsChangeListener<Length> myDistanceUnitChangeListener = new UnitsChangeListener<Length>()
     {
-        @Override
-        public void availableUnitsChanged(Class<Length> superType, Collection<Class<? extends Length>> newTypes)
-        {
-            /* intentionally blank */
-        }
 
         @Override
         public void preferredUnitsChanged(final Class<? extends Length> distanceUnits)

--- a/open-sphere-plugins/search/src/main/java/io/opensphere/search/view/SearchResultBasic.java
+++ b/open-sphere-plugins/search/src/main/java/io/opensphere/search/view/SearchResultBasic.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import io.opensphere.core.model.LatLonAlt;
 import io.opensphere.core.search.SearchResult;
-import io.opensphere.core.units.angle.Angle;
+import io.opensphere.core.units.angle.Coordinates;
 import io.opensphere.core.units.angle.DecimalDegrees;
 import io.opensphere.core.units.length.Length;
 import io.opensphere.core.units.length.Meters;
@@ -197,8 +197,8 @@ public class SearchResultBasic extends GridPane implements Closeable
     private String toString(LatLonAlt location)
     {
         StringBuilder builder = new StringBuilder();
-        Angle lat = Angle.create(DecimalDegrees.class, location.getLatD());
-        Angle lon = Angle.create(DecimalDegrees.class, location.getLonD());
+        Coordinates lat = Coordinates.create(DecimalDegrees.class, location.getLatD());
+        Coordinates lon = Coordinates.create(DecimalDegrees.class, location.getLonD());
         Length alt = Length.create(Meters.class, location.getAltitude().getMagnitude());
         builder.append(lat.toShortLabelString(12, 6, 'N', 'S')).append(' ');
         builder.append(lon.toShortLabelString(12, 6, 'E', 'W'));

--- a/pom.xml
+++ b/pom.xml
@@ -761,22 +761,22 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.8.1</version>
+				<version>3.7</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-collections4</artifactId>
-				<version>4.2</version>
+				<version>4.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-text</artifactId>
-				<version>1.6</version>
+				<version>1.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.5.6</version>
+				<version>4.5.5</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
@@ -791,7 +791,7 @@
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpmime</artifactId>
-				<version>4.5.6</version>
+				<version>4.5.5</version>
 			</dependency>
 
 			<!-- Additional Apache Deps -->
@@ -818,22 +818,22 @@
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-artifact</artifactId>
-				<version>3.5.4</version>
+				<version>3.5.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-model</artifactId>
-				<version>3.5.4</version>
+				<version>3.5.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-plugin-api</artifactId>
-				<version>3.5.4</version>
+				<version>3.5.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven.plugin-tools</groupId>
 				<artifactId>maven-plugin-annotations</artifactId>
-				<version>3.5.2</version>
+				<version>3.5.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven.shared</groupId>
@@ -843,7 +843,7 @@
 			<dependency>
 				<groupId>org.apache.mina</groupId>
 				<artifactId>mina-core</artifactId>
-				<version>2.0.19</version>
+				<version>2.0.17</version>
 			</dependency>
 
 			<!-- Extra Deps -->
@@ -1048,7 +1048,7 @@
 			<dependency>
 				<groupId>org.xerial</groupId>
 				<artifactId>sqlite-jdbc</artifactId>
-				<version>3.25.2</version>
+				<version>3.21.0.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.j256.ormlite</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -761,22 +761,22 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.7</version>
+				<version>3.8.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-collections4</artifactId>
-				<version>4.1</version>
+				<version>4.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-text</artifactId>
-				<version>1.3</version>
+				<version>1.6</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.5.5</version>
+				<version>4.5.6</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
@@ -791,7 +791,7 @@
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpmime</artifactId>
-				<version>4.5.5</version>
+				<version>4.5.6</version>
 			</dependency>
 
 			<!-- Additional Apache Deps -->
@@ -818,22 +818,22 @@
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-artifact</artifactId>
-				<version>3.5.3</version>
+				<version>3.5.4</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-model</artifactId>
-				<version>3.5.3</version>
+				<version>3.5.4</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-plugin-api</artifactId>
-				<version>3.5.3</version>
+				<version>3.5.4</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven.plugin-tools</groupId>
 				<artifactId>maven-plugin-annotations</artifactId>
-				<version>3.5.3</version>
+				<version>3.5.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven.shared</groupId>
@@ -843,7 +843,7 @@
 			<dependency>
 				<groupId>org.apache.mina</groupId>
 				<artifactId>mina-core</artifactId>
-				<version>2.0.17</version>
+				<version>2.0.19</version>
 			</dependency>
 
 			<!-- Extra Deps -->
@@ -1048,7 +1048,7 @@
 			<dependency>
 				<groupId>org.xerial</groupId>
 				<artifactId>sqlite-jdbc</artifactId>
-				<version>3.21.0.1</version>
+				<version>3.25.2</version>
 			</dependency>
 			<dependency>
 				<groupId>com.j256.ormlite</groupId>


### PR DESCRIPTION
Fixes # VORTEX-6248: Create quick copy to clipboard ability for feature info

## Proposed Changes

    --Rename "angle" to "Coordinates" in the Edits->Units Menu.
    --Add MGRS to Coordinates sub-menu.
    --Added hotkey "C" while on globe context to copy the coordinates in the sub menu selected above and add toast message.
    --Right click on map allows user to open "Coordinate Viewer" which is a display of position in all coordinates.
     --Refactor UnitsProvider abstract to remove blank methods in various places in our codebase.
    