### PR TITLE
update jaxb versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<checkstyle.suppressions.location>${session.executionRootDirectory}/src/main/resources/checkstyle-suppressions.xml</checkstyle.suppressions.location>
 		<org.eclipse.jetty.version>9.4.9.v20180320</org.eclipse.jetty.version>
 		<release.url>https://nexus.devops.geointservices.io/content/repositories/FADE-COTS/</release.url>
-		<jaxb.version>2.3.0</jaxb.version>
+		<jaxb.version>2.3.1</jaxb.version>
 		<izpack.version>5.1.3</izpack.version>
 		<jackson.core.version>2.9.7</jackson.core.version>
 		<jackson.base.version>1.9.13</jackson.base.version>
@@ -617,7 +617,7 @@
 			<dependency>
 				<groupId>com.sun.xml.bind</groupId>
 				<artifactId>jaxb-core</artifactId>
-				<version>${jaxb.version}</version>
+				<version>2.3.0</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Fixes #Java 9 runtime issues - fixes illegal reflection of JAXB which was causing H2 database to delete on startup. 

## Proposed Changes

  -  Change JAXB API,IMP,WX versions to 2.3.1 
  -  JAXB Core deprecated so kept at 2.3.0
  - 
