### PR TITLE
VORTEX-6194 Move icon delete button into preview area

### DIFF
--- a/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/view/SearchControlBar.java
+++ b/open-sphere-base/mantle/src/main/java/io/opensphere/mantle/icon/chooser/view/SearchControlBar.java
@@ -5,12 +5,10 @@ import java.util.List;
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuButton;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextField;
-import javafx.scene.control.Tooltip;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -19,12 +17,9 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 
 import io.opensphere.core.util.AwesomeIconSolid;
-import io.opensphere.core.util.fx.FXUtilities;
 import io.opensphere.core.util.fx.FxIcons;
-import io.opensphere.core.util.image.IconUtil.IconType;
 import io.opensphere.mantle.icon.IconProvider;
 import io.opensphere.mantle.icon.IconSourceFactory;
-import io.opensphere.mantle.icon.chooser.controller.IconRemover;
 import io.opensphere.mantle.icon.chooser.model.IconModel;
 
 /** An HBox containing display size controls, view style, and filter options. */
@@ -37,28 +32,12 @@ public class SearchControlBar extends HBox
     private final MenuButton myAddIconsButton;
 
     /**
-     * The remove icons button.
-     */
-    private final Button myRemoveButton;
-
-    /**
-     * Removes the selected icon from the icon manager.
-     */
-    private final IconRemover myIconRemover;
-
-    /**
-     * The icon model.
-     */
-    private final IconModel myModel;
-
-    /**
      * Creates the top menu bar of the icon manager UI.
      *
      * @param panelModel the current UI model.
      */
     public SearchControlBar(IconModel panelModel)
     {
-        myModel = panelModel;
         mySearchField = new TextField();
         mySearchField.setOnKeyTyped(e ->
         {
@@ -104,43 +83,9 @@ public class SearchControlBar extends HBox
             myAddIconsButton.getItems().add(item);
         }
 
-        myRemoveButton = FXUtilities.newIconButton(IconType.CLOSE, Color.RED);
-        myIconRemover = new IconRemover(panelModel);
-        myRemoveButton.setOnAction((e) ->
-        {
-            myIconRemover.deleteIcons();
-        });
-        enableDisableDelete();
-        myModel.selectedRecordProperty().addListener((e) ->
-        {
-            enableDisableDelete();
-        });
 
-        getChildren().addAll(sp, myAddIconsButton, myRemoveButton);
+        getChildren().addAll(sp, myAddIconsButton);
 
         setAlignment(javafx.geometry.Pos.TOP_CENTER);
-    }
-
-    /**
-     * Enables or disables the remove button depending on if the icon selected
-     * is a user imported icon.
-     */
-    void enableDisableDelete()
-    {
-        if (myModel.selectedRecordProperty().get() == null
-                || myModel.selectedRecordProperty().get().imageURLProperty().get() == null
-                || myModel.selectedRecordProperty().get().imageURLProperty().get().toString().startsWith("jar:file:")
-                || myModel.selectedRecordProperty().get().imageURLProperty().get().toString().contains("/target/classes/images/"))
-        {
-            // This is not a user imported icon, it is a system provided icon do
-            // not delete.
-            myRemoveButton.setDisable(true);
-            myRemoveButton.setTooltip(new Tooltip("Only user imported icons can be removed."));
-        }
-        else
-        {
-            myRemoveButton.setDisable(false);
-            myRemoveButton.setTooltip(new Tooltip("Remove selected icons."));
-        }
     }
 }


### PR DESCRIPTION
Fixes VORTEX-6194

## Proposed Changes

  - delete icon button moved onto the icon canvas, next to the favorite button
  - tooltips added to favorite button