### PR TITLE
fix: deploy.jar custom artifact

### DIFF
--- a/open-sphere-base/core/pom.xml
+++ b/open-sphere-base/core/pom.xml
@@ -50,6 +50,14 @@
 
 	<dependencies>
 		<dependency>
+			<!-- deploy.jar from old jdk versions; has been removed from java 9+ -->
+			<!-- stand this up somewhere or remove this & add to classpath -->
+			<groupId>com.user</groupId>
+			<artifactId>deploy</artifactId>
+			<version>1.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/open-sphere-base/core/src/test/java/com/bitsys/common/http/proxy/ProxyScriptRunnerTest.java
+++ b/open-sphere-base/core/src/test/java/com/bitsys/common/http/proxy/ProxyScriptRunnerTest.java
@@ -1,0 +1,28 @@
+package com.bitsys.common.http.proxy;
+
+import java.util.Collection;
+import javax.script.ScriptException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ProxyScriptRunnerTest
+{
+	@Test
+	public void testScriptsExist()
+	{
+		boolean initialized = true;
+		try
+		{
+			ProxyScriptRunner runner = new ProxyScriptRunner();
+			runner.loadSystemScripts();
+			
+			Collection<String> scripts = ProxyScriptRunner.getSystemScripts();
+			Assert.assertEquals(15, scripts.size());
+		}
+		catch (IllegalStateException | ScriptException e)
+		{
+			initialized = false;
+		}
+		Assert.assertTrue(initialized);
+	}
+}


### PR DESCRIPTION
deploy.jar from earlier Java versions is required for `ProxyScriptRunner` to function; use a custom Maven artifact so that anyone who needs this functionality can get it.