### PR TITLE
VORTEX-6183 XML Reading Whitespace

### DIFF
--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/XMLUtilities.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/XMLUtilities.java
@@ -981,7 +981,7 @@ public final class XMLUtilities
 
             XMLEventReader rawReader = factory.createXMLEventReader(stream);
             reader = factory.createFilteredReader(rawReader, (EventFilter)event -> !(event.isCharacters() && ((Characters)event).isWhiteSpace()
-                    && !((Characters)event).getData().equals("\t") && !((Characters)event).getData().equals(" ")));
+                    && !((Characters)event).getData().contains("\t") && !((Characters)event).getData().contains(" ")));
         }
         catch (XMLStreamException e)
         {

--- a/open-sphere-base/core/src/main/java/io/opensphere/core/util/XMLUtilities.java
+++ b/open-sphere-base/core/src/main/java/io/opensphere/core/util/XMLUtilities.java
@@ -980,7 +980,8 @@ public final class XMLUtilities
             }
 
             XMLEventReader rawReader = factory.createXMLEventReader(stream);
-            reader = factory.createFilteredReader(rawReader, (EventFilter)event -> !(event.isCharacters() && ((Characters)event).isWhiteSpace()));
+            reader = factory.createFilteredReader(rawReader, (EventFilter)event -> !(event.isCharacters() && ((Characters)event).isWhiteSpace()
+                    && !((Characters)event).getData().equals("\t") && !((Characters)event).getData().equals(" ")));
         }
         catch (XMLStreamException e)
         {


### PR DESCRIPTION
Fixes VORTEX-6183

## Proposed Changes

  - Whitespace filter has checks for if the field is only whitespace but is exactly a tab/space to help whitespace delimited files