### PR TITLE
VORTEX-6183 Tab delimited CSVs breaking upon startup

### DIFF
--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/config/v2/CSVDelimitedColumnFormat.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/config/v2/CSVDelimitedColumnFormat.java
@@ -92,6 +92,16 @@ public class CSVDelimitedColumnFormat extends CSVColumnFormat
         return myTokenDelimiter;
     }
 
+    /**
+     * Sets the token delimiter.
+     *
+     * @param delimiter the new delimiter
+     */
+    public void setTokenDelimiter(String delimiter)
+    {
+        myTokenDelimiter = delimiter;
+    }
+
     @Override
     public int hashCode()
     {


### PR DESCRIPTION
Fixes VORTEX-6183

## Proposed Changes

  - the word "TAB" is substituted for an actual tab in the prefs file so the token delimiter isn't lost to the aether upon MIST startup