### PR TITLE
VORTEX-6063 Coloring features from feature actions shades icon

### DIFF
--- a/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/styles/model/StyleOptions.java
+++ b/open-sphere-base/control-panels/src/main/java/io/opensphere/controlpanels/styles/model/StyleOptions.java
@@ -61,6 +61,13 @@ public class StyleOptions extends Observable implements Serializable
     private boolean myHasSizeBeenSet;
 
     /**
+     * The previous color of the bulls eye when icons are active.
+     */
+    @XmlJavaTypeAdapter(ColorAdapter.class)
+    @XmlAttribute(name = "holdColor")
+    private Color myHoldColor = myColor;
+
+    /**
      * The id of the icon to display in this style.
      */
     @XmlAttribute(name = "iconId")
@@ -91,6 +98,7 @@ public class StyleOptions extends Observable implements Serializable
     public void copyFrom(StyleOptions other)
     {
         setColor(other.getColor());
+        setHoldColor(other.getHoldColor());
         setIconId(other.getIconId());
         setSize(other.getSize());
         setStyle(other.getStyle());
@@ -108,8 +116,8 @@ public class StyleOptions extends Observable implements Serializable
             return false;
         }
         StyleOptions other = (StyleOptions)obj;
-        return Objects.equals(myColor, other.myColor) && myIconId == other.myIconId && mySize == other.mySize
-                && myStyle == other.myStyle;
+        return Objects.equals(myColor, other.myColor) && Objects.equals(myHoldColor, other.getHoldColor()) &&
+                myIconId == other.myIconId && mySize == other.mySize && myStyle == other.myStyle;
     }
 
     /**
@@ -120,6 +128,16 @@ public class StyleOptions extends Observable implements Serializable
     public Color getColor()
     {
         return myColor;
+    }
+
+    /**
+     * Gets the hold color of the bulls eye.
+     *
+     * @return the held color
+     */
+    public Color getHoldColor()
+    {
+        return myHoldColor;
     }
 
     /**
@@ -192,6 +210,18 @@ public class StyleOptions extends Observable implements Serializable
     public void setColor(Color color)
     {
         myColor = color;
+        setChanged();
+        notifyObservers(COLOR_PROP);
+    }
+
+    /**
+     * Sets the hold color of the bulls eye.
+     *
+     * @param holdColor the hold color to set
+     */
+    public void setHoldColor(Color holdColor)
+    {
+        myHoldColor = holdColor;
         setChanged();
         notifyObservers(COLOR_PROP);
     }

--- a/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/editor/ui/SimpleFeatureActionRowBinder.java
+++ b/open-sphere-plugins/feature-actions/src/main/java/io/opensphere/featureactions/editor/ui/SimpleFeatureActionRowBinder.java
@@ -7,9 +7,10 @@ import javafx.beans.value.ChangeListener;
 import javafx.collections.FXCollections;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
-
+import javafx.scene.paint.Color;
 import io.opensphere.controlpanels.styles.model.StyleOptions;
 import io.opensphere.controlpanels.styles.model.Styles;
+import io.opensphere.core.util.fx.FXUtilities;
 import io.opensphere.featureactions.editor.controller.FilterActionAdapter;
 import io.opensphere.featureactions.editor.controller.SimpleFeatureActionController;
 import io.opensphere.featureactions.editor.model.CriteriaOptions;
@@ -164,6 +165,12 @@ public class SimpleFeatureActionRowBinder
                 }
             };
             styleAction.getStyleOptions().addObserver(myUseIconObserver);
+            if (myView.getUseIconCheckBox().isSelected())
+            {
+                myView.getColorPicker().valueProperty().unbindBidirectional(myModel.colorProperty());
+                myView.getColorPicker().setDisable(true);
+                myView.getColorPicker().setValue(FXUtilities.fromAwtColor(styleAction.getStyleOptions().getHoldColor()));
+            }
         }
         myUseIconListener = (obs, o, n) ->
         {
@@ -171,6 +178,19 @@ public class SimpleFeatureActionRowBinder
             if (action != null)
             {
                 action.getStyleOptions().setStyle(n.booleanValue() ? Styles.ICON : Styles.POINT);
+                if (n.booleanValue())
+                {
+                    myView.getColorPicker().valueProperty().unbindBidirectional(myModel.colorProperty());
+                    action.getStyleOptions().setHoldColor(FXUtilities.toAwtColor(myModel.getColor()));
+                    myModel.setColor(Color.WHITE);
+                    myView.getColorPicker().setDisable(true);
+                }
+                else
+                {
+                    myView.getColorPicker().valueProperty().bindBidirectional(myModel.colorProperty());
+                    myView.getColorPicker().setValue(FXUtilities.fromAwtColor(action.getStyleOptions().getHoldColor()));
+                    myView.getColorPicker().setDisable(false);
+                }
             }
         };
         myView.getUseIconCheckBox().selectedProperty().addListener(myUseIconListener);


### PR DESCRIPTION
Fixes # VORTEX-6063

## Proposed Changes

  - when icons are enabled in feature actions, the color of the feature action is saved so it can be recovered later
  - activating icons in a feature action disables the color selector and turns the color of the feature action to white so the icon doesn't get colored