### PR TITLE
Ft csvPatch

### DIFF
--- a/open-sphere-plugins/csv-common/pom.xml
+++ b/open-sphere-plugins/csv-common/pom.xml
@@ -35,7 +35,10 @@
 		    <groupId>com.sun.xml.bind</groupId>
 		    <artifactId>jaxb-core</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>io.open-sphere</groupId>
+			<artifactId>analysis</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>io.open-sphere</groupId>
 			<artifactId>mantle</artifactId>

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/controller/ImportableColumnController.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/controller/ImportableColumnController.java
@@ -1,6 +1,9 @@
 package io.opensphere.csvcommon.ui.controller;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 import io.opensphere.core.preferences.PreferencesRegistry;
@@ -45,6 +48,22 @@ public class ImportableColumnController
                 String key = ourKeyPrefix + columnName.toLowerCase();
 
                 List<String> columnsToNotImport = CSVColumnPrefsUtil.getCustomKeys(registry, key);
+
+                List<?> currentParams = new ArrayList<String>();
+                currentParams = parameters.getColumnNames();
+                List<String> newParams = new ArrayList<String>();
+
+                Iterator<?> litr = currentParams.iterator();
+                while (litr.hasNext())
+                {
+                    Object element = litr.next();
+                    if (element.equals("Index") || element.equals("Color"))
+                    {
+                        element = element + "_import";
+                    }
+                    newParams.add(element.toString());
+                }
+                parameters.setColumnNames(newParams);
 
                 if (columnsToNotImport != null)
                 {

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/controller/ImportableColumnController.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/controller/ImportableColumnController.java
@@ -3,7 +3,6 @@ package io.opensphere.csvcommon.ui.controller;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 
 import io.opensphere.core.preferences.PreferencesRegistry;

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/controller/ImportableColumnController.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/controller/ImportableColumnController.java
@@ -1,10 +1,11 @@
 package io.opensphere.csvcommon.ui.controller;
 
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import io.opensphere.analysis.table.model.MetaColumn;
 import io.opensphere.core.preferences.PreferencesRegistry;
 import io.opensphere.core.util.collections.New;
 import io.opensphere.csvcommon.config.v2.CSVParseParameters;
@@ -29,9 +30,10 @@ public class ImportableColumnController
      * @param registry The preferences registry to get non importable
      *            configurations.
      */
-    @SuppressWarnings("unchecked")
     public void detectNonImportableColumns(CSVParseParameters parameters, PreferencesRegistry registry)
     {
+        List<String> metaColumns = new ArrayList<String>(Arrays.asList(MetaColumn.COLOR, MetaColumn.HILIGHT, MetaColumn.INDEX,
+                MetaColumn.LOB_VISIBLE, MetaColumn.MGRS_DERIVED, MetaColumn.SELECTED, MetaColumn.VISIBLE));
         if (parameters.getColumnNames() != null)
         {
             Map<String, Integer> upperCasedColumnNames = New.map();
@@ -47,20 +49,16 @@ public class ImportableColumnController
             {
                 String key = ourKeyPrefix + columnName.toLowerCase();
                 List<String> columnsToNotImport = CSVColumnPrefsUtil.getCustomKeys(registry, key);
-
-                List<String> currentParams = new ArrayList<String>();
-                currentParams = (List<String>)parameters.getColumnNames();
+                List<String> currentParams = new ArrayList<String>(parameters.getColumnNames());
                 List<String> newParams = new ArrayList<String>();
-                Iterator<String> litr = currentParams.iterator();
-                while (litr.hasNext())
+                currentParams.forEach(e ->
                 {
-                    Object element = litr.next();
-                    if (element.equals("Index") || element.equals("Color"))
+                    if (metaColumns.contains(e))
                     {
-                        element = element + "_import";
+                        e = e + "_user";
                     }
-                    newParams.add(element.toString());
-                }
+                    newParams.add(e);
+                });
                 parameters.setColumnNames(newParams);
 
                 if (columnsToNotImport != null)

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/controller/ImportableColumnController.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/ui/controller/ImportableColumnController.java
@@ -29,6 +29,7 @@ public class ImportableColumnController
      * @param registry The preferences registry to get non importable
      *            configurations.
      */
+    @SuppressWarnings("unchecked")
     public void detectNonImportableColumns(CSVParseParameters parameters, PreferencesRegistry registry)
     {
         if (parameters.getColumnNames() != null)
@@ -45,14 +46,12 @@ public class ImportableColumnController
             for (String columnName : parameters.getColumnNames())
             {
                 String key = ourKeyPrefix + columnName.toLowerCase();
-
                 List<String> columnsToNotImport = CSVColumnPrefsUtil.getCustomKeys(registry, key);
 
-                List<?> currentParams = new ArrayList<String>();
-                currentParams = parameters.getColumnNames();
+                List<String> currentParams = new ArrayList<String>();
+                currentParams = (List<String>)parameters.getColumnNames();
                 List<String> newParams = new ArrayList<String>();
-
-                Iterator<?> litr = currentParams.iterator();
+                Iterator<String> litr = currentParams.iterator();
                 while (litr.hasNext())
                 {
                     Object element = litr.next();


### PR DESCRIPTION
Fixes # VORTEX-6247:Reordering CSV columns

## Proposed Changes
Bug caused by duplicates of the Index and Color columns which must always exist.
  - When user has these fields automatically re-name on import to prevent memory confusion.
  - Retains user color & potential custom indexing.
---Could be modified to override our Index + Color with user; but may not neccessarily make sense to do so. 
