### PR TITLE
VORTEX-6292 Desktop not parsing/importing csv correctly

### DIFF
--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/columnformat/ColumnDelimiterDetector.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/columnformat/ColumnDelimiterDetector.java
@@ -337,7 +337,7 @@ public class ColumnDelimiterDetector implements LineDetector<DelimitedColumnForm
             // delimiter
             pattern.append("[\\").append(testSecond).append("^]\\").append(testFirst);
             // followed by at least one character which is not either delimiter
-            pattern.append("[^\\").append(testFirst).append('\\').append(testSecond).append("]*?\\");
+            pattern.append("[^\\").append(testFirst).append('\\').append(testSecond).append("]+?\\");
             // followed by the first delimiter, followed by the second delimiter
             // or the end of line
             pattern.append(testFirst).append("[$\\").append(testSecond).append(']');
@@ -441,7 +441,7 @@ public class ColumnDelimiterDetector implements LineDetector<DelimitedColumnForm
             }
             // End of a text delimiter
             else if (currentDelimiter.contains(currentChar) && (nextChar == null || nextChar.charValue() == tokenDelimiter
-                    && (!isTextDelimiter(previousChar) || Character.valueOf('.').compareTo(previousChar) == 0)))
+                            && (previousChar == null || previousChar.charValue() != tokenDelimiter)))
             {
                 if (delimiterWithinDelimiterCount == 0)
                 {

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/columnformat/ColumnDelimiterDetector.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/columnformat/ColumnDelimiterDetector.java
@@ -202,18 +202,6 @@ public class ColumnDelimiterDetector implements LineDetector<DelimitedColumnForm
     }
 
     /**
-     * Determines if the given character is a potential text delimiter.
-     *
-     * @see #isTextDelimiter(char)
-     * @param ch the character
-     * @return Whether it is a potential text delimiter and is not null
-     */
-    private static boolean isTextDelimiter(Character ch)
-    {
-        return ch != null && isTextDelimiter(ch.charValue());
-    }
-
-    /**
      * Determines if the given character is a potential token delimiter.
      *
      * @param ch the character

--- a/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/columnformat/ColumnDelimiterDetector.java
+++ b/open-sphere-plugins/csv-common/src/main/java/io/opensphere/csvcommon/detect/columnformat/ColumnDelimiterDetector.java
@@ -441,7 +441,7 @@ public class ColumnDelimiterDetector implements LineDetector<DelimitedColumnForm
             }
             // End of a text delimiter
             else if (currentDelimiter.contains(currentChar) && (nextChar == null || nextChar.charValue() == tokenDelimiter
-                            && (previousChar == null || previousChar.charValue() != tokenDelimiter)))
+                    && (previousChar == null || previousChar.charValue() != tokenDelimiter)))
             {
                 if (delimiterWithinDelimiterCount == 0)
                 {


### PR DESCRIPTION
Fixes VORTEX-6292

## Proposed Changes

  - end of delimiter check doesn't only compares if previous character is the same as the current delimiter, instead of all potential delimiters
  - updated regex to match the comments