### PR TITLE
remove menu being added twice

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionCommandFactory.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/plugin/selection/SelectionCommandFactory.java
@@ -235,7 +235,6 @@ public class SelectionCommandFactory
         menuOpts.add(createHeader("Features"));
         menuOpts.add(SELECT.createMenuItem(listener));
         menuOpts.add(DESELECT.createMenuItem(listener));
-        menuOpts.add(DESELECT.createMenuItem(listener));
         menuOpts.add(REMOVE_ALL.createMenuItem(listener));
         return menuOpts;
     }
@@ -256,7 +255,6 @@ public class SelectionCommandFactory
         menuOpts.add(new JSeparator());
         menuOpts.add(createHeader("Features"));
         menuOpts.add(SELECT.createMenuItem(listener));
-        menuOpts.add(DESELECT.createMenuItem(listener));
         menuOpts.add(DESELECT.createMenuItem(listener));
         menuOpts.add(REMOVE_ALL.createMenuItem(listener));
         return menuOpts;


### PR DESCRIPTION
Removes the duplicate menu item "Deselect All"

## Proposed Changes

  - Delete the listener and menu item from being added twice. 
  -
  -
